### PR TITLE
Add Etherbone support (Control-Path) + UDP RX (Datapath).

### DIFF
--- a/software/build.py
+++ b/software/build.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import argparse
 import os
 import subprocess
 
@@ -26,6 +27,22 @@ def build_driver(path, cmake_options=""):
     for command in commands:
         run_command(command)
 
+parser = argparse.ArgumentParser(description="LiteX-M2SDR Software build.", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("--data-path",    default="pcie", help="Data path interface",    choices=["pcie", "ethernet"])
+parser.add_argument("--control-path", default="pcie", help="Control path interface", choices=["pcie", "ethernet"])
+
+args = parser.parse_args()
+
+if args.data_path == "pcie":
+    data_path = "-DWITH_ETH_STREAM=OFF"
+else:
+    data_path = "-DWITH_ETH_STREAM=ON"
+
+if args.control_path == "pcie":
+    control_path = "-DWITH_ETH_CTRL=OFF"
+else:
+    control_path = "-DWITH_ETH_CTRL=ON"
+
 run_command("cd kernel && make clean all")
 run_command("cd user   && make clean all")
-build_driver("soapysdr", "-DCMAKE_INSTALL_PREFIX=/usr")
+build_driver("soapysdr", f"-DCMAKE_INSTALL_PREFIX=/usr {data_path} {control_path}")

--- a/software/soapysdr/CMakeLists.txt
+++ b/software/soapysdr/CMakeLists.txt
@@ -3,6 +3,9 @@ project(SoapySDRLiteXM2SDR CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(WITH_ETH_STREAM "Uses Ethernet interface for the stream" OFF)
+option(WITH_ETH_CTRL   "Uses Ethernet interface for the control" OFF)
+
 ########################################################################
 ## LitePCIe discovery
 ########################################################################
@@ -88,10 +91,20 @@ set(LITEXM2SDR_SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/ad9361/util.c
 )
 
+if(WITH_ETH_STREAM)
+    add_definitions(-DWITH_ETH_STREAM=1)
+endif()
+
+if(WITH_ETH_CTRL)
+	add_definitions(-DWITH_ETH_CTRL=1)
+endif()
+
 SOAPY_SDR_MODULE_UTIL(
     TARGET SoapyLiteXM2SDR
     SOURCES LiteXM2SDRDevice.cpp LiteXM2SDRStreaming.cpp
-    LiteXM2SDRRegistration.cpp ${LITEXM2SDR_SOURCE}
+    LiteXM2SDRRegistration.cpp etherbone.c
+	LiteXM2SDRUDPRx.cpp
+	${LITEXM2SDR_SOURCE}
     LIBRARIES ${LITEPCIE_LIBRARY} ${LIBM2SDR_LIBRARY} m
 )
 

--- a/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -235,7 +235,7 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
 
 #ifdef WITH_ETH_CTRL
     /* EtherBone */
-    _eb_fd = eb_connect(eth_ip.c_str(), "2345", 1);
+    _eb_fd = eb_connect(eth_ip.c_str(), "1234", 1);
     if (!_eb_fd)
         throw std::runtime_error("Can't connect to EtherBone!");
     eb_fd = _eb_fd;

--- a/software/soapysdr/LiteXM2SDRUDPRx.cpp
+++ b/software/soapysdr/LiteXM2SDRUDPRx.cpp
@@ -1,0 +1,162 @@
+/*
+ * SoapySDR driver for the LiteX M2SDR.
+ *
+ * Copyright (c) 2021-2024 Enjoy Digital.
+ * SPDX-License-Identifier: Apache-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <stdexcept>
+#include <cstring>
+#include <mutex>
+#include <queue>
+
+#include <netdb.h> 
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#include "LiteXM2SDRUDPRx.hpp"
+
+LiteXM2SDRUPDRx::LiteXM2SDRUPDRx(std::string ip_addr, std::string port, size_t min_size, size_t max_size, size_t buffer_size,
+    uint32_t bytesPerComplex):
+    _read_sock(-1), _running(true),
+    _max_size(max_size), _min_size(min_size), _buffer_size(buffer_size * bytesPerComplex), _overflow(0), _started(false)
+{
+    /* Prepare Read/Write streams socket */                     
+    struct addrinfo hints;
+    int err;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;                            
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    hints.ai_flags = AI_ADDRCONFIG;                   
+    err = getaddrinfo(ip_addr.c_str(), port.c_str(), &hints, &_addr);
+    if (err != 0) {     
+        char mess[256];                 
+        snprintf(mess, 256, "failed to _addrolve remote socket add_addrs (err=%d / %s)\n",
+            err, gai_strerror(err));               
+        throw std::runtime_error(mess);
+    }
+
+    struct sockaddr_in si_read;
+    memset((char *) &si_read, 0, sizeof(si_read));
+    si_read.sin_family = _addr->ai_family;
+    si_read.sin_port = ((struct sockaddr_in *)_addr->ai_addr)->sin_port;
+    si_read.sin_addr.s_addr = htobe32(INADDR_ANY);
+
+    /* Read Sock */
+    _read_sock = socket(_addr->ai_family, _addr->ai_socktype, _addr->ai_protocol);
+    if (_read_sock == -1) {
+        char mess[256];
+        snprintf(mess, 256, "Unable to create Rx socket: %s\n", strerror(errno));
+        throw std::runtime_error(mess);
+    }
+
+    if (bind(_read_sock, (struct sockaddr*)&si_read, sizeof(si_read)) == -1) {
+        char mess[256];
+        snprintf(mess, 256, "Unable to bind Rx socket to port: %s\n", strerror(errno));
+        close(_read_sock);
+        freeaddrinfo(_addr);
+        throw std::runtime_error(mess);
+    }
+}
+
+LiteXM2SDRUPDRx::~LiteXM2SDRUPDRx(void)
+{
+    /* thread must be disabled/stopped to avoid errors */
+    stop();
+    /* clock socket */
+    close(_read_sock);
+    freeaddrinfo(_addr);
+}
+
+bool LiteXM2SDRUPDRx::add_data(const std::vector<char>& data)
+{
+    std::unique_lock<std::mutex> lock(_mtx);
+    if (_buffer.size() >= _max_size) {
+        _overflow++;
+        return false;
+    }
+    _buffer.push(data);
+    _overflow = 0;
+    return true;
+}
+
+std::vector<char> LiteXM2SDRUPDRx::get_data()
+{
+#ifdef USE_THREAD
+    std::unique_lock<std::mutex> lock(_mtx);
+    if (_buffer.size() < _min_size)
+        return std::vector<char>();
+
+    std::vector<char> data = _buffer.front();
+    _buffer.pop();
+#else
+    size_t pos = 0;
+    char bytes[_buffer_size];
+    while(pos < _buffer_size) {
+        int nb = recvfrom(_read_sock, &bytes[pos], _buffer_size - pos, 0, NULL, NULL);
+        if (nb == -1) {
+            char mess[256];
+            snprintf(mess, 256, "socket error: %s", strerror(errno));
+            throw std::runtime_error(mess);
+        }
+        pos += nb;
+    }
+    std::vector<char> data(bytes, bytes+ pos);
+#endif
+
+    return data;
+}
+
+void LiteXM2SDRUPDRx::rx_callback(void)
+{
+    size_t pos = 0;
+    char bytes[_buffer_size];
+    while (_running) {
+        int nb = recvfrom(_read_sock, &bytes[pos], _buffer_size - pos, 0, NULL, NULL);
+        if (nb == -1) {
+            char mess[256];
+            snprintf(mess, 256, "socket error: %s", strerror(errno));
+            throw std::runtime_error(mess);
+        }
+        pos += nb;
+        if (pos >= _buffer_size) {
+            std::vector<char> data(bytes, bytes+ pos);
+            add_data(data);
+            pos = 0;
+        }
+    }
+}
+
+void LiteXM2SDRUPDRx::start(void)
+{
+    if (_started)
+        return;
+    _started = true;
+#ifdef USE_THREAD
+    _thread = std::thread(&LiteXM2SDRUPDRx::rx_callback, this);
+#endif
+}
+
+void LiteXM2SDRUPDRx::stop(void)
+{
+    if (!_started)
+        return;
+    _started = false;
+    /* tells thread to stop after next recv */
+    _running = false;
+#ifdef USE_THREAD
+    /* wait thread end completion before return
+     * we must ensure thread is stopped before closing socket
+     * to avoid "bad file descriptor" error
+     */
+    if (_thread.joinable())
+        _thread.join();
+#endif
+}

--- a/software/soapysdr/LiteXM2SDRUDPRx.hpp
+++ b/software/soapysdr/LiteXM2SDRUDPRx.hpp
@@ -1,0 +1,75 @@
+/*
+ * SoapySDR driver for the LiteX M2SDR.
+ *
+ * Copyright (c) 2021-2024 Enjoy Digital.
+ * SPDX-License-Identifier: Apache-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef LITEXM2SDRUDPRX_HPP
+#define LITEXM2SDRUDPRX_HPP
+#include <iostream>
+#include <string>
+#include <thread>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+class LiteXM2SDRUPDRx {
+    public:
+        /* Constructor:
+         * ip_addr (string): server addr
+         * port (string):    server port
+         * min_size:         minimum queue length before popping buffer
+         * max_size:         maximum queue size (avoid to increase indefinitively the queue)
+         * buffer_size:      size of each queue slots (in byte)
+         */
+        LiteXM2SDRUPDRx(std::string ip_addr, std::string port,
+            size_t min_size, size_t max_size, size_t buffer_size, uint32_t bytesPerComplex);
+        /* Destructor
+         */
+        ~LiteXM2SDRUPDRx(void);
+
+        /* Thread method for acquisition and buffer filling */
+        void rx_callback();
+
+        /* Start thread acquisition */
+        void start();
+        void stop();
+
+        /* Return a vector with buffer_size char or
+         * and empty vector
+         */
+        std::vector<char> get_data(void);
+
+        size_t buffers_available(void) {
+            std::unique_lock<std::mutex> lock(_mtx);
+            size_t nb_buff = _buffer.size() - _min_size - 1;
+            if (nb_buff <= 0)
+                return 0;
+            else
+                return nb_buff;
+        }
+
+        /* return true when one or more overflow, false otherwise */
+        bool overflow() { return !(_overflow == 0); }
+        size_t buffer_count() {return _max_size;}
+        size_t buffer_size()  {return _buffer_size;}
+
+    private:
+        /* Fill queue with buffer_size char */
+        bool add_data(const std::vector<char> &data);
+        int _read_sock;         /* UDP socket */
+        bool _running;          /* loop until goes false */
+        struct addrinfo *_addr; /* UDP related */
+        std::thread _thread;    /* thread used to receive data */
+        std::mutex _mtx;        /* mutex to lock fifo access */
+        size_t _max_size;       /* queue max len */
+        size_t _min_size;       /* queue min len before pop */
+        size_t _buffer_size;    /* size of a buffer per queue slots */
+        std::queue<std::vector<char>> _buffer;
+        size_t _overflow;
+        bool _started;
+};
+
+#endif /* LITEXM2SDRUDPRX_HPP */

--- a/software/soapysdr/etherbone.c
+++ b/software/soapysdr/etherbone.c
@@ -1,0 +1,261 @@
+/*
+ * Etherbone C Library.
+ *
+ * Copyright (c) 2020-2024 LiteX-Hub community.
+ * SPDX-License-Identifier: Apache-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Copied from https://github.com/litex-hub/wishbone-utils/tree/master/libeb-c
+ */
+
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#include "etherbone.h"
+
+struct eb_connection {
+    int fd;
+    int read_fd;
+    int is_direct;
+    struct addrinfo* addr;
+};
+
+int eb_unfill_read32(uint8_t wb_buffer[20]) {
+    int buffer;
+    uint32_t intermediate;
+    memcpy(&intermediate, &wb_buffer[16], sizeof(intermediate));
+    intermediate = be32toh(intermediate);
+    memcpy(&buffer, &intermediate, sizeof(intermediate));
+    return buffer;
+}
+
+int eb_fill_readwrite32(uint8_t wb_buffer[20], uint32_t data, uint32_t address, int is_read) {
+    memset(wb_buffer, 0, 20);
+    wb_buffer[0] = 0x4e;	// Magic byte 0
+    wb_buffer[1] = 0x6f;	// Magic byte 1
+    wb_buffer[2] = 0x10;	// Version 1, all other flags 0
+    wb_buffer[3] = 0x44;	// Address is 32-bits, port is 32-bits
+    wb_buffer[4] = 0;		// Padding
+    wb_buffer[5] = 0;		// Padding
+    wb_buffer[6] = 0;		// Padding
+    wb_buffer[7] = 0;		// Padding
+
+    // Record
+    wb_buffer[8] = 0;		// No Wishbone flags are set (cyc, wca, wff, etc.)
+    wb_buffer[9] = 0x0f;	// Byte enable
+
+    if (is_read) {
+        wb_buffer[10] = 0;  // Write count
+        wb_buffer[11] = 1;	// Read count
+        data = htobe32(address);
+        memcpy(&wb_buffer[16], &data, sizeof(data));
+    }
+    else {
+        wb_buffer[10] = 1;	// Write count
+        wb_buffer[11] = 0;  // Read count
+        address = htobe32(address);
+        memcpy(&wb_buffer[12], &address, sizeof(address));
+
+        data = htobe32(data);
+        memcpy(&wb_buffer[16], &data, sizeof(data));
+    }
+    return 20;
+}
+
+int eb_fill_write32(uint8_t wb_buffer[20], uint32_t data, uint32_t address) {
+    return eb_fill_readwrite32(wb_buffer, data, address, 0);
+}
+
+int eb_fill_read32(uint8_t wb_buffer[20], uint32_t address) {
+    return eb_fill_readwrite32(wb_buffer, 0, address, 1);
+}
+
+int eb_send(struct eb_connection *conn, const void *bytes, size_t len) {
+    if (conn->is_direct)
+        return sendto(conn->fd, bytes, len, 0, conn->addr->ai_addr, conn->addr->ai_addrlen);
+    return write(conn->fd, bytes, len);
+}
+
+int eb_recv(struct eb_connection *conn, void *bytes, size_t max_len) {
+    if (conn->is_direct)
+        return recvfrom(conn->read_fd, bytes, max_len, 0, NULL, NULL);
+    return read(conn->fd, bytes, max_len);
+}
+
+void eb_write32(struct eb_connection *conn, uint32_t val, uint32_t addr) {
+    uint8_t raw_pkt[20];
+    eb_fill_write32(raw_pkt, val, addr);
+    eb_send(conn, raw_pkt, sizeof(raw_pkt));
+}
+
+uint32_t eb_read32(struct eb_connection *conn, uint32_t addr) {
+    uint8_t raw_pkt[20];
+    eb_fill_read32(raw_pkt, addr);
+
+    eb_send(conn, raw_pkt, sizeof(raw_pkt));
+
+    if (conn->is_direct) {
+        int count = eb_recv(conn, raw_pkt, sizeof(raw_pkt));
+
+        if (count != sizeof(raw_pkt)) {
+            fprintf(stderr, "unexpected read length: %d\n", count);
+            return -1;
+        }
+    } else {
+        // If we are connected via TCP we need to take into account any size
+        // read because it is a stream oriented protocol.
+        int ret;
+        uint8_t *p   = raw_pkt;
+        uint8_t *end = raw_pkt + sizeof(raw_pkt);
+
+        while (p < end) {
+            ret = eb_recv(conn, p, end - p);
+
+            if (ret < 0) {
+                switch (errno) {
+                    case EINTR:
+                    case EAGAIN:
+                        continue;
+                    default:
+                        fprintf(stderr, "socket read error: %s\n", strerror(errno));
+                        return -1;
+                }
+            }
+
+            p += ret;
+        }
+    }
+
+    return eb_unfill_read32(raw_pkt);
+}
+
+struct eb_connection *eb_connect(const char *addr, const char *port, int is_direct) {
+
+    struct addrinfo hints;
+    struct addrinfo* res = 0;
+    int err;
+    int sock;
+
+    struct eb_connection *conn = malloc(sizeof(struct eb_connection));
+    if (!conn) {
+        perror("couldn't allocate memory for eb_connection");
+        return NULL;
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = is_direct ? SOCK_DGRAM : SOCK_STREAM;
+    hints.ai_protocol = is_direct ? IPPROTO_UDP : IPPROTO_TCP;
+    hints.ai_flags = AI_ADDRCONFIG;
+    err = getaddrinfo(addr, port, &hints, &res);
+    if (err != 0) {
+        fprintf(stderr, "failed to resolve remote socket address (err=%d / %s)\n", err, gai_strerror(err));
+        free(conn);
+        return NULL;
+    }
+
+    conn->is_direct = is_direct;
+
+    if (is_direct) {
+        // Rx half
+        struct sockaddr_in si_me;
+
+        memset((char *) &si_me, 0, sizeof(si_me));
+        si_me.sin_family = res->ai_family;
+        si_me.sin_port = ((struct sockaddr_in *)res->ai_addr)->sin_port;
+        si_me.sin_addr.s_addr = htobe32(INADDR_ANY);
+
+        int rx_socket;
+        if ((rx_socket = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
+            fprintf(stderr, "Unable to create Rx socket: %s\n", strerror(errno));
+            freeaddrinfo(res);
+            free(conn);
+            return NULL;
+        }
+        if (bind(rx_socket, (struct sockaddr*)&si_me, sizeof(si_me)) == -1) {
+            fprintf(stderr, "Unable to bind Rx socket to port: %s\n", strerror(errno));
+            close(rx_socket);
+            freeaddrinfo(res);
+            free(conn);
+            return NULL;
+        }
+
+        // Tx half
+        int tx_socket = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        if (tx_socket == -1) {
+            fprintf(stderr, "Unable to create socket: %s\n", strerror(errno));
+            close(rx_socket);
+            close(tx_socket);
+            freeaddrinfo(res);
+            fprintf(stderr, "unable to create socket: %s\n", strerror(errno));
+            free(conn);
+            return NULL;
+        }
+
+        conn->read_fd = rx_socket;
+        conn->fd = tx_socket;
+        conn->addr = res;
+    }
+    else {
+        sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock == -1) {
+            fprintf(stderr, "failed to create socket: %s\n", strerror(errno));
+            freeaddrinfo(res);
+            free(conn);
+            return NULL;
+        }
+
+        int connection = connect(sock, res->ai_addr, res->ai_addrlen);
+        if (connection == -1) {
+            close(sock);
+            freeaddrinfo(res);
+            fprintf(stderr, "unable to create socket: %s\n", strerror(errno));
+            free(conn);
+            return NULL;
+        }
+
+        int ret;
+        int val = 1;
+
+        ret = setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+        if (ret < 0) {
+             close(sock);
+            freeaddrinfo(res);
+            fprintf(stderr, "setsockopt error: %s\n", strerror(errno));
+            free(conn);
+            return NULL;
+        }
+
+        conn->fd = sock;
+        conn->addr = res;
+    }
+
+    return conn;
+}
+
+void eb_disconnect(struct eb_connection **conn) {
+    if (!conn || !*conn)
+        return;
+
+    freeaddrinfo((*conn)->addr);
+    close((*conn)->fd);
+    if ((*conn)->read_fd)
+        close((*conn)->read_fd);
+    free(*conn);
+    *conn = NULL;
+    return;
+}

--- a/software/soapysdr/etherbone.h
+++ b/software/soapysdr/etherbone.h
@@ -1,0 +1,86 @@
+/*
+ * Etherbone C Library.
+ *
+ * Copyright (c) 2020-2024 LiteX-Hub community.
+ * SPDX-License-Identifier: Apache-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Copied from https://github.com/litex-hub/wishbone-utils/tree/master/libeb-c
+ */
+
+#ifndef __ETHERBONE_H__
+#define __ETHERBONE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <stdint.h>
+
+/*
+
+The EtherBone record has a struct that looks like this:
+
+struct etherbone_record {
+	// 1...
+	uint8_t bca : 1;
+	uint8_t rca : 1;
+	uint8_t rff : 1;
+	uint8_t ign1 : 1;
+	uint8_t cyc : 1;
+	uint8_t wca : 1;
+	uint8_t wff : 1;
+	uint8_t ign2 : 1;
+
+	uint8_t byte_enable;
+
+	uint8_t wcount;
+
+	uint8_t rcount;
+
+	uint32_t write_addr;
+    union {
+    	uint32_t value;
+        read_addr;
+    };
+} __attribute__((packed));
+
+This is wrapped inside of an EtherBone network packet header:
+
+struct etherbone_packet {
+	uint8_t magic[2]; // 0x4e 0x6f
+	uint8_t version : 4;
+	uint8_t ign : 1;
+	uint8_t no_reads : 1;
+	uint8_t probe_reply : 1;
+	uint8_t probe_flag : 1;
+	uint8_t port_size : 4;
+	uint8_t addr_size : 4;
+	uint8_t padding[4];
+
+	struct etherbone_record records[0];
+} __attribute__((packed));
+
+LiteX only supports a single record per packet, so either wcount or rcount
+is set to 1.  For a read, the read_addr is specified.  For a write, the
+write_addr is specified along with a value.
+
+The same type of record is returned, so your data is at offset 16.
+*/
+
+struct eb_connection;
+
+int eb_unfill_read32(uint8_t wb_buffer[20]);
+int eb_fill_write32(uint8_t wb_buffer[20], uint32_t data, uint32_t address);
+int eb_fill_read32(uint8_t wb_buffer[20], uint32_t address);
+
+struct eb_connection *eb_connect(const char *addr, const char *port, int is_direct);
+void eb_disconnect(struct eb_connection **conn);
+uint32_t eb_read32(struct eb_connection *conn, uint32_t addr);
+void eb_write32(struct eb_connection *conn, uint32_t val, uint32_t addr);
+
+#ifdef __cplusplus
+};
+#endif /* __cplusplus */
+
+#endif /* __ETHERBONE_H__ */


### PR DESCRIPTION
litex_m2sdr target support etherbone for MMAP (control) and UDP Streamer (data).
This PR adds etherbone SoapySDR support to acces control and stream via etherbone instead of PCIe:
- it adds etherbone.c/h from  https://github.com/litex-hub/wishbone-utils/tree/master/libeb-c
- a new class to handle UDP Rx traffic (data)
- adapts existing code to deal with both options

This feature is configured at build time:
```bash
cd software/soapysdr
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=/usr [-DWITH_ETH_STREAM=ON/OFF] [-DWITH_ETH_CTRL=ON/OFF] ..
make -j
sudo make install
```
With:
- `-DWITH_ETH_STREAM` is used to select between etherbone (**ON**) or PCIe (**OFF**) for data 
- `-DWITH_ETH_CTRL` is used to select between etherbone (**ON**) or PCIe (**OFF**) for control

It also possible to use *software/build.py* to do the same thing with:
```bash
./build.py [--data-path {pcie,ethernet}] [--control-path {pcie,ethernet}]
```

With:
- `--data-path` to select between PCIe or etherbone (default pcie)
- `--control-path` to select between PCIe or etherbone (default etherbone)

**Note:** Using control via etherbone is not currently stable