### PR TITLE
Etherbone socket

### DIFF
--- a/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -461,6 +461,15 @@ SoapyLiteXM2SDR::~SoapyLiteXM2SDR(void) {
 
 #if USE_LITEPCIE
     close(_fd);
+#elif USE_LITEETH
+    if (_rx_udp_receiver) {
+        delete _rx_udp_receiver;
+        _rx_udp_receiver = NULL;
+    }
+    if (_fd) {
+        eb_disconnect(&_fd);
+        _fd = NULL;
+    }
 #endif
 }
 

--- a/software/soapysdr/LiteXM2SDRUDPRx.cpp
+++ b/software/soapysdr/LiteXM2SDRUDPRx.cpp
@@ -57,16 +57,6 @@ LiteXM2SDRUPDRx::LiteXM2SDRUPDRx(std::string ip_addr, std::string port, size_t m
         throw std::runtime_error(mess);
     }
 
-    /* Enable address reuse on Sock, FIXME: Close socket properly */
-    int opt = 1;
-    if (setsockopt(_read_sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-        char mess[256];
-        snprintf(mess, 256, "Unable to set SO_REUSEADDR on Rx socket: %s\n", strerror(errno));
-        close(_read_sock);
-        freeaddrinfo(_addr);
-        throw std::runtime_error(mess);
-    }
-
     if (bind(_read_sock, (struct sockaddr*)&si_read, sizeof(si_read)) == -1) {
         char mess[256];
         snprintf(mess, 256, "Unable to bind Rx socket to port: %s\n", strerror(errno));

--- a/software/user/libliteeth/etherbone.c
+++ b/software/user/libliteeth/etherbone.c
@@ -186,15 +186,6 @@ struct eb_connection *eb_connect(const char *addr, const char *port, int is_dire
             free(conn);
             return NULL;
         }
-        /* Enable address reuse on RX Socket, FIXME: Close socket properly */
-        int opt = 1;
-        if (setsockopt(rx_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-            fprintf(stderr, "setsockopt(SO_REUSEADDR) on rx_socket failed: %s\n", strerror(errno));
-            close(rx_socket);
-            freeaddrinfo(res);
-            free(conn);
-            return NULL;
-        }
         if (bind(rx_socket, (struct sockaddr*)&si_me, sizeof(si_me)) == -1) {
             fprintf(stderr, "Unable to bind Rx socket to port: %s\n", strerror(errno));
             close(rx_socket);
@@ -211,15 +202,6 @@ struct eb_connection *eb_connect(const char *addr, const char *port, int is_dire
             close(tx_socket);
             freeaddrinfo(res);
             fprintf(stderr, "unable to create socket: %s\n", strerror(errno));
-            free(conn);
-            return NULL;
-        }
-        /* Enable address reuse on TX Socket, FIXME: Close socket properly */
-        if (setsockopt(tx_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-            fprintf(stderr, "setsockopt(SO_REUSEADDR) on tx_socket failed: %s\n", strerror(errno));
-            close(rx_socket);
-            close(tx_socket);
-            freeaddrinfo(res);
             free(conn);
             return NULL;
         }


### PR DESCRIPTION
Before commit a95fb68d433ff4f30149e0ed2a2254ac0b62ae74 closing the GQRX application or changing settings would cause a segmentation fault or errors due to previously unclosed sockets.

At constructor level, `eb_connect` is called and an instance of `LiteXM2SDRUDPRx` is created. But at destructor level `eb_disconnect` is not called and `_rx_udp_receiver` is not removed/deleted.
When a reconfiguration is done, only the module is detroyed, not the application, consequently this two sockets are not removed/closed.

This PR adds explicit sockets closing by calling `eb_disconnect` and `delete _rx_udp_receiver`. Commit a95fb68d433ff4f30149e0ed2a2254ac0b62ae74 is not more required

**Note:** To be able to uses SoapySDR module with liteeth, d9b1dd8e050138b909e77290d659b32624f03eb9 has been locally reverted to avoid wrong configurations, uncoherent reads or segfault.