### PR TITLE
Removing Soapy borders to stream at 122.88Msps and keep using dynamic bitmode for Gen2 X1/X2

### DIFF
--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -285,6 +285,8 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
 
     if (args.count("bitmode") > 0) {
         _bitMode = std::stoi(args.at("bitmode"));
+    } else {
+        _bitMode = 16;
     }
 
     if (args.count("oversampling") > 0) {
@@ -756,14 +758,8 @@ void SoapyLiteXM2SDR::setSampleRate(
 
 #if USE_LITEPCIE
     /* For PCIe, if the sample rate is above 61.44 MSPS, switch to 8-bit mode + oversampling. */
-    /* FIXME: We could keep 16-bit when PCIe > Gen2 X1. */
-    if (rate > LITEPCIE_8BIT_THRESHOLD) {
-        _bitMode      = 8;
+    if (rate > LITEPCIE_8BIT_THRESHOLD) // keeping 16-bit mode unless it is specified in arguments
         _oversampling = 1;
-    } else {
-        _bitMode      = 16;
-        _oversampling = 0;
-    }
 #elif USE_LITEETH
     /* For Ethernet, if the sample rate is above 20 MSPS, switch to 8-bit mode. */
     if (rate > LITEETH_8BIT_THRESHOLD) {

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRRegistration.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRRegistration.cpp
@@ -80,7 +80,6 @@ SoapySDR::Kwargs createDeviceKwargs(
         {"identification", getLiteXM2SDRIdentification(fd)},
         {"version",        "1234"},
         {"label",          ""},
-        {"bitmode",        "16"},
         {"oversampling",   "0"},
     };
     dev["label"] = generateDeviceLabel(dev, path);


### PR DESCRIPTION
This commit just removes borders that limits us to stream at 122.88Msps.

Also, as Gen2 X1 may use 8-bit mode, the bitmode args is back to dynamic with default value=16.