### PR TITLE
Fix 10 MHz synchronisation of the SI5351

### DIFF
--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -615,7 +615,7 @@ class BaseSoC(SoCMini):
             sfp_i2c_pads = platform.request("sfp_i2c")
             LiteXWRNICSoC.add_wr_core(self,
                 # CPU.
-                cpu_firmware    = "../litex_wr_nic/firmware/spec_a7_wrc.bram", # FIXME: Avoid hardcoded path.
+                cpu_firmware    = "../litex_wr_nic/litex_wr_nic/firmware/spec_a7_wrc.bram", # FIXME: Avoid hardcoded path.
 
                 # Board name.
                 board_name       = "SAWR",

--- a/litex_m2sdr/software/user/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/m2sdr_rf.c
@@ -510,7 +510,7 @@ int main(int argc, char **argv)
 
     /* Parse/Handle Parameters. */
     for (;;) {
-        c = getopt_long_only(argc, argv, "hc8", options, &option_index);
+        c = getopt_long_only(argc, argv, "hc:8", options, &option_index);
         if (c == -1)
             break;
         switch(c) {

--- a/litex_m2sdr_platform.py
+++ b/litex_m2sdr_platform.py
@@ -32,7 +32,7 @@ _io = [
         Misc("PULLUP=TRUE"),
         IOStandard("LVCMOS33")
     ),
-    ("si5351_en_clkin", 0, Pins("W22"), IOStandard("LVCMOS33")), # SI5351_EN (B) / SI5351_CLKIN (C).
+    ("si5351_ssen_clkin", 0, Pins("W22"), IOStandard("LVCMOS33")), # SI5351_SSEN (A, B) / SI5351_CLKIN (C).
     ("si5351_pwm",      0, Pins("W19"), IOStandard("LVCMOS33")), # VCXO_TUNE_FPGA.
     ("si5351_clk0",     0, Pins("J19"), IOStandard("LVCMOS33")), # FPGA_AUXCLK_0.
     ("si5351_clk1",     0, Pins("E19"), IOStandard("LVCMOS33")), # FPGA_AUXCLK_1.


### PR DESCRIPTION
This allows the m2sdr to be fully syntonized on white rabbit, and fix the misleading name of the spread spectrum enable pin. Some improvements can be done to unify this gateware with the software (in terms of capabilities). I can do them in another PR if needed.

Good evening.