### PR TITLE
Move etherbone spi access

### DIFF
--- a/software/soapysdr/CMakeLists.txt
+++ b/software/soapysdr/CMakeLists.txt
@@ -101,7 +101,7 @@ set(LITEXM2SDR_SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/ad9361/ad9361.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/ad9361/ad9361_conv.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/ad9361/util.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/libliteeth/etherbone.c
+	#${CMAKE_CURRENT_SOURCE_DIR}/../../software/user/libliteeth/etherbone.c
 )
 
 if(USE_LITEETH)
@@ -116,7 +116,7 @@ SOAPY_SDR_MODULE_UTIL(
     LiteXM2SDRRegistration.cpp
     LiteXM2SDRUDPRx.cpp
     ${LITEXM2SDR_SOURCE}
-    LIBRARIES ${LITEPCIE_LIBRARY} ${LIBM2SDR_LIBRARY} m
+    LIBRARIES ${LIBM2SDR_LIBRARY} ${LITEPCIE_LIBRARY} m
 )
 
 # Suppress specific warnings

--- a/software/user/Makefile
+++ b/software/user/Makefile
@@ -1,4 +1,4 @@
-CFLAGS  = -O2 -Wall -g -I../kernel -Iliblitepcie -Ilibm2sdr -Iad9361 -MMD -fPIC
+CFLAGS  = -O2 -Wall -g -I../kernel -Ilibliteeth -Iliblitepcie -Ilibm2sdr -Iad9361 -MMD -fPIC
 LDFLAGS = -g
 CC      = $(CROSS_COMPILE)gcc
 AR      = ar
@@ -11,7 +11,7 @@ liblitepcie/liblitepcie.a: liblitepcie/litepcie_dma.o liblitepcie/litepcie_flash
 	ar rcs $@ $+
 	ranlib $@
 
-libm2sdr/libm2sdr.a: libm2sdr/m2sdr_si5351_i2c.o libm2sdr/m2sdr_ad9361_spi.o
+libm2sdr/libm2sdr.a: libm2sdr/m2sdr_si5351_i2c.o libm2sdr/m2sdr_ad9361_spi.o libliteeth/etherbone.o
 	ar rcs $@ $+
 	ranlib $@
 
@@ -39,6 +39,7 @@ clean:
 	rm -f $(PROGS) *.o *.a *.d *~
 	rm -f liblitepcie/*.a liblitepcie/*.o liblitepcie/*.d
 	rm -f libm2sdr/*.a libm2sdr/*.o libm2sdr/*.d
+	rm -f libliteeth/*.a libliteeth/*.o libliteeth/*.d
 	rm -f  ad9361/*.o ad9361/*.d ad9361/*~
 
 %.o: %.c

--- a/software/user/libm2sdr/m2sdr_ad9361_spi.c
+++ b/software/user/libm2sdr/m2sdr_ad9361_spi.c
@@ -14,6 +14,8 @@
 
 #include "m2sdr_ad9361_spi.h"
 
+#include "etherbone.h"
+
 //#define AD9361_SPI_WRITE_DEBUG
 //#define AD9361_SPI_READ_DEBUG
 
@@ -82,3 +84,69 @@ uint8_t m2sdr_ad9361_spi_read(int fd, uint16_t reg) {
 
     return dat;
 }
+
+/* Etherbone */
+/*-----------*/
+#define eb_writel(_eb, _addr, _val) eb_write32(_eb, _val, _addr)
+void m2sdr_ad9361_eb_spi_xfer(struct eb_connection *eb, uint8_t len, uint8_t *mosi, uint8_t *miso) {
+    eb_writel(eb, CSR_AD9361_SPI_MOSI_ADDR, mosi[0] << 16 | mosi[1] << 8 | mosi[2]);
+    eb_writel(eb, CSR_AD9361_SPI_CONTROL_ADDR, 24*SPI_CONTROL_LENGTH | SPI_CONTROL_START);
+    while ((eb_read32(eb, CSR_AD9361_SPI_STATUS_ADDR) & 0x1) != SPI_STATUS_DONE);
+    miso[2] = eb_read32(eb, CSR_AD9361_SPI_MISO_ADDR) & 0xff;
+}
+
+void m2sdr_ad9361_eb_spi_write(struct eb_connection *eb, uint16_t reg, uint8_t dat) {
+    uint8_t mosi[3];
+    uint8_t miso[3];
+
+#ifdef AD9361_SPI_WRITE_DEBUG
+    printf("ad9361_spi_write_reg; reg:0x%04x dat:%02x\n", reg, dat);
+#endif
+
+    /* Prepare Data. */
+    mosi[0]  = (1 << 7);
+    mosi[0] |= (reg >> 8) & 0x7f;
+    mosi[1]  = (reg >> 0) & 0xff;
+    mosi[2]  = dat;
+
+    /* Do SPI Xfer. */
+    m2sdr_ad9361_eb_spi_xfer(eb, 3, mosi, miso);
+}
+
+uint8_t m2sdr_ad9361_eb_spi_read(struct eb_connection *eb, uint16_t reg) {
+    uint8_t dat;
+    uint8_t mosi[3];
+    uint8_t miso[3];
+
+    /* Prepare Data. */
+    mosi[0]  = (0 << 7);
+    mosi[0] |= (reg >> 8) & 0x7f;
+    mosi[1]  = (reg >> 0) & 0xff;
+    mosi[2]  = 0x00;
+
+    /* Do SPI Xfer. */
+    m2sdr_ad9361_eb_spi_xfer(eb, 3, mosi, miso);
+
+    /* Process Data. */
+    dat = miso[2];
+
+#ifdef AD9361_SPI_READ_DEBUG
+    printf("ad9361_spi_read_reg; reg:0x%04x dat:%02x\n", reg, dat);
+#endif
+
+    return dat;
+}
+
+void m2sdr_ad9361_eb_spi_init(struct eb_connection *fd, uint8_t reset) {
+    if (reset) {
+        /* Reset Through GPIO */
+        eb_write32(fd, 0b00, CSR_AD9361_CONFIG_ADDR);
+        usleep(1000);
+    }
+    eb_write32(fd, 0b11, CSR_AD9361_CONFIG_ADDR);
+    usleep(1000);
+
+    /* Small delay. */
+    usleep(1000);
+}
+

--- a/software/user/libm2sdr/m2sdr_ad9361_spi.h
+++ b/software/user/libm2sdr/m2sdr_ad9361_spi.h
@@ -15,6 +15,8 @@
 #include "csr.h"
 #include "soc.h"
 
+#include "etherbone.h"
+
 /* SPI Constants */
 /*---------------*/
 
@@ -29,5 +31,12 @@ void m2sdr_ad9361_spi_init(int fd, uint8_t reset);
 void m2sdr_ad9361_spi_xfer(int fd, uint8_t len, uint8_t *mosi, uint8_t *miso);
 void m2sdr_ad9361_spi_write(int fd, uint16_t reg, uint8_t dat);
 uint8_t m2sdr_ad9361_spi_read(int fd, uint16_t reg);
+
+/* SPI Over Etherbone functions */
+/*------------------------------*/
+//void m2sdr_ad9361_spi_xfer(struct eb_connection *eb, uint8_t len, uint8_t *mosi, uint8_t *miso);
+void m2sdr_ad9361_eb_spi_init(struct eb_connection *fd, uint8_t reset);
+void m2sdr_ad9361_eb_spi_write(struct eb_connection *eb, uint16_t reg, uint8_t dat);
+uint8_t m2sdr_ad9361_eb_spi_read(struct eb_connection *eb, uint16_t reg);
 
 #endif /* M2SDR_LIB_AD9361_SPI_H */


### PR DESCRIPTION
SPI access via etherbone are implemented at SoapySDR module.
This has for effect to add "noise" in LiteXM2SDRDevice class and only this module could access SPI via etherbone.
This PR moves these functions to software/user/libm2sdr/m2sdr_ad9361_spi.