### PR TITLE
Add shared memory streaming utilities for GC-immune DMA transfers

### DIFF
--- a/litex_m2sdr/software/user/.gitignore
+++ b/litex_m2sdr/software/user/.gitignore
@@ -6,4 +6,6 @@
 /m2sdr_record
 /m2sdr_rf
 /m2sdr_sata
+/m2sdr_rx_stream_shm
+/m2sdr_tx_stream_shm
 /m2sdr_util

--- a/litex_m2sdr/software/user/.gitignore
+++ b/litex_m2sdr/software/user/.gitignore
@@ -7,5 +7,6 @@
 /m2sdr_rf
 /m2sdr_sata
 /m2sdr_rx_stream_shm
+/m2sdr_stream_shm
 /m2sdr_tx_stream_shm
 /m2sdr_util

--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -12,7 +12,7 @@ INTERFACE ?= USE_LITEPCIE
 ifeq ($(INTERFACE),USE_LITEETH)
   BINARIES := m2sdr_util m2sdr_rf m2sdr_gpio m2sdr_play m2sdr_record m2sdr_sata
 else ifeq ($(INTERFACE),USE_LITEPCIE)
-  BINARIES := m2sdr_util m2sdr_rf m2sdr_gen m2sdr_play m2sdr_record m2sdr_gpio m2sdr_fm_tx m2sdr_fm_rx m2sdr_sata m2sdr_rx_stream_shm m2sdr_tx_stream_shm
+  BINARIES := m2sdr_util m2sdr_rf m2sdr_gen m2sdr_play m2sdr_record m2sdr_gpio m2sdr_fm_tx m2sdr_fm_rx m2sdr_sata m2sdr_rx_stream_shm m2sdr_tx_stream_shm m2sdr_stream_shm
 else
   $(error INTERFACE must be USE_LITEPCIE or USE_LITEETH)
 endif
@@ -99,6 +99,10 @@ m2sdr_rx_stream_shm: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_rx_stre
 	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -llitepcie -lm2sdr
 
 m2sdr_tx_stream_shm: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_tx_stream_shm.o \
+	ad9361/ad9361.o ad9361/ad9361_api.o ad9361/ad9361_conv.o ad9361/util.o
+	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -llitepcie -lm2sdr
+
+m2sdr_stream_shm: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_stream_shm.o \
 	ad9361/ad9361.o ad9361/ad9361_api.o ad9361/ad9361_conv.o ad9361/util.o
 	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -llitepcie -lm2sdr
 endif

--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -12,7 +12,7 @@ INTERFACE ?= USE_LITEPCIE
 ifeq ($(INTERFACE),USE_LITEETH)
   BINARIES := m2sdr_util m2sdr_rf m2sdr_gpio m2sdr_play m2sdr_record m2sdr_sata
 else ifeq ($(INTERFACE),USE_LITEPCIE)
-  BINARIES := m2sdr_util m2sdr_rf m2sdr_gen m2sdr_play m2sdr_record m2sdr_gpio m2sdr_fm_tx m2sdr_fm_rx m2sdr_sata
+  BINARIES := m2sdr_util m2sdr_rf m2sdr_gen m2sdr_play m2sdr_record m2sdr_gpio m2sdr_fm_tx m2sdr_fm_rx m2sdr_sata m2sdr_rx_stream_shm m2sdr_tx_stream_shm
 else
   $(error INTERFACE must be USE_LITEPCIE or USE_LITEETH)
 endif
@@ -93,6 +93,14 @@ m2sdr_fm_tx: liblitepcie/liblitepcie.a m2sdr_fm_tx.o
 
 m2sdr_fm_rx: liblitepcie/liblitepcie.a m2sdr_fm_rx.o
 	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -lm -llitepcie -lsndfile -lsamplerate
+
+m2sdr_rx_stream_shm: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_rx_stream_shm.o \
+	ad9361/ad9361.o ad9361/ad9361_api.o ad9361/ad9361_conv.o ad9361/util.o
+	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -llitepcie -lm2sdr
+
+m2sdr_tx_stream_shm: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_tx_stream_shm.o \
+	ad9361/ad9361.o ad9361/ad9361_api.o ad9361/ad9361_conv.o ad9361/util.o
+	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -llitepcie -lm2sdr
 endif
 
 clean:

--- a/litex_m2sdr/software/user/m2sdr_common.h
+++ b/litex_m2sdr/software/user/m2sdr_common.h
@@ -1,0 +1,172 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * M2SDR Common - Signal handling, AD9361 platform stubs & shared RF init.
+ *
+ * Provides:
+ *   - Signal handling (SIGINT/SIGTERM)
+ *   - AD9361 platform abstraction layer (SPI, GPIO, delay stubs)
+ *   - Common RF initialization code shared between streaming executables
+ *   - AGC mode helpers
+ *
+ * This file is part of LiteX-M2SDR project.
+ *
+ * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
+ */
+
+#ifndef M2SDR_COMMON_H
+#define M2SDR_COMMON_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+
+#include "ad9361/platform.h"
+#include "ad9361/ad9361.h"
+#include "ad9361/ad9361_api.h"
+
+#include "m2sdr_config.h"
+#include "liblitepcie.h"
+#include "libm2sdr.h"
+
+/*
+ * Signal Handling
+ */
+static volatile sig_atomic_t g_keep_running = 1;
+
+static void m2sdr_signal_handler(int sig) {
+    (void)sig;
+    g_keep_running = 0;
+}
+
+static inline void m2sdr_install_signal_handlers(void) {
+    signal(SIGINT,  m2sdr_signal_handler);
+    signal(SIGTERM, m2sdr_signal_handler);
+}
+
+/*
+ * AD9361 Platform Stubs
+ */
+#define AD9361_GPIO_RESET_PIN 0
+
+struct ad9361_rf_phy *ad9361_phy;
+
+static int g_spi_fd = -1;
+
+int spi_write_then_read(struct spi_device *spi,
+                        const unsigned char *txbuf, unsigned n_tx,
+                        unsigned char *rxbuf, unsigned n_rx)
+{
+    (void)spi;
+    if (n_tx == 2 && n_rx == 1) {
+        rxbuf[0] = m2sdr_ad9361_spi_read((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1]);
+    } else if (n_tx == 3 && n_rx == 0) {
+        m2sdr_ad9361_spi_write((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1], txbuf[2]);
+    } else {
+        fprintf(stderr, "Unsupported SPI transfer n_tx=%d n_rx=%d\n", n_tx, n_rx);
+        return -1;
+    }
+    return 0;
+}
+
+void udelay(unsigned long usecs) { usleep(usecs); }
+void mdelay(unsigned long msecs) { usleep(msecs * 1000); }
+unsigned long msleep_interruptible(unsigned int msecs) { usleep(msecs * 1000); return 0; }
+bool gpio_is_valid(int number) { return (number == AD9361_GPIO_RESET_PIN); }
+void gpio_set_value(unsigned gpio, int value) { (void)gpio; (void)value; }
+
+/*
+ * AGC Mode Helpers
+ */
+static const char *agc_mode_names[] __attribute__((unused)) = {"manual", "fast_attack", "slow_attack", "hybrid"};
+
+static uint8_t __attribute__((unused)) parse_agc_mode(const char *str) {
+    if (strcasecmp(str, "manual") == 0 || strcasecmp(str, "mgc") == 0)
+        return RF_GAIN_MGC;
+    if (strcasecmp(str, "fast_attack") == 0 || strcasecmp(str, "fast") == 0)
+        return RF_GAIN_FASTATTACK_AGC;
+    if (strcasecmp(str, "slow_attack") == 0 || strcasecmp(str, "slow") == 0)
+        return RF_GAIN_SLOWATTACK_AGC;
+    if (strcasecmp(str, "hybrid") == 0)
+        return RF_GAIN_HYBRID_AGC;
+    fprintf(stderr, "Unknown AGC mode '%s'. Valid: manual, fast_attack, slow_attack, hybrid\n", str);
+    exit(1);
+}
+
+static inline const char *agc_mode_str(uint8_t mode) {
+    return (mode <= RF_GAIN_HYBRID_AGC) ? agc_mode_names[mode] : "unknown";
+}
+
+/*
+ * Common RF Initialization
+ *
+ * Performs the shared setup steps used by both RX and TX:
+ *   - SI5351 clocking (if available)
+ *   - AD9361 power-up and SPI init
+ *   - 1T1R / 2T2R mode configuration
+ *   - Reference clock and init params
+ *   - 16-bit mode, synchronizer enable, loopback disable
+ *
+ * After calling this, the caller should do direction-specific setup
+ * (RX freq/gain/AGC/FIR or TX freq/attenuation/FIR interpolation).
+ *
+ * The fd is stored in g_spi_fd for use by spi_write_then_read().
+ */
+static void m2sdr_rf_common_init(int fd, uint8_t num_channels)
+{
+    g_spi_fd = fd;
+
+#ifdef CSR_SI5351_BASE
+    printf("Initializing SI5351 clocking...\n");
+    m2sdr_writel((void *)(intptr_t)fd, CSR_SI5351_CONTROL_ADDR,
+        SI5351B_VERSION * (1 << CSR_SI5351_CONTROL_VERSION_OFFSET));
+    m2sdr_si5351_i2c_config((void *)(intptr_t)fd, SI5351_I2C_ADDR,
+        si5351_xo_40m_config,
+        sizeof(si5351_xo_40m_config) / sizeof(si5351_xo_40m_config[0]));
+#endif
+
+    printf("Powering up AD9361...\n");
+    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_CONFIG_ADDR, 0b11);
+
+    printf("Initializing AD9361 SPI...\n");
+    m2sdr_ad9361_spi_init((void *)(intptr_t)fd, 1);
+
+    /* Configure 1T1R or 2T2R mode */
+    if (num_channels == 2) {
+        printf("Initializing AD9361 RFIC (2T2R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 1;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 1;
+        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 0);
+    } else {
+        printf("Initializing AD9361 RFIC (1T1R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 0;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 0;
+        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 1);
+    }
+
+    default_init_param.reference_clk_rate = 40000000;
+    default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
+    default_init_param.gpio_sync          = -1;
+    default_init_param.gpio_cal_sw1       = -1;
+    default_init_param.gpio_cal_sw2       = -1;
+
+    /* 16-bit mode (12-bit samples in 16-bit words) */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_BITMODE_ADDR, 0);
+
+    /* Enable synchronizer (disable bypass) - matches SoapySDR */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_SYNCHRONIZER_BYPASS_ADDR, 0);
+
+    /* Disable DMA loopback - matches SoapySDR */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_LOOPBACK_ENABLE_ADDR, 0);
+}
+
+#endif /* M2SDR_COMMON_H */

--- a/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
@@ -309,11 +309,13 @@ static void rf_init(int fd, uint32_t samplerate, int64_t bandwidth,
         m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 1);
     }
 
-    default_init_param.reference_clk_rate = 40000000;
-    default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
-    default_init_param.gpio_sync          = -1;
-    default_init_param.gpio_cal_sw1       = -1;
-    default_init_param.gpio_cal_sw2       = -1;
+    default_init_param.reference_clk_rate          = 40000000;
+    default_init_param.gpio_resetb                 = AD9361_GPIO_RESET_PIN;
+    default_init_param.gpio_sync                   = -1;
+    default_init_param.gpio_cal_sw1                = -1;
+    default_init_param.gpio_cal_sw2                = -1;
+    default_init_param.rx_synthesizer_frequency_hz = rx_freq;
+    default_init_param.rf_rx_bandwidth_hz          = bandwidth;
 
     ad9361_init(&ad9361_phy, &default_init_param, 1);
 

--- a/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: BSD-2-Clause
  *
- * M2SDR RX Stream to Shared Memory Utility (v2).
+ * M2SDR RX Stream to Shared Memory Utility.
  *
  * This utility configures the AD9361 RF frontend and streams RX data
  * to a shared memory ring buffer. Designed for Julia integration where
  * a larger buffer helps overcome GC pauses.
  *
- * Key differences from v1:
+ * Key features:
  *   - Follows SoapySDR driver DMA patterns exactly for correctness
  *   - No per-chunk lost samples header - pure sample data only
  *   - Simplified overflow detection matching SoapySDR
@@ -16,17 +16,6 @@
  *   - Multi-channel data is interleaved: I0,Q0,I1,Q1,I0,Q0,I1,Q1,...
  *   - 12-bit ADC samples are sign-extended to 16-bit
  *
- * Shared Memory Layout:
- *   Bytes 0-7:   write_index (uint64_t) - next slot to write (producer)
- *   Bytes 8-15:  read_index (uint64_t) - next slot to read (consumer)
- *   Bytes 16-23: overflow_count (uint64_t) - DMA overflows detected
- *   Bytes 24-27: chunk_size (uint32_t) - samples per chunk (per channel)
- *   Bytes 28-31: num_slots (uint32_t) - number of slots in ring buffer
- *   Bytes 32-33: num_channels (uint16_t) - 1 or 2
- *   Bytes 34-35: flags (uint16_t) - bit 0 = writer_done
- *   Bytes 36-63: reserved (28 bytes)
- *   Bytes 64+:   slot data (pure samples, no per-slot headers)
- *
  * This file is part of LiteX-M2SDR project.
  *
  * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
@@ -35,285 +24,33 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
 #include <inttypes.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <signal.h>
-#include <stdbool.h>
 #include <getopt.h>
 #include <stdint.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <time.h>
 #include <poll.h>
 
-#include "ad9361/platform.h"
-#include "ad9361/ad9361.h"
-#include "ad9361/ad9361_api.h"
-
-#include "m2sdr_config.h"
-
-#include "liblitepcie.h"
-#include "libm2sdr.h"
-
-/*
- * Shared Memory Header Layout (64 bytes)
- */
-#define SHM_HEADER_SIZE         64
-#define SHM_OFFSET_WRITE_INDEX  0
-#define SHM_OFFSET_READ_INDEX   8
-#define SHM_OFFSET_OVERFLOW     16
-#define SHM_OFFSET_CHUNK_SIZE   24
-#define SHM_OFFSET_NUM_SLOTS    28
-#define SHM_OFFSET_NUM_CHANNELS 32
-#define SHM_OFFSET_FLAGS        34
-
-#define SHM_FLAG_WRITER_DONE    (1 << 0)
-
-/* Sample size for Complex{Int16} */
-#define BYTES_PER_COMPLEX       4
+#include "m2sdr_shm.h"
+#include "m2sdr_common.h"
 
 /*
  * Global state
  */
 static char g_device_path[256];
 static int g_device_num = 0;
-static volatile sig_atomic_t g_keep_running = 1;
-
-static void signal_handler(int sig) {
-    (void)sig;
-    g_keep_running = 0;
-}
-
-/* get_time_ms is provided by litepcie_helpers.h */
 
 /*
- * AD9361 Platform Stubs
- */
-#define AD9361_GPIO_RESET_PIN 0
-
-struct ad9361_rf_phy *ad9361_phy;
-
-static int g_spi_fd = -1;
-
-int spi_write_then_read(struct spi_device *spi,
-                        const unsigned char *txbuf, unsigned n_tx,
-                        unsigned char *rxbuf, unsigned n_rx)
-{
-    (void)spi;
-    if (n_tx == 2 && n_rx == 1) {
-        rxbuf[0] = m2sdr_ad9361_spi_read((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1]);
-    } else if (n_tx == 3 && n_rx == 0) {
-        m2sdr_ad9361_spi_write((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1], txbuf[2]);
-    } else {
-        fprintf(stderr, "Unsupported SPI transfer n_tx=%d n_rx=%d\n", n_tx, n_rx);
-        return -1;
-    }
-    return 0;
-}
-
-void udelay(unsigned long usecs) { usleep(usecs); }
-void mdelay(unsigned long msecs) { usleep(msecs * 1000); }
-unsigned long msleep_interruptible(unsigned int msecs) { usleep(msecs * 1000); return 0; }
-bool gpio_is_valid(int number) { return (number == AD9361_GPIO_RESET_PIN); }
-void gpio_set_value(unsigned gpio, int value) { (void)gpio; (void)value; }
-
-/*
- * Shared Memory Ring Buffer
- */
-typedef struct {
-    uint8_t  *base;          /* mmap base pointer */
-    size_t    total_size;    /* total mmap size */
-    uint32_t  num_slots;     /* number of slots */
-    uint32_t  chunk_size;    /* samples per chunk per channel */
-    uint32_t  chunk_bytes;   /* bytes per chunk (all channels) */
-    uint16_t  num_channels;  /* 1 or 2 */
-} shm_buffer_t;
-
-/* Atomic accessors for producer/consumer indices */
-static inline uint64_t shm_load_write_index(shm_buffer_t *shm) {
-    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), __ATOMIC_ACQUIRE);
-}
-
-static inline void shm_store_write_index(shm_buffer_t *shm, uint64_t val) {
-    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), val, __ATOMIC_RELEASE);
-}
-
-static inline uint64_t shm_load_read_index(shm_buffer_t *shm) {
-    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_READ_INDEX), __ATOMIC_ACQUIRE);
-}
-
-static inline void shm_store_overflow(shm_buffer_t *shm, uint64_t val) {
-    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_OVERFLOW), val, __ATOMIC_RELAXED);
-}
-
-static inline void shm_set_flags(shm_buffer_t *shm, uint16_t flags) {
-    __atomic_store_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), flags, __ATOMIC_RELEASE);
-}
-
-static inline uint16_t shm_get_flags(shm_buffer_t *shm) {
-    return __atomic_load_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), __ATOMIC_ACQUIRE);
-}
-
-/* Get pointer to slot data (no per-slot header, pure samples) */
-static inline uint8_t *shm_slot_ptr(shm_buffer_t *shm, uint64_t index) {
-    size_t slot_offset = SHM_HEADER_SIZE + (index % shm->num_slots) * shm->chunk_bytes;
-    return shm->base + slot_offset;
-}
-
-/* Check if we can write (ring buffer not full) */
-static inline bool shm_can_write(shm_buffer_t *shm, uint64_t write_idx) {
-    uint64_t read_idx = shm_load_read_index(shm);
-    return (write_idx - read_idx) < shm->num_slots;
-}
-
-/*
- * Create shared memory ring buffer
- */
-static shm_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
-                                 uint16_t num_channels, double buffer_seconds,
-                                 uint32_t sample_rate)
-{
-    shm_buffer_t *shm = calloc(1, sizeof(shm_buffer_t));
-    if (!shm) {
-        perror("calloc");
-        return NULL;
-    }
-
-    shm->num_channels = num_channels;
-    shm->chunk_bytes = chunk_bytes;
-    shm->chunk_size = chunk_bytes / (BYTES_PER_COMPLEX * num_channels);
-
-    /* Calculate number of slots for requested buffer duration */
-    uint64_t bytes_per_second = (uint64_t)sample_rate * BYTES_PER_COMPLEX * num_channels;
-    uint64_t total_buffer_bytes = (uint64_t)(bytes_per_second * buffer_seconds);
-    shm->num_slots = (total_buffer_bytes + chunk_bytes - 1) / chunk_bytes;
-    if (shm->num_slots < 16)
-        shm->num_slots = 16;
-
-    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * shm->chunk_bytes;
-
-    /* Create/open shared memory file */
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
-    if (fd < 0) {
-        perror(path);
-        free(shm);
-        return NULL;
-    }
-
-    if (ftruncate(fd, shm->total_size) < 0) {
-        perror("ftruncate");
-        close(fd);
-        free(shm);
-        return NULL;
-    }
-
-    shm->base = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    close(fd);
-
-    if (shm->base == MAP_FAILED) {
-        perror("mmap");
-        free(shm);
-        return NULL;
-    }
-
-    /* Initialize header */
-    memset(shm->base, 0, SHM_HEADER_SIZE);
-    *(uint32_t *)(shm->base + SHM_OFFSET_CHUNK_SIZE)   = shm->chunk_size;
-    *(uint32_t *)(shm->base + SHM_OFFSET_NUM_SLOTS)    = shm->num_slots;
-    *(uint16_t *)(shm->base + SHM_OFFSET_NUM_CHANNELS) = num_channels;
-
-    printf("Created shared memory ring buffer:\n");
-    printf("  Path: %s\n", path);
-    printf("  Chunk size: %u bytes (%u samples/channel)\n", chunk_bytes, shm->chunk_size);
-    printf("  Num channels: %u\n", num_channels);
-    printf("  Num slots: %u\n", shm->num_slots);
-    printf("  Buffer size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
-    printf("  Buffer time: %.2f seconds\n", (double)shm->num_slots * shm->chunk_size / sample_rate);
-
-    return shm;
-}
-
-static void shm_destroy(shm_buffer_t *shm) {
-    if (shm) {
-        if (shm->base && shm->base != MAP_FAILED) {
-            /* Signal writer done */
-            shm_set_flags(shm, shm_get_flags(shm) | SHM_FLAG_WRITER_DONE);
-            munmap(shm->base, shm->total_size);
-        }
-        free(shm);
-    }
-}
-
-/*
- * AGC Mode Helpers
- */
-static const char *agc_mode_names[] = {"manual", "fast_attack", "slow_attack", "hybrid"};
-
-static uint8_t parse_agc_mode(const char *str) {
-    if (strcasecmp(str, "manual") == 0 || strcasecmp(str, "mgc") == 0)
-        return RF_GAIN_MGC;
-    if (strcasecmp(str, "fast_attack") == 0 || strcasecmp(str, "fast") == 0)
-        return RF_GAIN_FASTATTACK_AGC;
-    if (strcasecmp(str, "slow_attack") == 0 || strcasecmp(str, "slow") == 0)
-        return RF_GAIN_SLOWATTACK_AGC;
-    if (strcasecmp(str, "hybrid") == 0)
-        return RF_GAIN_HYBRID_AGC;
-    fprintf(stderr, "Unknown AGC mode '%s'. Valid: manual, fast_attack, slow_attack, hybrid\n", str);
-    exit(1);
-}
-
-static const char *agc_mode_str(uint8_t mode) {
-    return (mode <= RF_GAIN_HYBRID_AGC) ? agc_mode_names[mode] : "unknown";
-}
-
-/*
- * RF Initialization (matching SoapySDR)
+ * RF Initialization (RX-specific)
  */
 static void rf_init(int fd, uint32_t samplerate, int64_t bandwidth,
                     int64_t rx_freq, int64_t rx_gain, uint8_t agc_mode,
                     uint8_t num_channels)
 {
-    g_spi_fd = fd;
+    /* Common AD9361 setup (SI5351, power-up, SPI, mode, bitmode, sync, loopback) */
+    m2sdr_rf_common_init(fd, num_channels);
 
-#ifdef CSR_SI5351_BASE
-    printf("Initializing SI5351 clocking...\n");
-    m2sdr_writel((void *)(intptr_t)fd, CSR_SI5351_CONTROL_ADDR,
-        SI5351B_VERSION * (1 << CSR_SI5351_CONTROL_VERSION_OFFSET));
-    m2sdr_si5351_i2c_config((void *)(intptr_t)fd, SI5351_I2C_ADDR,
-        si5351_xo_40m_config,
-        sizeof(si5351_xo_40m_config) / sizeof(si5351_xo_40m_config[0]));
-#endif
-
-    printf("Powering up AD9361...\n");
-    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_CONFIG_ADDR, 0b11);
-
-    printf("Initializing AD9361 SPI...\n");
-    m2sdr_ad9361_spi_init((void *)(intptr_t)fd, 1);
-
-    /* Configure 1T1R or 2T2R mode */
-    if (num_channels == 2) {
-        printf("Initializing AD9361 RFIC (2T2R mode)...\n");
-        default_init_param.two_rx_two_tx_mode_enable     = 1;
-        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
-        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
-        default_init_param.two_t_two_r_timing_enable     = 1;
-        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 0);
-    } else {
-        printf("Initializing AD9361 RFIC (1T1R mode)...\n");
-        default_init_param.two_rx_two_tx_mode_enable     = 0;
-        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
-        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
-        default_init_param.two_t_two_r_timing_enable     = 0;
-        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 1);
-    }
-
-    default_init_param.reference_clk_rate          = 40000000;
-    default_init_param.gpio_resetb                 = AD9361_GPIO_RESET_PIN;
-    default_init_param.gpio_sync                   = -1;
-    default_init_param.gpio_cal_sw1                = -1;
-    default_init_param.gpio_cal_sw2                = -1;
+    /* Set synthesizer frequency hint before init */
     default_init_param.rx_synthesizer_frequency_hz = rx_freq;
     default_init_param.rf_rx_bandwidth_hz          = bandwidth;
 
@@ -340,15 +77,6 @@ static void rf_init(int fd, uint32_t samplerate, int64_t bandwidth,
     ad9361_set_rx_rf_gain(ad9361_phy, 0, rx_gain);
     if (num_channels == 2)
         ad9361_set_rx_rf_gain(ad9361_phy, 1, rx_gain);
-
-    /* 16-bit mode (12-bit samples in 16-bit words) */
-    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_BITMODE_ADDR, 0);
-
-    /* Enable synchronizer (disable bypass) - matches SoapySDR */
-    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_SYNCHRONIZER_BYPASS_ADDR, 0);
-
-    /* Disable DMA loopback - matches SoapySDR */
-    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_LOOPBACK_ENABLE_ADDR, 0);
 }
 
 /*
@@ -414,7 +142,7 @@ static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
     uint32_t dma_buf_count = dma_info.dma_rx_buf_count;
 
     /* Samples per DMA buffer (per channel) */
-    size_t samples_per_dma = dma_buf_size / (BYTES_PER_COMPLEX * shm->num_channels);
+    size_t samples_per_dma = dma_buf_size / (SHM_BYTES_PER_COMPLEX * shm->num_channels);
     /* int16 values per DMA buffer (I and Q for all channels) */
     size_t int16_per_dma = dma_buf_size / sizeof(int16_t);
 
@@ -491,7 +219,7 @@ static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
          */
         if ((hw_count - sw_count) > (int64_t)(dma_buf_count / 2)) {
             overflow_count++;
-            shm_store_overflow(shm, overflow_count);
+            shm_store_error_count(shm, overflow_count);
 
             if (!quiet) {
                 fprintf(stderr, "\nOVERFLOW #%" PRIu64 ": hw=%" PRId64 " sw=%" PRId64
@@ -514,6 +242,7 @@ static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
             /* Wait for SHM space */
             while (!shm_can_write(shm, shm_write_idx)) {
                 buffer_full_waits++;
+                shm_store_buffer_stall(shm, buffer_full_waits);
                 usleep(10);
                 if (!g_keep_running)
                     goto done;
@@ -522,7 +251,7 @@ static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
                 litepcie_dma_writer(fd, 1, &hw_count, &sw_count);
                 if ((hw_count - sw_count) > (int64_t)(dma_buf_count / 2)) {
                     overflow_count++;
-                    shm_store_overflow(shm, overflow_count);
+                    shm_store_error_count(shm, overflow_count);
                     if (!quiet) {
                         fprintf(stderr, "\nOVERFLOW #%" PRIu64 " (while waiting for SHM)\n",
                                 overflow_count);
@@ -577,7 +306,7 @@ static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
         int64_t elapsed = now - last_stats_time;
         if (!quiet && elapsed >= 200) {
             double speed_gbps = (double)(user_count - last_sw_count) * dma_buf_size * 8 / (elapsed * 1e6);
-            uint64_t size_mb = (total_samples * BYTES_PER_COMPLEX * shm->num_channels) / (1024 * 1024);
+            uint64_t size_mb = (total_samples * SHM_BYTES_PER_COMPLEX * shm->num_channels) / (1024 * 1024);
 
             if (stats_line % 10 == 0) {
                 fprintf(stderr, "\n\033[1m%10s %12s %9s %10s %12s\033[0m\n",
@@ -611,8 +340,8 @@ done:
  */
 static void print_help(void)
 {
-    printf("M2SDR RX Stream to Shared Memory (v2)\n"
-           "Usage: m2sdr_rx_stream_shm2 [options]\n"
+    printf("M2SDR RX Stream to Shared Memory\n"
+           "Usage: m2sdr_rx_stream_shm [options]\n"
            "\n"
            "Options:\n"
            "  -h                     Show this help\n"
@@ -667,8 +396,7 @@ int main(int argc, char **argv)
     double buffer_time = 3.0;
     size_t num_samples = 0;
 
-    signal(SIGINT, signal_handler);
-    signal(SIGTERM, signal_handler);
+    m2sdr_install_signal_handlers();
 
     int c;
     while ((c = getopt_long_only(argc, argv, "hc:q", long_options, NULL)) != -1) {
@@ -720,8 +448,8 @@ int main(int argc, char **argv)
 
     snprintf(g_device_path, sizeof(g_device_path), "/dev/m2sdr%d", g_device_num);
 
-    printf("M2SDR RX Stream to Shared Memory (v2)\n");
-    printf("=====================================\n");
+    printf("M2SDR RX Stream to Shared Memory\n");
+    printf("=================================\n");
     printf("Device: %s\n", g_device_path);
     printf("Sample rate: %.2f MHz\n", samplerate / 1e6);
     printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);

--- a/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
@@ -1,35 +1,31 @@
 /* SPDX-License-Identifier: BSD-2-Clause
  *
- * M2SDR Stream to Shared Memory Utility.
+ * M2SDR RX Stream to Shared Memory Utility (v2).
  *
  * This utility configures the AD9361 RF frontend and streams RX data
- * directly to a shared memory ring buffer. Designed to run as a separate
- * process from Julia signal processing to avoid GC pause interference.
+ * to a shared memory ring buffer. Designed for Julia integration where
+ * a larger buffer helps overcome GC pauses.
+ *
+ * Key differences from v1:
+ *   - Follows SoapySDR driver DMA patterns exactly for correctness
+ *   - No per-chunk lost samples header - pure sample data only
+ *   - Simplified overflow detection matching SoapySDR
  *
  * Data Format:
- *   - Each DMA buffer is copied directly to a shared memory slot
  *   - Samples are Complex{Int16} (4 bytes per sample per channel)
  *   - Multi-channel data is interleaved: I0,Q0,I1,Q1,I0,Q0,I1,Q1,...
  *   - 12-bit ADC samples are sign-extended to 16-bit
  *
- * Shared Memory Header Layout (64 bytes):
- *   Bytes 0-7:   write_index (uint64_t) - next slot to write
- *   Bytes 8-15:  read_index (uint64_t) - next slot to read
- *   Bytes 16-23: chunks_written (uint64_t) - total chunks written
- *   Bytes 24-31: chunks_read (uint64_t) - total chunks read
- *   Bytes 32-35: chunk_size (uint32_t) - samples per chunk (per channel)
- *   Bytes 36-39: sample_size (uint32_t) - bytes per sample (4 for Complex{Int16})
- *   Bytes 40-43: num_slots (uint32_t) - number of slots in buffer
- *   Bytes 44-45: num_channels (uint16_t) - number of channels (1 or 2)
- *   Bytes 46-47: flags (uint16_t) - bit 0 = writer_done
- *   Bytes 48-55: overflow_count (uint64_t) - number of DMA overflows
- *   Bytes 56-63: lost_samples (uint64_t) - total samples lost to overflow
- *
- * Per-Chunk Header Layout (8 bytes, prepended to each slot):
- *   Bytes 0-7:   samples_lost_before (uint64_t) - samples lost since previous chunk
- *
- * Slot Layout:
- *   [8-byte chunk header][sample data...]
+ * Shared Memory Layout:
+ *   Bytes 0-7:   write_index (uint64_t) - next slot to write (producer)
+ *   Bytes 8-15:  read_index (uint64_t) - next slot to read (consumer)
+ *   Bytes 16-23: overflow_count (uint64_t) - DMA overflows detected
+ *   Bytes 24-27: chunk_size (uint32_t) - samples per chunk (per channel)
+ *   Bytes 28-31: num_slots (uint32_t) - number of slots in ring buffer
+ *   Bytes 32-33: num_channels (uint16_t) - 1 or 2
+ *   Bytes 34-35: flags (uint16_t) - bit 0 = writer_done
+ *   Bytes 36-63: reserved (28 bytes)
+ *   Bytes 64+:   slot data (pure samples, no per-slot headers)
  *
  * This file is part of LiteX-M2SDR project.
  *
@@ -50,6 +46,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <poll.h>
 
 #include "ad9361/platform.h"
 #include "ad9361/ad9361.h"
@@ -60,192 +57,125 @@
 #include "liblitepcie.h"
 #include "libm2sdr.h"
 
-/* Shared memory header offsets (0-indexed for C) */
+/*
+ * Shared Memory Header Layout (64 bytes)
+ */
 #define SHM_HEADER_SIZE         64
-#define OFFSET_WRITE_INDEX      0
-#define OFFSET_READ_INDEX       8
-#define OFFSET_CHUNKS_WRITTEN   16
-#define OFFSET_CHUNKS_READ      24
-#define OFFSET_CHUNK_SIZE       32
-#define OFFSET_SAMPLE_SIZE      36
-#define OFFSET_NUM_SLOTS        40
-#define OFFSET_NUM_CHANNELS     44
-#define OFFSET_FLAGS            46
-#define OFFSET_OVERFLOW_COUNT   48
-#define OFFSET_LOST_SAMPLES     56
+#define SHM_OFFSET_WRITE_INDEX  0
+#define SHM_OFFSET_READ_INDEX   8
+#define SHM_OFFSET_OVERFLOW     16
+#define SHM_OFFSET_CHUNK_SIZE   24
+#define SHM_OFFSET_NUM_SLOTS    28
+#define SHM_OFFSET_NUM_CHANNELS 32
+#define SHM_OFFSET_FLAGS        34
 
-/* Flag bits */
-#define FLAG_WRITER_DONE        1
+#define SHM_FLAG_WRITER_DONE    (1 << 0)
 
-/* Per-chunk header size (prepended to each slot's sample data)
- * Bytes 0-7: samples_lost_before (uint64_t) - samples lost since previous chunk
+/* Sample size for Complex{Int16} */
+#define BYTES_PER_COMPLEX       4
+
+/*
+ * Global state
  */
-#define CHUNK_HEADER_SIZE       8
+static char g_device_path[256];
+static int g_device_num = 0;
+static volatile sig_atomic_t g_keep_running = 1;
 
-/* Sample size for Complex{Int16} (real + imag, each int16) */
-#define SAMPLE_SIZE_COMPLEX_INT16 4
-
-/* Sign-extend 12-bit samples to 16-bit in-place
- * AD9361 outputs 12-bit signed samples in 16-bit words.
- * Bit 11 is the sign bit, so we need to extend it to bit 15.
- */
-static inline void sign_extend_12bit_inplace(int16_t *data, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        data[i] = (int16_t)(data[i] << 4) >> 4;
-    }
+static void signal_handler(int sig) {
+    (void)sig;
+    g_keep_running = 0;
 }
 
-/* Variables */
-/*-----------*/
+/* get_time_ms is provided by litepcie_helpers.h */
 
-static char m2sdr_device[1024];
-static int m2sdr_device_num = 0;
-
-sig_atomic_t keep_running = 1;
-
-void intHandler(int dummy) {
-    (void)dummy;
-    keep_running = 0;
-}
-
-/* forward (provided in tree elsewhere; used here) */
-extern int64_t get_time_ms(void);
-
-/* AD9361 */
-/*--------*/
-
+/*
+ * AD9361 Platform Stubs
+ */
 #define AD9361_GPIO_RESET_PIN 0
 
 struct ad9361_rf_phy *ad9361_phy;
 
-static void * m2sdr_open(void) {
-    int fd = open(m2sdr_device, O_RDWR);
-    if (fd < 0) {
-        fprintf(stderr, "Could not open device %s\n", m2sdr_device);
-        exit(1);
-    }
-    return (void *)(intptr_t)fd;
-}
-
-static void m2sdr_close(void *conn) {
-    close((int)(intptr_t)conn);
-}
+static int g_spi_fd = -1;
 
 int spi_write_then_read(struct spi_device *spi,
                         const unsigned char *txbuf, unsigned n_tx,
                         unsigned char *rxbuf, unsigned n_rx)
 {
-    void *conn = m2sdr_open();
-
+    (void)spi;
     if (n_tx == 2 && n_rx == 1) {
-        rxbuf[0] = m2sdr_ad9361_spi_read(conn, txbuf[0] << 8 | txbuf[1]);
+        rxbuf[0] = m2sdr_ad9361_spi_read((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1]);
     } else if (n_tx == 3 && n_rx == 0) {
-        m2sdr_ad9361_spi_write(conn, txbuf[0] << 8 | txbuf[1], txbuf[2]);
+        m2sdr_ad9361_spi_write((void *)(intptr_t)g_spi_fd, txbuf[0] << 8 | txbuf[1], txbuf[2]);
     } else {
         fprintf(stderr, "Unsupported SPI transfer n_tx=%d n_rx=%d\n", n_tx, n_rx);
-        m2sdr_close(conn);
-        exit(1);
+        return -1;
     }
-
-    m2sdr_close(conn);
     return 0;
 }
 
 void udelay(unsigned long usecs) { usleep(usecs); }
 void mdelay(unsigned long msecs) { usleep(msecs * 1000); }
 unsigned long msleep_interruptible(unsigned int msecs) { usleep(msecs * 1000); return 0; }
+bool gpio_is_valid(int number) { return (number == AD9361_GPIO_RESET_PIN); }
+void gpio_set_value(unsigned gpio, int value) { (void)gpio; (void)value; }
 
-bool gpio_is_valid(int number) {
-    return (number == AD9361_GPIO_RESET_PIN);
-}
-
-void gpio_set_value(unsigned gpio, int value) {
-    (void)gpio; (void)value;
-}
-
-/* Shared Memory Ring Buffer */
-/*---------------------------*/
-
+/*
+ * Shared Memory Ring Buffer
+ */
 typedef struct {
-    uint8_t *data;
-    size_t   total_size;
-    uint32_t num_slots;
-    uint32_t chunk_size;      /* samples per chunk (per channel) */
-    uint32_t chunk_bytes;     /* bytes per chunk (all channels) */
-    uint16_t num_channels;
-} shm_ring_buffer_t;
+    uint8_t  *base;          /* mmap base pointer */
+    size_t    total_size;    /* total mmap size */
+    uint32_t  num_slots;     /* number of slots */
+    uint32_t  chunk_size;    /* samples per chunk per channel */
+    uint32_t  chunk_bytes;   /* bytes per chunk (all channels) */
+    uint16_t  num_channels;  /* 1 or 2 */
+} shm_buffer_t;
 
-/* RX: C is the producer, Julia is the consumer.
- * C writes samples then updates write_index with release semantics.
- * Julia reads write_index with acquire semantics to see the samples.
- * Julia updates read_index with release semantics after consuming.
- * C reads read_index with acquire semantics before overwriting slots. */
-
-static inline uint64_t shm_get_write_index(shm_ring_buffer_t *shm) {
-    return *(volatile uint64_t *)(shm->data + OFFSET_WRITE_INDEX);
+/* Atomic accessors for producer/consumer indices */
+static inline uint64_t shm_load_write_index(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), __ATOMIC_ACQUIRE);
 }
 
-static inline void shm_set_write_index(shm_ring_buffer_t *shm, uint64_t val) {
-    /* Release: ensures sample data is visible before index update */
-    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_WRITE_INDEX), val, __ATOMIC_RELEASE);
+static inline void shm_store_write_index(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), val, __ATOMIC_RELEASE);
 }
 
-static inline uint64_t shm_get_read_index(shm_ring_buffer_t *shm) {
-    /* Acquire: ensures we see Julia consumer's release-store of read_index */
-    return __atomic_load_n((volatile uint64_t *)(shm->data + OFFSET_READ_INDEX), __ATOMIC_ACQUIRE);
+static inline uint64_t shm_load_read_index(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_READ_INDEX), __ATOMIC_ACQUIRE);
 }
 
-static inline void shm_set_chunks_written(shm_ring_buffer_t *shm, uint64_t val) {
-    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_CHUNKS_WRITTEN), val, __ATOMIC_RELAXED);
+static inline void shm_store_overflow(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_OVERFLOW), val, __ATOMIC_RELAXED);
 }
 
-static inline void shm_set_overflow_count(shm_ring_buffer_t *shm, uint64_t val) {
-    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_OVERFLOW_COUNT), val, __ATOMIC_RELAXED);
+static inline void shm_set_flags(shm_buffer_t *shm, uint16_t flags) {
+    __atomic_store_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), flags, __ATOMIC_RELEASE);
 }
 
-static inline void shm_set_lost_samples(shm_ring_buffer_t *shm, uint64_t val) {
-    *(volatile uint64_t *)(shm->data + OFFSET_LOST_SAMPLES) = val;
+static inline uint16_t shm_get_flags(shm_buffer_t *shm) {
+    return __atomic_load_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), __ATOMIC_ACQUIRE);
 }
 
-static inline void shm_set_flags(shm_ring_buffer_t *shm, uint16_t val) {
-    *(volatile uint16_t *)(shm->data + OFFSET_FLAGS) = val;
+/* Get pointer to slot data (no per-slot header, pure samples) */
+static inline uint8_t *shm_slot_ptr(shm_buffer_t *shm, uint64_t index) {
+    size_t slot_offset = SHM_HEADER_SIZE + (index % shm->num_slots) * shm->chunk_bytes;
+    return shm->base + slot_offset;
 }
 
-static inline uint16_t shm_get_flags(shm_ring_buffer_t *shm) {
-    return *(volatile uint16_t *)(shm->data + OFFSET_FLAGS);
-}
-
-static inline void shm_mark_writer_done(shm_ring_buffer_t *shm) {
-    shm_set_flags(shm, shm_get_flags(shm) | FLAG_WRITER_DONE);
-}
-
-static inline bool shm_can_write(shm_ring_buffer_t *shm) {
-    uint64_t write_idx = shm_get_write_index(shm);
-    uint64_t read_idx = shm_get_read_index(shm);
+/* Check if we can write (ring buffer not full) */
+static inline bool shm_can_write(shm_buffer_t *shm, uint64_t write_idx) {
+    uint64_t read_idx = shm_load_read_index(shm);
     return (write_idx - read_idx) < shm->num_slots;
 }
 
-/* Get pointer to start of slot (includes chunk header) */
-static inline uint8_t *shm_slot_ptr(shm_ring_buffer_t *shm, uint64_t slot) {
-    size_t slot_size = CHUNK_HEADER_SIZE + shm->chunk_bytes;
-    size_t offset = SHM_HEADER_SIZE + (slot % shm->num_slots) * slot_size;
-    return shm->data + offset;
-}
-
-/* Set per-chunk header: samples lost before this chunk */
-static inline void shm_set_chunk_lost_samples(uint8_t *slot_ptr, uint64_t samples_lost) {
-    *(uint64_t *)(slot_ptr) = samples_lost;
-}
-
-/* Create shared memory ring buffer
- * chunk_size = DMA_BUFFER_SIZE (no rechunking)
- * Each slot holds: [16-byte chunk header] + [sample data]
+/*
+ * Create shared memory ring buffer
  */
-static shm_ring_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
-                                      uint16_t num_channels, double buffer_seconds,
-                                      uint32_t sample_rate)
+static shm_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
+                                 uint16_t num_channels, double buffer_seconds,
+                                 uint32_t sample_rate)
 {
-    shm_ring_buffer_t *shm = calloc(1, sizeof(shm_ring_buffer_t));
+    shm_buffer_t *shm = calloc(1, sizeof(shm_buffer_t));
     if (!shm) {
         perror("calloc");
         return NULL;
@@ -253,20 +183,18 @@ static shm_ring_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
 
     shm->num_channels = num_channels;
     shm->chunk_bytes = chunk_bytes;
-    /* samples per chunk per channel */
-    shm->chunk_size = chunk_bytes / (SAMPLE_SIZE_COMPLEX_INT16 * num_channels);
+    shm->chunk_size = chunk_bytes / (BYTES_PER_COMPLEX * num_channels);
 
-    /* Calculate number of slots for requested buffer time */
-    uint64_t bytes_per_second = (uint64_t)sample_rate * SAMPLE_SIZE_COMPLEX_INT16 * num_channels;
+    /* Calculate number of slots for requested buffer duration */
+    uint64_t bytes_per_second = (uint64_t)sample_rate * BYTES_PER_COMPLEX * num_channels;
     uint64_t total_buffer_bytes = (uint64_t)(bytes_per_second * buffer_seconds);
     shm->num_slots = (total_buffer_bytes + chunk_bytes - 1) / chunk_bytes;
-    if (shm->num_slots < 16) shm->num_slots = 16;  /* minimum slots */
+    if (shm->num_slots < 16)
+        shm->num_slots = 16;
 
-    /* Each slot = chunk header + sample data */
-    size_t slot_size = CHUNK_HEADER_SIZE + shm->chunk_bytes;
-    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * slot_size;
+    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * shm->chunk_bytes;
 
-    /* Create shared memory file */
+    /* Create/open shared memory file */
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
     if (fd < 0) {
         perror(path);
@@ -281,21 +209,20 @@ static shm_ring_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
         return NULL;
     }
 
-    shm->data = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    shm->base = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     close(fd);
 
-    if (shm->data == MAP_FAILED) {
+    if (shm->base == MAP_FAILED) {
         perror("mmap");
         free(shm);
         return NULL;
     }
 
     /* Initialize header */
-    memset(shm->data, 0, SHM_HEADER_SIZE);
-    *(uint32_t *)(shm->data + OFFSET_CHUNK_SIZE) = shm->chunk_size;
-    *(uint32_t *)(shm->data + OFFSET_SAMPLE_SIZE) = SAMPLE_SIZE_COMPLEX_INT16;
-    *(uint32_t *)(shm->data + OFFSET_NUM_SLOTS) = shm->num_slots;
-    *(uint16_t *)(shm->data + OFFSET_NUM_CHANNELS) = num_channels;
+    memset(shm->base, 0, SHM_HEADER_SIZE);
+    *(uint32_t *)(shm->base + SHM_OFFSET_CHUNK_SIZE)   = shm->chunk_size;
+    *(uint32_t *)(shm->base + SHM_OFFSET_NUM_SLOTS)    = shm->num_slots;
+    *(uint16_t *)(shm->base + SHM_OFFSET_NUM_CHANNELS) = num_channels;
 
     printf("Created shared memory ring buffer:\n");
     printf("  Path: %s\n", path);
@@ -303,101 +230,86 @@ static shm_ring_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
     printf("  Num channels: %u\n", num_channels);
     printf("  Num slots: %u\n", shm->num_slots);
     printf("  Buffer size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
-    printf("  Buffer time: %.2f seconds\n",
-           (double)shm->num_slots * shm->chunk_size / sample_rate);
+    printf("  Buffer time: %.2f seconds\n", (double)shm->num_slots * shm->chunk_size / sample_rate);
 
     return shm;
 }
 
-static void shm_destroy(shm_ring_buffer_t *shm) {
+static void shm_destroy(shm_buffer_t *shm) {
     if (shm) {
-        if (shm->data && shm->data != MAP_FAILED) {
-            shm_mark_writer_done(shm);
-            munmap(shm->data, shm->total_size);
+        if (shm->base && shm->base != MAP_FAILED) {
+            /* Signal writer done */
+            shm_set_flags(shm, shm_get_flags(shm) | SHM_FLAG_WRITER_DONE);
+            munmap(shm->base, shm->total_size);
         }
         free(shm);
     }
 }
 
-/* AGC Mode Parsing */
-/*------------------*/
+/*
+ * AGC Mode Helpers
+ */
+static const char *agc_mode_names[] = {"manual", "fast_attack", "slow_attack", "hybrid"};
 
-static const char *agc_mode_names[] = {
-    "manual",
-    "fast_attack",
-    "slow_attack",
-    "hybrid"
-};
-
-static uint8_t parse_agc_mode(const char *mode_str) {
-    if (strcasecmp(mode_str, "manual") == 0 || strcasecmp(mode_str, "mgc") == 0)
+static uint8_t parse_agc_mode(const char *str) {
+    if (strcasecmp(str, "manual") == 0 || strcasecmp(str, "mgc") == 0)
         return RF_GAIN_MGC;
-    if (strcasecmp(mode_str, "fast_attack") == 0 || strcasecmp(mode_str, "fast") == 0)
+    if (strcasecmp(str, "fast_attack") == 0 || strcasecmp(str, "fast") == 0)
         return RF_GAIN_FASTATTACK_AGC;
-    if (strcasecmp(mode_str, "slow_attack") == 0 || strcasecmp(mode_str, "slow") == 0)
+    if (strcasecmp(str, "slow_attack") == 0 || strcasecmp(str, "slow") == 0)
         return RF_GAIN_SLOWATTACK_AGC;
-    if (strcasecmp(mode_str, "hybrid") == 0)
+    if (strcasecmp(str, "hybrid") == 0)
         return RF_GAIN_HYBRID_AGC;
-    fprintf(stderr, "Error: unknown AGC mode '%s'\n", mode_str);
-    fprintf(stderr, "Valid modes: manual, fast_attack, slow_attack, hybrid\n");
+    fprintf(stderr, "Unknown AGC mode '%s'. Valid: manual, fast_attack, slow_attack, hybrid\n", str);
     exit(1);
 }
 
-static const char *agc_mode_to_string(uint8_t mode) {
-    if (mode <= RF_GAIN_HYBRID_AGC)
-        return agc_mode_names[mode];
-    return "unknown";
+static const char *agc_mode_str(uint8_t mode) {
+    return (mode <= RF_GAIN_HYBRID_AGC) ? agc_mode_names[mode] : "unknown";
 }
 
-/* RF Initialization */
-/*-------------------*/
-
-static void m2sdr_rf_init(
-    uint32_t samplerate,
-    int64_t  bandwidth,
-    int64_t  rx_freq,
-    int64_t  rx_gain,
-    uint8_t  agc_mode,
-    uint8_t  num_channels
-) {
-    void *conn = m2sdr_open();
+/*
+ * RF Initialization (matching SoapySDR)
+ */
+static void rf_init(int fd, uint32_t samplerate, int64_t bandwidth,
+                    int64_t rx_freq, int64_t rx_gain, uint8_t agc_mode,
+                    uint8_t num_channels)
+{
+    g_spi_fd = fd;
 
 #ifdef CSR_SI5351_BASE
-    /* Initialize SI5351 Clocking with internal XO */
-    printf("Initializing SI5351 Clocking...\n");
-    m2sdr_writel(conn, CSR_SI5351_CONTROL_ADDR,
+    printf("Initializing SI5351 clocking...\n");
+    m2sdr_writel((void *)(intptr_t)fd, CSR_SI5351_CONTROL_ADDR,
         SI5351B_VERSION * (1 << CSR_SI5351_CONTROL_VERSION_OFFSET));
-    m2sdr_si5351_i2c_config(conn, SI5351_I2C_ADDR,
+    m2sdr_si5351_i2c_config((void *)(intptr_t)fd, SI5351_I2C_ADDR,
         si5351_xo_40m_config,
-        sizeof(si5351_xo_40m_config)/sizeof(si5351_xo_40m_config[0]));
+        sizeof(si5351_xo_40m_config) / sizeof(si5351_xo_40m_config[0]));
 #endif
 
-    /* Power-up AD9361 */
     printf("Powering up AD9361...\n");
-    m2sdr_writel(conn, CSR_AD9361_CONFIG_ADDR, 0b11);
+    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_CONFIG_ADDR, 0b11);
 
-    /* Initialize AD9361 SPI */
     printf("Initializing AD9361 SPI...\n");
-    m2sdr_ad9361_spi_init(conn, 1);
+    m2sdr_ad9361_spi_init((void *)(intptr_t)fd, 1);
 
-    /* Initialize AD9361 RFIC */
+    /* Configure 1T1R or 2T2R mode */
     if (num_channels == 2) {
         printf("Initializing AD9361 RFIC (2T2R mode)...\n");
         default_init_param.two_rx_two_tx_mode_enable     = 1;
         default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
         default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
         default_init_param.two_t_two_r_timing_enable     = 1;
-        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 0);  /* 2T2R */
+        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 0);
     } else {
         printf("Initializing AD9361 RFIC (1T1R mode)...\n");
         default_init_param.two_rx_two_tx_mode_enable     = 0;
         default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
         default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
         default_init_param.two_t_two_r_timing_enable     = 0;
-        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 1);  /* 1T1R */
+        m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, 1);
     }
 
-    default_init_param.reference_clk_rate = 40000000;  /* 40 MHz */
+    default_init_param.reference_clk_rate = 40000000;
     default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
     default_init_param.gpio_sync          = -1;
     default_init_param.gpio_cal_sw1       = -1;
@@ -405,315 +317,365 @@ static void m2sdr_rf_init(
 
     ad9361_init(&ad9361_phy, &default_init_param, 1);
 
-    /* Configure AD9361 Samplerate */
-    printf("Setting RX Samplerate to %.2f MSPS.\n", samplerate/1e6);
+    printf("Setting RX sample rate to %.2f MSPS...\n", samplerate / 1e6);
     ad9361_set_rx_sampling_freq(ad9361_phy, samplerate);
 
-    /* Configure AD9361 RX Bandwidth */
-    printf("Setting RX Bandwidth to %.2f MHz.\n", bandwidth/1e6);
+    printf("Setting RX bandwidth to %.2f MHz...\n", bandwidth / 1e6);
     ad9361_set_rx_rf_bandwidth(ad9361_phy, bandwidth);
 
-    /* Configure AD9361 RX Frequency */
-    printf("Setting RX LO Freq to %.2f MHz.\n", rx_freq/1e6);
+    printf("Setting RX LO frequency to %.2f MHz...\n", rx_freq / 1e6);
     ad9361_set_rx_lo_freq(ad9361_phy, rx_freq);
 
-    /* Configure AD9361 RX FIR */
     ad9361_set_rx_fir_config(ad9361_phy, rx_fir_config);
 
-    /* Configure AD9361 RX Gain Control Mode */
-    printf("Setting RX AGC mode to %s.\n", agc_mode_to_string(agc_mode));
+    printf("Setting RX AGC mode to %s...\n", agc_mode_str(agc_mode));
     ad9361_set_rx_gain_control_mode(ad9361_phy, 0, agc_mode);
-    if (num_channels == 2) {
+    if (num_channels == 2)
         ad9361_set_rx_gain_control_mode(ad9361_phy, 1, agc_mode);
-    }
 
-    /* Configure AD9361 RX Gain (same for both channels) */
-    printf("Setting RX Gain to %ld dB%s.\n", rx_gain,
-           agc_mode != RF_GAIN_MGC ? " (initial, AGC will adjust)" : "");
+    printf("Setting RX gain to %ld dB%s...\n", rx_gain,
+           agc_mode != RF_GAIN_MGC ? " (initial, AGC active)" : "");
     ad9361_set_rx_rf_gain(ad9361_phy, 0, rx_gain);
-    if (num_channels == 2) {
+    if (num_channels == 2)
         ad9361_set_rx_rf_gain(ad9361_phy, 1, rx_gain);
-    }
 
     /* 16-bit mode (12-bit samples in 16-bit words) */
-    m2sdr_writel(conn, CSR_AD9361_BITMODE_ADDR, 0);
+    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_BITMODE_ADDR, 0);
 
-    /* Enable Synchronizer (disable bypass) - matches SoapySDR */
-    m2sdr_writel(conn, CSR_PCIE_DMA0_SYNCHRONIZER_BYPASS_ADDR, 0);
+    /* Enable synchronizer (disable bypass) - matches SoapySDR */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_SYNCHRONIZER_BYPASS_ADDR, 0);
 
     /* Disable DMA loopback - matches SoapySDR */
-    m2sdr_writel(conn, CSR_PCIE_DMA0_LOOPBACK_ENABLE_ADDR, 0);
-
-    m2sdr_close(conn);
+    m2sdr_writel((void *)(intptr_t)fd, CSR_PCIE_DMA0_LOOPBACK_ENABLE_ADDR, 0);
 }
 
-/* Stream to Shared Memory */
-/*-------------------------*/
+/*
+ * Sign-extend 12-bit samples to 16-bit in-place
+ *
+ * The AD9361 outputs 12-bit signed samples in 16-bit words.
+ * The 12-bit value occupies bits 0-11, with bit 11 as sign.
+ * We sign-extend by shifting left 4, then arithmetic right 4.
+ */
+static inline void sign_extend_12bit_buffer(int16_t *data, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        data[i] = (int16_t)(data[i] << 4) >> 4;
+    }
+}
 
-static void m2sdr_stream_to_shm(
-    const char *device_name,
-    shm_ring_buffer_t *shm,
-    size_t num_samples,  /* 0 for infinite */
-    uint8_t quiet
-) {
-    static struct litepcie_dma_ctrl dma = {.use_writer = 1};
+/*
+ * DMA RX Streaming to Shared Memory
+ *
+ * This follows the SoapySDR acquireReadBuffer/releaseReadBuffer pattern:
+ * 1. Check hw_count - user_count for available buffers
+ * 2. If none, poll/wait then refresh counters
+ * 3. Detect overflow when (hw_count - sw_count) > buf_count/2
+ * 4. On overflow, drain all buffers and report
+ * 5. Otherwise, process buffer and advance user_count
+ * 6. When done with buffer, update sw_count via ioctl
+ */
+static void stream_to_shm(shm_buffer_t *shm, size_t num_samples, uint8_t quiet)
+{
+    struct litepcie_dma_ctrl dma;
+    memset(&dma, 0, sizeof(dma));
 
-    int i = 0;
-    size_t samples_written = 0;
-    int64_t last_time;
-    int64_t writer_sw_count_last = 0;
+    /* Open device */
+    int fd = open(g_device_path, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open %s\n", g_device_path);
+        return;
+    }
+
+    /* Setup DMA for RX (writer from FPGA perspective, reader from SW) */
+    dma.fds.fd = fd;
+    dma.use_writer = 1;
+    dma.use_reader = 0;
+    dma.loopback = 0;
+    dma.zero_copy = 1;
+    dma.shared_fd = 1;  /* We already opened fd */
+
+    if (litepcie_dma_init(&dma, "", 1) < 0) {
+        fprintf(stderr, "DMA init failed\n");
+        close(fd);
+        return;
+    }
+
+    /* Get DMA buffer info */
+    struct litepcie_ioctl_mmap_dma_info dma_info;
+    if (ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_INFO, &dma_info) < 0) {
+        perror("LITEPCIE_IOCTL_MMAP_DMA_INFO");
+        litepcie_dma_cleanup(&dma);
+        close(fd);
+        return;
+    }
+
+    uint32_t dma_buf_size = dma_info.dma_rx_buf_size;
+    uint32_t dma_buf_count = dma_info.dma_rx_buf_count;
+
+    /* Samples per DMA buffer (per channel) */
+    size_t samples_per_dma = dma_buf_size / (BYTES_PER_COMPLEX * shm->num_channels);
+    /* int16 values per DMA buffer (I and Q for all channels) */
+    size_t int16_per_dma = dma_buf_size / sizeof(int16_t);
+
+    printf("DMA configuration:\n");
+    printf("  Buffer size: %u bytes (%zu samples/channel)\n", dma_buf_size, samples_per_dma);
+    printf("  Buffer count: %u\n", dma_buf_count);
+
+    /* Configure RX header (disabled - raw samples only) */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_HEADER_RX_CONTROL_ADDR,
+        (1 << CSR_HEADER_RX_CONTROL_ENABLE_OFFSET) |
+        (0 << CSR_HEADER_RX_CONTROL_HEADER_ENABLE_OFFSET));
+
+    /* Crossbar demux: select PCIe for RX */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_CROSSBAR_DEMUX_SEL_ADDR, 0);
+
+    /* Reset DMA counters before starting (SoapySDR pattern) */
+    int64_t hw_count = 0, sw_count = 0;
+    litepcie_dma_writer(fd, 0, &hw_count, &sw_count);
+
+    /* Our user-space tracking counter (matches SoapySDR user_count) */
+    int64_t user_count = 0;
+
+    printf("Starting DMA streaming...\n");
+
+    /* Enable DMA */
+    litepcie_dma_writer(fd, 1, &hw_count, &sw_count);
+
+    /* Statistics */
+    uint64_t shm_write_idx = 0;
     uint64_t chunks_written = 0;
     uint64_t overflow_count = 0;
-    uint64_t lost_samples = 0;
-    uint64_t buffer_full_count = 0;
-    uint64_t pending_lost_samples = 0;  /* Samples lost since last written chunk */
-    int64_t last_overflow_hw_count = 0; /* Track hw_count at last overflow detection */
+    uint64_t buffer_full_waits = 0;
+    size_t total_samples = 0;
+    int64_t last_stats_time = get_time_ms();
+    int64_t last_sw_count = 0;
+    int stats_line = 0;
 
-    /* Samples per DMA buffer (accounting for all channels) */
-    size_t samples_per_dma = DMA_BUFFER_SIZE / (SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels);
-    /* int16 values per DMA buffer (I and Q for all channels) */
-    size_t int16_per_dma = DMA_BUFFER_SIZE / sizeof(int16_t);
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN;
 
-    /* Initialize DMA */
-    if (litepcie_dma_init(&dma, device_name, 0))  /* zero_copy = 0 */
-        exit(1);
-    dma.writer_enable = 1;
-
-    /* Configure RX Header (disabled - we just want raw samples) */
-    m2sdr_writel(dma.fds.fd, CSR_HEADER_RX_CONTROL_ADDR,
-       (1 << CSR_HEADER_RX_CONTROL_ENABLE_OFFSET) |
-       (0 << CSR_HEADER_RX_CONTROL_HEADER_ENABLE_OFFSET)
-    );
-
-    /* Crossbar Demux: select PCIe streaming for RX */
-    m2sdr_writel(dma.fds.fd, CSR_CROSSBAR_DEMUX_SEL_ADDR, 0);
-
-    /* Reset DMA counters to ensure clean state (matches SoapySDR behavior).
-     * This prevents stale counter values from previous runs causing issues.
-     * Call with enable=0 to reset counters before starting. */
-    litepcie_dma_writer(dma.fds.fd, 0, &dma.writer_hw_count, &dma.writer_sw_count);
-
-    printf("Starting DMA stream to shared memory...\n");
-    printf("  DMA buffer size: %d bytes (%zu samples/channel)\n",
-           DMA_BUFFER_SIZE, samples_per_dma);
-    printf("  Per-chunk header: %d bytes (samples_lost_before)\n", CHUNK_HEADER_SIZE);
-
-    last_time = get_time_ms();
-
-    for (;;) {
-        if (!keep_running)
+    while (g_keep_running) {
+        if (num_samples > 0 && total_samples >= num_samples)
             break;
 
-        if (num_samples > 0 && samples_written >= num_samples)
-            break;
+        /* Get current DMA counters */
+        litepcie_dma_writer(fd, 1, &hw_count, &sw_count);
 
-        /* Update DMA status */
-        litepcie_dma_process(&dma);
+        /* Check for available buffers */
+        int64_t buffers_available = hw_count - user_count;
 
-        /* Check for DMA overflow BEFORE processing buffers.
-         * Only count NEW overflows since last check (hw_count advancement).
-         * This ensures we know how many samples were lost before each chunk.
+        if (buffers_available <= 0) {
+            /* No buffers, wait for data */
+            int ret = poll(&pfd, 1, 100);
+            if (ret < 0) {
+                if (g_keep_running)
+                    perror("poll");
+                break;
+            }
+            if (ret == 0)
+                continue;  /* Timeout */
+
+            /* Refresh counters */
+            litepcie_dma_writer(fd, 1, &hw_count, &sw_count);
+            buffers_available = hw_count - user_count;
+            if (buffers_available <= 0)
+                continue;
+        }
+
+        /*
+         * Overflow detection (SoapySDR pattern):
+         * If hw is too far ahead of sw, we've lost buffers.
+         * Threshold is half the ring buffer.
          */
-        if (dma.writer_hw_count > dma.writer_sw_count + 16 &&
-            dma.writer_hw_count > last_overflow_hw_count) {
-            /* Count only the new buffers lost since last overflow detection */
-            uint64_t new_hw_count = dma.writer_hw_count;
-            uint64_t baseline = (last_overflow_hw_count > dma.writer_sw_count + 16)
-                                ? last_overflow_hw_count
-                                : dma.writer_sw_count + 16;
-            uint64_t lost_buffers = new_hw_count - baseline;
-            uint64_t newly_lost = lost_buffers * samples_per_dma;
+        if ((hw_count - sw_count) > (int64_t)(dma_buf_count / 2)) {
             overflow_count++;
-            lost_samples += newly_lost;
-            pending_lost_samples += newly_lost;
-            last_overflow_hw_count = new_hw_count;
-            shm_set_overflow_count(shm, overflow_count);
-            shm_set_lost_samples(shm, lost_samples);
+            shm_store_overflow(shm, overflow_count);
 
             if (!quiet) {
-                fprintf(stderr, "\rOVERFLOW #%" PRIu64 ": lost %" PRIu64 " buffers (%" PRIu64 " samples total)\n",
-                    overflow_count, lost_buffers, lost_samples);
+                fprintf(stderr, "\nOVERFLOW #%" PRIu64 ": hw=%" PRId64 " sw=%" PRId64
+                        " (gap=%" PRId64 ", threshold=%u)\n",
+                        overflow_count, hw_count, sw_count,
+                        hw_count - sw_count, dma_buf_count / 2);
             }
+
+            /* Drain all buffers (SoapySDR recovery pattern) */
+            struct litepcie_ioctl_mmap_dma_update update;
+            update.sw_count = hw_count;
+            ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
+            user_count = hw_count;
+            sw_count = hw_count;
+            continue;
         }
 
-        /* Read from DMA and copy directly to shared memory */
-        while (1) {
-            char *buf_rd = litepcie_dma_next_read_buffer(&dma);
-            if (!buf_rd)
+        /* Process available buffers */
+        while (buffers_available > 0 && g_keep_running) {
+            /* Wait for SHM space */
+            while (!shm_can_write(shm, shm_write_idx)) {
+                buffer_full_waits++;
+                usleep(10);
+                if (!g_keep_running)
+                    goto done;
+
+                /* Check for DMA overflow while waiting */
+                litepcie_dma_writer(fd, 1, &hw_count, &sw_count);
+                if ((hw_count - sw_count) > (int64_t)(dma_buf_count / 2)) {
+                    overflow_count++;
+                    shm_store_overflow(shm, overflow_count);
+                    if (!quiet) {
+                        fprintf(stderr, "\nOVERFLOW #%" PRIu64 " (while waiting for SHM)\n",
+                                overflow_count);
+                    }
+                    /* Drain and restart outer loop */
+                    struct litepcie_ioctl_mmap_dma_update update;
+                    update.sw_count = hw_count;
+                    ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
+                    user_count = hw_count;
+                    sw_count = hw_count;
+                    buffers_available = 0;
+                    break;
+                }
+            }
+
+            if (buffers_available == 0)
                 break;
 
-            /* Wait for space in ring buffer */
-            while (!shm_can_write(shm)) {
-                buffer_full_count++;
-                /* While waiting, refresh DMA counters to detect overflows.
-                 * Note: litepcie_dma_writer() is just an ioctl that returns
-                 * current hw_count/sw_count - it doesn't drain any buffers.
-                 * This is critical because overflows typically happen when
-                 * Julia is slow to consume chunks from the SHM ring buffer. */
-                litepcie_dma_writer(dma.fds.fd, 1, &dma.writer_hw_count, &dma.writer_sw_count);
-                /* Only count NEW overflows since last check */
-                if (dma.writer_hw_count > dma.writer_sw_count + 16 &&
-                    dma.writer_hw_count > last_overflow_hw_count) {
-                    uint64_t new_hw_count = dma.writer_hw_count;
-                    uint64_t baseline = (last_overflow_hw_count > dma.writer_sw_count + 16)
-                                        ? last_overflow_hw_count
-                                        : dma.writer_sw_count + 16;
-                    uint64_t lost_buffers = new_hw_count - baseline;
-                    uint64_t newly_lost = lost_buffers * samples_per_dma;
-                    overflow_count++;
-                    lost_samples += newly_lost;
-                    pending_lost_samples += newly_lost;
-                    last_overflow_hw_count = new_hw_count;
-                    shm_set_overflow_count(shm, overflow_count);
-                    shm_set_lost_samples(shm, lost_samples);
+            /* Get DMA buffer pointer */
+            int buf_idx = user_count % dma_buf_count;
+            char *dma_buf = dma.buf_rd + buf_idx * dma_buf_size;
 
-                    if (!quiet) {
-                        fprintf(stderr, "\rOVERFLOW #%" PRIu64 ": lost %" PRIu64 " buffers (%" PRIu64 " samples total)\n",
-                            overflow_count, lost_buffers, lost_samples);
-                    }
-                }
-                usleep(10);
-                if (!keep_running)
-                    goto done;
-            }
+            /* Get SHM slot pointer */
+            uint8_t *shm_slot = shm_slot_ptr(shm, shm_write_idx);
 
-            /* Get slot pointer and write per-chunk header first */
-            uint64_t write_idx = shm_get_write_index(shm);
-            uint8_t *slot = shm_slot_ptr(shm, write_idx);
-            shm_set_chunk_lost_samples(slot, pending_lost_samples);
+            /* Copy and sign-extend */
+            memcpy(shm_slot, dma_buf, dma_buf_size);
+            sign_extend_12bit_buffer((int16_t *)shm_slot, int16_per_dma);
 
-            /* Copy DMA buffer to sample data area (after header) */
-            uint8_t *dst = slot + CHUNK_HEADER_SIZE;
-            memcpy(dst, buf_rd, DMA_BUFFER_SIZE);
+            /* Advance user counter (buffer consumed from user perspective) */
+            user_count++;
+            buffers_available--;
 
-            /* Sign-extend 12-bit samples to 16-bit in-place */
-            sign_extend_12bit_inplace((int16_t *)dst, int16_per_dma);
+            /* Release buffer to kernel */
+            struct litepcie_ioctl_mmap_dma_update update;
+            update.sw_count = user_count;
+            ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
 
-            /* Reset pending lost samples - this chunk now "owns" them */
-            pending_lost_samples = 0;
+            /* Update SHM write index (makes data visible to consumer) */
+            shm_write_idx++;
+            shm_store_write_index(shm, shm_write_idx);
 
-            /* Update counters */
             chunks_written++;
-            samples_written += samples_per_dma;
-            shm_set_write_index(shm, write_idx + 1);
-            shm_set_chunks_written(shm, chunks_written);
+            total_samples += samples_per_dma;
+
+            if (num_samples > 0 && total_samples >= num_samples)
+                break;
         }
 
-        /* Statistics every 200ms */
-        int64_t duration = get_time_ms() - last_time;
-        if (!quiet && duration > 200) {
-            double speed = (double)(dma.writer_sw_count - writer_sw_count_last) * DMA_BUFFER_SIZE * 8 / ((double)duration * 1e6);
-            uint64_t size_mb = (samples_written * SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels) / 1024 / 1024;
+        /* Statistics display */
+        int64_t now = get_time_ms();
+        int64_t elapsed = now - last_stats_time;
+        if (!quiet && elapsed >= 200) {
+            double speed_gbps = (double)(user_count - last_sw_count) * dma_buf_size * 8 / (elapsed * 1e6);
+            uint64_t size_mb = (total_samples * BYTES_PER_COMPLEX * shm->num_channels) / (1024 * 1024);
 
-            if (i % 10 == 0) {
-                fprintf(stderr, "\e[1m%10s %12s %9s %10s %12s\e[0m\n",
-                    "SPEED(Gbps)", "CHUNKS", "SIZE(MB)", "OVERFLOWS", "BUF_FULL");
+            if (stats_line % 10 == 0) {
+                fprintf(stderr, "\n\033[1m%10s %12s %9s %10s %12s\033[0m\n",
+                        "SPEED(Gbps)", "CHUNKS", "SIZE(MB)", "OVERFLOWS", "SHM_WAITS");
             }
-            i++;
+            stats_line++;
 
-            fprintf(stderr, "%11.2f %12" PRIu64 " %9" PRIu64 " %10" PRIu64 " %12" PRIu64 "\n",
-                speed, chunks_written, size_mb, overflow_count, buffer_full_count);
+            fprintf(stderr, "%10.2f %12" PRIu64 " %9" PRIu64 " %10" PRIu64 " %12" PRIu64 "\n",
+                    speed_gbps, chunks_written, size_mb, overflow_count, buffer_full_waits);
 
-            last_time = get_time_ms();
-            writer_sw_count_last = dma.writer_sw_count;
+            last_stats_time = now;
+            last_sw_count = user_count;
         }
     }
 
 done:
+    /* Disable DMA */
+    litepcie_dma_writer(fd, 0, &hw_count, &sw_count);
     litepcie_dma_cleanup(&dma);
+    close(fd);
 
     printf("\nStream complete:\n");
     printf("  Chunks written: %" PRIu64 "\n", chunks_written);
-    printf("  Samples written: %zu\n", samples_written);
+    printf("  Total samples: %zu\n", total_samples);
     printf("  Overflows: %" PRIu64 "\n", overflow_count);
-    printf("  Lost samples: %" PRIu64 "\n", lost_samples);
-    printf("  Buffer full events: %" PRIu64 "\n", buffer_full_count);
+    printf("  SHM buffer-full waits: %" PRIu64 "\n", buffer_full_waits);
 }
 
-/* Help */
-/*------*/
-
-static void help(void)
+/*
+ * Help
+ */
+static void print_help(void)
 {
-    printf("M2SDR Stream to Shared Memory Utility\n"
-           "usage: m2sdr_stream_shm [options]\n"
+    printf("M2SDR RX Stream to Shared Memory (v2)\n"
+           "Usage: m2sdr_rx_stream_shm2 [options]\n"
            "\n"
            "Options:\n"
-           "  -h                     Show this help message and exit.\n"
-           "  -c device_num          Select the device (default: 0).\n"
-           "  -q                     Quiet mode (suppress statistics).\n"
+           "  -h                     Show this help\n"
+           "  -c device_num          Select device (default: 0)\n"
+           "  -q                     Quiet mode\n"
            "\n"
            "RF Configuration:\n"
-           "  -samplerate sps        Set RF samplerate in Hz (default: %d).\n"
-           "  -bandwidth bw          Set the RF bandwidth in Hz (default: %d).\n"
-           "  -rx_freq freq          Set the RX frequency in Hz (default: %" PRId64 ").\n"
-           "  -rx_gain gain          Set the RX gain in dB (default: %d).\n"
-           "  -agc_mode mode         Set AGC mode (default: manual).\n"
-           "                         Modes: manual, fast_attack, slow_attack, hybrid\n"
-           "  -channels n            Number of RX channels: 1 or 2 (default: 1).\n"
+           "  -samplerate Hz         Sample rate (default: %d)\n"
+           "  -bandwidth Hz          RF bandwidth (default: %d)\n"
+           "  -rx_freq Hz            RX frequency (default: %" PRId64 ")\n"
+           "  -rx_gain dB            RX gain (default: %d)\n"
+           "  -agc_mode mode         AGC mode: manual, fast_attack, slow_attack, hybrid\n"
+           "  -channels N            Number of channels: 1 or 2 (default: 1)\n"
            "\n"
-           "Shared Memory Configuration:\n"
-           "  -shm_path path         Shared memory path (default: /dev/shm/sdr_ringbuffer).\n"
-           "  -buffer_time seconds   Ring buffer duration in seconds (default: 3.0).\n"
-           "  -num_samples count     Number of samples to capture (default: 0 = infinite).\n",
+           "Shared Memory:\n"
+           "  -shm_path path         SHM path (default: /dev/shm/sdr_ringbuffer)\n"
+           "  -buffer_time seconds   Buffer duration (default: 3.0)\n"
+           "  -num_samples N         Samples to capture (default: 0 = infinite)\n",
            DEFAULT_SAMPLERATE,
            DEFAULT_BANDWIDTH,
            DEFAULT_RX_FREQ,
            DEFAULT_RX_GAIN);
-    exit(1);
+    exit(0);
 }
 
-/* Options */
-/*---------*/
-
-static struct option options[] = {
-    { "help",        no_argument,       NULL, 'h' },
-    { "samplerate",  required_argument, NULL, 's' },
-    { "bandwidth",   required_argument, NULL, 'b' },
-    { "rx_freq",     required_argument, NULL, 'f' },
-    { "rx_gain",     required_argument, NULL, 'g' },
-    { "agc_mode",    required_argument, NULL, 'a' },
-    { "channels",    required_argument, NULL, 'C' },
-    { "shm_path",    required_argument, NULL, 'p' },
-    { "buffer_time", required_argument, NULL, 't' },
-    { "num_samples", required_argument, NULL, 'n' },
-    { NULL },
+static struct option long_options[] = {
+    {"help",        no_argument,       NULL, 'h'},
+    {"samplerate",  required_argument, NULL, 's'},
+    {"bandwidth",   required_argument, NULL, 'b'},
+    {"rx_freq",     required_argument, NULL, 'f'},
+    {"rx_gain",     required_argument, NULL, 'g'},
+    {"agc_mode",    required_argument, NULL, 'a'},
+    {"channels",    required_argument, NULL, 'C'},
+    {"shm_path",    required_argument, NULL, 'p'},
+    {"buffer_time", required_argument, NULL, 't'},
+    {"num_samples", required_argument, NULL, 'n'},
+    {NULL, 0, NULL, 0}
 };
-
-/* Main */
-/*------*/
 
 int main(int argc, char **argv)
 {
-    int c;
-
     /* Defaults */
-    uint32_t samplerate  = DEFAULT_SAMPLERATE;
-    int64_t  bandwidth   = DEFAULT_BANDWIDTH;
-    int64_t  rx_freq     = DEFAULT_RX_FREQ;
-    int64_t  rx_gain     = DEFAULT_RX_GAIN;
-    uint8_t  agc_mode    = RF_GAIN_MGC;  /* manual gain control by default */
-    uint8_t  num_channels = 1;
-    uint8_t  quiet       = 0;
+    uint32_t samplerate = DEFAULT_SAMPLERATE;
+    int64_t bandwidth = DEFAULT_BANDWIDTH;
+    int64_t rx_freq = DEFAULT_RX_FREQ;
+    int64_t rx_gain = DEFAULT_RX_GAIN;
+    uint8_t agc_mode = RF_GAIN_MGC;
+    uint8_t num_channels = 1;
+    uint8_t quiet = 0;
 
     const char *shm_path = "/dev/shm/sdr_ringbuffer";
-    double   buffer_time = 3.0;
-    size_t   num_samples = 0;  /* 0 = infinite */
+    double buffer_time = 3.0;
+    size_t num_samples = 0;
 
-    signal(SIGINT, intHandler);
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
 
-    /* Parse options */
-    for (;;) {
-        c = getopt_long_only(argc, argv, "hc:q", options, NULL);
-        if (c == -1)
-            break;
-
-        switch(c) {
+    int c;
+    while ((c = getopt_long_only(argc, argv, "hc:q", long_options, NULL)) != -1) {
+        switch (c) {
         case 'h':
-            help();
+            print_help();
             break;
         case 'c':
-            m2sdr_device_num = atoi(optarg);
+            g_device_num = atoi(optarg);
             break;
         case 'q':
             quiet = 1;
@@ -736,8 +698,8 @@ int main(int argc, char **argv)
         case 'C':
             num_channels = (uint8_t)atoi(optarg);
             if (num_channels != 1 && num_channels != 2) {
-                fprintf(stderr, "Error: channels must be 1 or 2\n");
-                exit(1);
+                fprintf(stderr, "Channels must be 1 or 2\n");
+                return 1;
             }
             break;
         case 'p':
@@ -750,23 +712,22 @@ int main(int argc, char **argv)
             num_samples = (size_t)strtoull(optarg, NULL, 0);
             break;
         default:
-            exit(1);
+            return 1;
         }
     }
 
-    /* Select device */
-    snprintf(m2sdr_device, sizeof(m2sdr_device), "/dev/m2sdr%d", m2sdr_device_num);
+    snprintf(g_device_path, sizeof(g_device_path), "/dev/m2sdr%d", g_device_num);
 
-    printf("M2SDR Stream to Shared Memory\n");
-    printf("=============================\n");
-    printf("Device: %s\n", m2sdr_device);
+    printf("M2SDR RX Stream to Shared Memory (v2)\n");
+    printf("=====================================\n");
+    printf("Device: %s\n", g_device_path);
     printf("Sample rate: %.2f MHz\n", samplerate / 1e6);
+    printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);
     printf("RX frequency: %.2f MHz\n", rx_freq / 1e6);
     printf("RX gain: %ld dB\n", rx_gain);
-    printf("AGC mode: %s\n", agc_mode_to_string(agc_mode));
-    printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);
+    printf("AGC mode: %s\n", agc_mode_str(agc_mode));
     printf("Channels: %d (%s)\n", num_channels, num_channels == 2 ? "2T2R" : "1T1R");
-    printf("Shared memory: %s\n", shm_path);
+    printf("SHM path: %s\n", shm_path);
     printf("Buffer time: %.1f seconds\n", buffer_time);
     if (num_samples > 0)
         printf("Num samples: %zu\n", num_samples);
@@ -774,19 +735,27 @@ int main(int argc, char **argv)
         printf("Num samples: infinite (Ctrl+C to stop)\n");
     printf("\n");
 
-    /* Initialize RF */
-    m2sdr_rf_init(samplerate, bandwidth, rx_freq, rx_gain, agc_mode, num_channels);
+    /* Open device for RF init */
+    int fd = open(g_device_path, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open %s\n", g_device_path);
+        return 1;
+    }
 
-    /* Create shared memory - chunk size = DMA buffer size (no rechunking) */
-    shm_ring_buffer_t *shm = shm_create(shm_path, DMA_BUFFER_SIZE,
-                                         num_channels, buffer_time, samplerate);
+    /* Initialize RF */
+    rf_init(fd, samplerate, bandwidth, rx_freq, rx_gain, agc_mode, num_channels);
+    close(fd);
+
+    /* Create shared memory (chunk_bytes = DMA buffer size) */
+    shm_buffer_t *shm = shm_create(shm_path, DMA_BUFFER_SIZE, num_channels,
+                                    buffer_time, samplerate);
     if (!shm) {
         fprintf(stderr, "Failed to create shared memory\n");
         return 1;
     }
 
     /* Stream to shared memory */
-    m2sdr_stream_to_shm(m2sdr_device, shm, num_samples, quiet);
+    stream_to_shm(shm, num_samples, quiet);
 
     /* Cleanup */
     shm_destroy(shm);

--- a/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_rx_stream_shm.c
@@ -1,0 +1,693 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * M2SDR Stream to Shared Memory Utility.
+ *
+ * This utility configures the AD9361 RF frontend and streams RX data
+ * directly to a shared memory ring buffer. Designed to run as a separate
+ * process from Julia signal processing to avoid GC pause interference.
+ *
+ * Data Format:
+ *   - Each DMA buffer is copied directly to a shared memory slot
+ *   - Samples are Complex{Int16} (4 bytes per sample per channel)
+ *   - Multi-channel data is interleaved: I0,Q0,I1,Q1,I0,Q0,I1,Q1,...
+ *   - 12-bit ADC samples are sign-extended to 16-bit
+ *
+ * Shared Memory Header Layout (64 bytes):
+ *   Bytes 0-7:   write_index (uint64_t) - next slot to write
+ *   Bytes 8-15:  read_index (uint64_t) - next slot to read
+ *   Bytes 16-23: chunks_written (uint64_t) - total chunks written
+ *   Bytes 24-31: chunks_read (uint64_t) - total chunks read
+ *   Bytes 32-35: chunk_size (uint32_t) - samples per chunk (per channel)
+ *   Bytes 36-39: sample_size (uint32_t) - bytes per sample (4 for Complex{Int16})
+ *   Bytes 40-43: num_slots (uint32_t) - number of slots in buffer
+ *   Bytes 44-45: num_channels (uint16_t) - number of channels (1 or 2)
+ *   Bytes 46-47: flags (uint16_t) - bit 0 = writer_done
+ *   Bytes 48-55: overflow_count (uint64_t) - number of DMA overflows
+ *   Bytes 56-63: lost_samples (uint64_t) - total samples lost to overflow
+ *
+ * Per-Chunk Header Layout (8 bytes, prepended to each slot):
+ *   Bytes 0-7:   samples_lost_before (uint64_t) - samples lost since previous chunk
+ *
+ * Slot Layout:
+ *   [8-byte chunk header][sample data...]
+ *
+ * This file is part of LiteX-M2SDR project.
+ *
+ * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "ad9361/platform.h"
+#include "ad9361/ad9361.h"
+#include "ad9361/ad9361_api.h"
+
+#include "m2sdr_config.h"
+
+#include "liblitepcie.h"
+#include "libm2sdr.h"
+
+/* Shared memory header offsets (0-indexed for C) */
+#define SHM_HEADER_SIZE         64
+#define OFFSET_WRITE_INDEX      0
+#define OFFSET_READ_INDEX       8
+#define OFFSET_CHUNKS_WRITTEN   16
+#define OFFSET_CHUNKS_READ      24
+#define OFFSET_CHUNK_SIZE       32
+#define OFFSET_SAMPLE_SIZE      36
+#define OFFSET_NUM_SLOTS        40
+#define OFFSET_NUM_CHANNELS     44
+#define OFFSET_FLAGS            46
+#define OFFSET_OVERFLOW_COUNT   48
+#define OFFSET_LOST_SAMPLES     56
+
+/* Flag bits */
+#define FLAG_WRITER_DONE        1
+
+/* Per-chunk header size (prepended to each slot's sample data)
+ * Bytes 0-7: samples_lost_before (uint64_t) - samples lost since previous chunk
+ */
+#define CHUNK_HEADER_SIZE       8
+
+/* Sample size for Complex{Int16} (real + imag, each int16) */
+#define SAMPLE_SIZE_COMPLEX_INT16 4
+
+/* Sign-extend 12-bit samples to 16-bit in-place
+ * AD9361 outputs 12-bit signed samples in 16-bit words.
+ * Bit 11 is the sign bit, so we need to extend it to bit 15.
+ */
+static inline void sign_extend_12bit_inplace(int16_t *data, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        data[i] = (int16_t)(data[i] << 4) >> 4;
+    }
+}
+
+/* Variables */
+/*-----------*/
+
+static char m2sdr_device[1024];
+static int m2sdr_device_num = 0;
+
+sig_atomic_t keep_running = 1;
+
+void intHandler(int dummy) {
+    (void)dummy;
+    keep_running = 0;
+}
+
+/* forward (provided in tree elsewhere; used here) */
+extern int64_t get_time_ms(void);
+
+/* AD9361 */
+/*--------*/
+
+#define AD9361_GPIO_RESET_PIN 0
+
+struct ad9361_rf_phy *ad9361_phy;
+
+static void * m2sdr_open(void) {
+    int fd = open(m2sdr_device, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open device %s\n", m2sdr_device);
+        exit(1);
+    }
+    return (void *)(intptr_t)fd;
+}
+
+static void m2sdr_close(void *conn) {
+    close((int)(intptr_t)conn);
+}
+
+int spi_write_then_read(struct spi_device *spi,
+                        const unsigned char *txbuf, unsigned n_tx,
+                        unsigned char *rxbuf, unsigned n_rx)
+{
+    void *conn = m2sdr_open();
+
+    if (n_tx == 2 && n_rx == 1) {
+        rxbuf[0] = m2sdr_ad9361_spi_read(conn, txbuf[0] << 8 | txbuf[1]);
+    } else if (n_tx == 3 && n_rx == 0) {
+        m2sdr_ad9361_spi_write(conn, txbuf[0] << 8 | txbuf[1], txbuf[2]);
+    } else {
+        fprintf(stderr, "Unsupported SPI transfer n_tx=%d n_rx=%d\n", n_tx, n_rx);
+        m2sdr_close(conn);
+        exit(1);
+    }
+
+    m2sdr_close(conn);
+    return 0;
+}
+
+void udelay(unsigned long usecs) { usleep(usecs); }
+void mdelay(unsigned long msecs) { usleep(msecs * 1000); }
+unsigned long msleep_interruptible(unsigned int msecs) { usleep(msecs * 1000); return 0; }
+
+bool gpio_is_valid(int number) {
+    return (number == AD9361_GPIO_RESET_PIN);
+}
+
+void gpio_set_value(unsigned gpio, int value) {
+    (void)gpio; (void)value;
+}
+
+/* Shared Memory Ring Buffer */
+/*---------------------------*/
+
+typedef struct {
+    uint8_t *data;
+    size_t   total_size;
+    uint32_t num_slots;
+    uint32_t chunk_size;      /* samples per chunk (per channel) */
+    uint32_t chunk_bytes;     /* bytes per chunk (all channels) */
+    uint16_t num_channels;
+} shm_ring_buffer_t;
+
+static inline uint64_t shm_get_write_index(shm_ring_buffer_t *shm) {
+    return *(volatile uint64_t *)(shm->data + OFFSET_WRITE_INDEX);
+}
+
+static inline void shm_set_write_index(shm_ring_buffer_t *shm, uint64_t val) {
+    *(volatile uint64_t *)(shm->data + OFFSET_WRITE_INDEX) = val;
+}
+
+static inline uint64_t shm_get_read_index(shm_ring_buffer_t *shm) {
+    return *(volatile uint64_t *)(shm->data + OFFSET_READ_INDEX);
+}
+
+static inline void shm_set_chunks_written(shm_ring_buffer_t *shm, uint64_t val) {
+    *(volatile uint64_t *)(shm->data + OFFSET_CHUNKS_WRITTEN) = val;
+}
+
+static inline void shm_set_overflow_count(shm_ring_buffer_t *shm, uint64_t val) {
+    *(volatile uint64_t *)(shm->data + OFFSET_OVERFLOW_COUNT) = val;
+}
+
+static inline void shm_set_lost_samples(shm_ring_buffer_t *shm, uint64_t val) {
+    *(volatile uint64_t *)(shm->data + OFFSET_LOST_SAMPLES) = val;
+}
+
+static inline void shm_set_flags(shm_ring_buffer_t *shm, uint16_t val) {
+    *(volatile uint16_t *)(shm->data + OFFSET_FLAGS) = val;
+}
+
+static inline uint16_t shm_get_flags(shm_ring_buffer_t *shm) {
+    return *(volatile uint16_t *)(shm->data + OFFSET_FLAGS);
+}
+
+static inline void shm_mark_writer_done(shm_ring_buffer_t *shm) {
+    shm_set_flags(shm, shm_get_flags(shm) | FLAG_WRITER_DONE);
+}
+
+static inline bool shm_can_write(shm_ring_buffer_t *shm) {
+    uint64_t write_idx = shm_get_write_index(shm);
+    uint64_t read_idx = shm_get_read_index(shm);
+    return (write_idx - read_idx) < shm->num_slots;
+}
+
+/* Get pointer to start of slot (includes chunk header) */
+static inline uint8_t *shm_slot_ptr(shm_ring_buffer_t *shm, uint64_t slot) {
+    size_t slot_size = CHUNK_HEADER_SIZE + shm->chunk_bytes;
+    size_t offset = SHM_HEADER_SIZE + (slot % shm->num_slots) * slot_size;
+    return shm->data + offset;
+}
+
+/* Set per-chunk header: samples lost before this chunk */
+static inline void shm_set_chunk_lost_samples(uint8_t *slot_ptr, uint64_t samples_lost) {
+    *(uint64_t *)(slot_ptr) = samples_lost;
+}
+
+/* Create shared memory ring buffer
+ * chunk_size = DMA_BUFFER_SIZE (no rechunking)
+ * Each slot holds: [16-byte chunk header] + [sample data]
+ */
+static shm_ring_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
+                                      uint16_t num_channels, double buffer_seconds,
+                                      uint32_t sample_rate)
+{
+    shm_ring_buffer_t *shm = calloc(1, sizeof(shm_ring_buffer_t));
+    if (!shm) {
+        perror("calloc");
+        return NULL;
+    }
+
+    shm->num_channels = num_channels;
+    shm->chunk_bytes = chunk_bytes;
+    /* samples per chunk per channel */
+    shm->chunk_size = chunk_bytes / (SAMPLE_SIZE_COMPLEX_INT16 * num_channels);
+
+    /* Calculate number of slots for requested buffer time */
+    uint64_t bytes_per_second = (uint64_t)sample_rate * SAMPLE_SIZE_COMPLEX_INT16 * num_channels;
+    uint64_t total_buffer_bytes = (uint64_t)(bytes_per_second * buffer_seconds);
+    shm->num_slots = (total_buffer_bytes + chunk_bytes - 1) / chunk_bytes;
+    if (shm->num_slots < 16) shm->num_slots = 16;  /* minimum slots */
+
+    /* Each slot = chunk header + sample data */
+    size_t slot_size = CHUNK_HEADER_SIZE + shm->chunk_bytes;
+    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * slot_size;
+
+    /* Create shared memory file */
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0) {
+        perror(path);
+        free(shm);
+        return NULL;
+    }
+
+    if (ftruncate(fd, shm->total_size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        free(shm);
+        return NULL;
+    }
+
+    shm->data = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (shm->data == MAP_FAILED) {
+        perror("mmap");
+        free(shm);
+        return NULL;
+    }
+
+    /* Initialize header */
+    memset(shm->data, 0, SHM_HEADER_SIZE);
+    *(uint32_t *)(shm->data + OFFSET_CHUNK_SIZE) = shm->chunk_size;
+    *(uint32_t *)(shm->data + OFFSET_SAMPLE_SIZE) = SAMPLE_SIZE_COMPLEX_INT16;
+    *(uint32_t *)(shm->data + OFFSET_NUM_SLOTS) = shm->num_slots;
+    *(uint16_t *)(shm->data + OFFSET_NUM_CHANNELS) = num_channels;
+
+    printf("Created shared memory ring buffer:\n");
+    printf("  Path: %s\n", path);
+    printf("  Chunk size: %u bytes (%u samples/channel)\n", chunk_bytes, shm->chunk_size);
+    printf("  Num channels: %u\n", num_channels);
+    printf("  Num slots: %u\n", shm->num_slots);
+    printf("  Buffer size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
+    printf("  Buffer time: %.2f seconds\n",
+           (double)shm->num_slots * shm->chunk_size / sample_rate);
+
+    return shm;
+}
+
+static void shm_destroy(shm_ring_buffer_t *shm) {
+    if (shm) {
+        if (shm->data && shm->data != MAP_FAILED) {
+            shm_mark_writer_done(shm);
+            munmap(shm->data, shm->total_size);
+        }
+        free(shm);
+    }
+}
+
+/* RF Initialization */
+/*-------------------*/
+
+static void m2sdr_rf_init(
+    uint32_t samplerate,
+    int64_t  bandwidth,
+    int64_t  rx_freq,
+    int64_t  rx_gain,
+    uint8_t  num_channels
+) {
+    void *conn = m2sdr_open();
+
+#ifdef CSR_SI5351_BASE
+    /* Initialize SI5351 Clocking with internal XO */
+    printf("Initializing SI5351 Clocking...\n");
+    m2sdr_writel(conn, CSR_SI5351_CONTROL_ADDR,
+        SI5351B_VERSION * (1 << CSR_SI5351_CONTROL_VERSION_OFFSET));
+    m2sdr_si5351_i2c_config(conn, SI5351_I2C_ADDR,
+        si5351_xo_40m_config,
+        sizeof(si5351_xo_40m_config)/sizeof(si5351_xo_40m_config[0]));
+#endif
+
+    /* Power-up AD9361 */
+    printf("Powering up AD9361...\n");
+    m2sdr_writel(conn, CSR_AD9361_CONFIG_ADDR, 0b11);
+
+    /* Initialize AD9361 SPI */
+    printf("Initializing AD9361 SPI...\n");
+    m2sdr_ad9361_spi_init(conn, 1);
+
+    /* Initialize AD9361 RFIC */
+    if (num_channels == 2) {
+        printf("Initializing AD9361 RFIC (2T2R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 1;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 1;
+        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 0);  /* 2T2R */
+    } else {
+        printf("Initializing AD9361 RFIC (1T1R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 0;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 0;
+        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 1);  /* 1T1R */
+    }
+
+    default_init_param.reference_clk_rate = 40000000;  /* 40 MHz */
+    default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
+    default_init_param.gpio_sync          = -1;
+    default_init_param.gpio_cal_sw1       = -1;
+    default_init_param.gpio_cal_sw2       = -1;
+
+    ad9361_init(&ad9361_phy, &default_init_param, 1);
+
+    /* Configure AD9361 Samplerate */
+    printf("Setting RX Samplerate to %.2f MSPS.\n", samplerate/1e6);
+    ad9361_set_rx_sampling_freq(ad9361_phy, samplerate);
+
+    /* Configure AD9361 RX Bandwidth */
+    printf("Setting RX Bandwidth to %.2f MHz.\n", bandwidth/1e6);
+    ad9361_set_rx_rf_bandwidth(ad9361_phy, bandwidth);
+
+    /* Configure AD9361 RX Frequency */
+    printf("Setting RX LO Freq to %.2f MHz.\n", rx_freq/1e6);
+    ad9361_set_rx_lo_freq(ad9361_phy, rx_freq);
+
+    /* Configure AD9361 RX FIR */
+    ad9361_set_rx_fir_config(ad9361_phy, rx_fir_config);
+
+    /* Configure AD9361 RX Gain (same for both channels) */
+    printf("Setting RX Gain to %ld dB.\n", rx_gain);
+    ad9361_set_rx_rf_gain(ad9361_phy, 0, rx_gain);
+    if (num_channels == 2) {
+        ad9361_set_rx_rf_gain(ad9361_phy, 1, rx_gain);
+    }
+
+    /* 16-bit mode (12-bit samples in 16-bit words) */
+    m2sdr_writel(conn, CSR_AD9361_BITMODE_ADDR, 0);
+
+    m2sdr_close(conn);
+}
+
+/* Stream to Shared Memory */
+/*-------------------------*/
+
+static void m2sdr_stream_to_shm(
+    const char *device_name,
+    shm_ring_buffer_t *shm,
+    size_t num_samples,  /* 0 for infinite */
+    uint8_t quiet
+) {
+    static struct litepcie_dma_ctrl dma = {.use_writer = 1};
+
+    int i = 0;
+    size_t samples_written = 0;
+    int64_t last_time;
+    int64_t writer_sw_count_last = 0;
+    uint64_t chunks_written = 0;
+    uint64_t overflow_count = 0;
+    uint64_t lost_samples = 0;
+    uint64_t buffer_full_count = 0;
+    uint64_t pending_lost_samples = 0;  /* Samples lost since last written chunk */
+
+    /* Samples per DMA buffer (accounting for all channels) */
+    size_t samples_per_dma = DMA_BUFFER_SIZE / (SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels);
+    /* int16 values per DMA buffer (I and Q for all channels) */
+    size_t int16_per_dma = DMA_BUFFER_SIZE / sizeof(int16_t);
+
+    /* Initialize DMA */
+    if (litepcie_dma_init(&dma, device_name, 0))  /* zero_copy = 0 */
+        exit(1);
+    dma.writer_enable = 1;
+
+    /* Configure RX Header (disabled - we just want raw samples) */
+    m2sdr_writel(dma.fds.fd, CSR_HEADER_RX_CONTROL_ADDR,
+       (1 << CSR_HEADER_RX_CONTROL_ENABLE_OFFSET) |
+       (0 << CSR_HEADER_RX_CONTROL_HEADER_ENABLE_OFFSET)
+    );
+
+    /* Crossbar Demux: select PCIe streaming for RX */
+    m2sdr_writel(dma.fds.fd, CSR_CROSSBAR_DEMUX_SEL_ADDR, 0);
+
+    printf("Starting DMA stream to shared memory...\n");
+    printf("  DMA buffer size: %d bytes (%zu samples/channel)\n",
+           DMA_BUFFER_SIZE, samples_per_dma);
+    printf("  Per-chunk header: %d bytes (samples_lost_before)\n", CHUNK_HEADER_SIZE);
+
+    last_time = get_time_ms();
+
+    for (;;) {
+        if (!keep_running)
+            break;
+
+        if (num_samples > 0 && samples_written >= num_samples)
+            break;
+
+        /* Update DMA status */
+        litepcie_dma_process(&dma);
+
+        /* Check for DMA overflow BEFORE processing buffers
+         * This ensures we know how many samples were lost before each chunk
+         */
+        if (dma.writer_hw_count > dma.writer_sw_count + 16) {
+            uint64_t lost_buffers = dma.writer_hw_count - dma.writer_sw_count - 1;
+            uint64_t newly_lost = lost_buffers * samples_per_dma;
+            overflow_count++;
+            lost_samples += newly_lost;
+            pending_lost_samples += newly_lost;
+            shm_set_overflow_count(shm, overflow_count);
+            shm_set_lost_samples(shm, lost_samples);
+
+            if (!quiet) {
+                fprintf(stderr, "\rOVERFLOW #%" PRIu64 ": lost %" PRIu64 " buffers (%" PRIu64 " samples total)\n",
+                    overflow_count, lost_buffers, lost_samples);
+            }
+        }
+
+        /* Read from DMA and copy directly to shared memory */
+        while (1) {
+            char *buf_rd = litepcie_dma_next_read_buffer(&dma);
+            if (!buf_rd)
+                break;
+
+            /* Wait for space in ring buffer */
+            while (!shm_can_write(shm)) {
+                buffer_full_count++;
+                usleep(10);
+                if (!keep_running)
+                    goto done;
+            }
+
+            /* Get slot pointer and write per-chunk header first */
+            uint64_t write_idx = shm_get_write_index(shm);
+            uint8_t *slot = shm_slot_ptr(shm, write_idx);
+            shm_set_chunk_lost_samples(slot, pending_lost_samples);
+
+            /* Copy DMA buffer to sample data area (after header) */
+            uint8_t *dst = slot + CHUNK_HEADER_SIZE;
+            memcpy(dst, buf_rd, DMA_BUFFER_SIZE);
+
+            /* Sign-extend 12-bit samples to 16-bit in-place */
+            sign_extend_12bit_inplace((int16_t *)dst, int16_per_dma);
+
+            /* Reset pending lost samples - this chunk now "owns" them */
+            pending_lost_samples = 0;
+
+            /* Update counters */
+            chunks_written++;
+            samples_written += samples_per_dma;
+            shm_set_write_index(shm, write_idx + 1);
+            shm_set_chunks_written(shm, chunks_written);
+        }
+
+        /* Statistics every 200ms */
+        int64_t duration = get_time_ms() - last_time;
+        if (!quiet && duration > 200) {
+            double speed = (double)(dma.writer_sw_count - writer_sw_count_last) * DMA_BUFFER_SIZE * 8 / ((double)duration * 1e6);
+            uint64_t size_mb = (samples_written * SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels) / 1024 / 1024;
+
+            if (i % 10 == 0) {
+                fprintf(stderr, "\e[1m%10s %12s %9s %10s %12s\e[0m\n",
+                    "SPEED(Gbps)", "CHUNKS", "SIZE(MB)", "OVERFLOWS", "BUF_FULL");
+            }
+            i++;
+
+            fprintf(stderr, "%11.2f %12" PRIu64 " %9" PRIu64 " %10" PRIu64 " %12" PRIu64 "\n",
+                speed, chunks_written, size_mb, overflow_count, buffer_full_count);
+
+            last_time = get_time_ms();
+            writer_sw_count_last = dma.writer_sw_count;
+        }
+    }
+
+done:
+    litepcie_dma_cleanup(&dma);
+
+    printf("\nStream complete:\n");
+    printf("  Chunks written: %" PRIu64 "\n", chunks_written);
+    printf("  Samples written: %zu\n", samples_written);
+    printf("  Overflows: %" PRIu64 "\n", overflow_count);
+    printf("  Lost samples: %" PRIu64 "\n", lost_samples);
+    printf("  Buffer full events: %" PRIu64 "\n", buffer_full_count);
+}
+
+/* Help */
+/*------*/
+
+static void help(void)
+{
+    printf("M2SDR Stream to Shared Memory Utility\n"
+           "usage: m2sdr_stream_shm [options]\n"
+           "\n"
+           "Options:\n"
+           "  -h                     Show this help message and exit.\n"
+           "  -c device_num          Select the device (default: 0).\n"
+           "  -q                     Quiet mode (suppress statistics).\n"
+           "\n"
+           "RF Configuration:\n"
+           "  -samplerate sps        Set RF samplerate in Hz (default: %d).\n"
+           "  -bandwidth bw          Set the RF bandwidth in Hz (default: %d).\n"
+           "  -rx_freq freq          Set the RX frequency in Hz (default: %" PRId64 ").\n"
+           "  -rx_gain gain          Set the RX gain in dB (default: %d).\n"
+           "  -channels n            Number of RX channels: 1 or 2 (default: 1).\n"
+           "\n"
+           "Shared Memory Configuration:\n"
+           "  -shm_path path         Shared memory path (default: /dev/shm/sdr_ringbuffer).\n"
+           "  -buffer_time seconds   Ring buffer duration in seconds (default: 3.0).\n"
+           "  -num_samples count     Number of samples to capture (default: 0 = infinite).\n",
+           DEFAULT_SAMPLERATE,
+           DEFAULT_BANDWIDTH,
+           DEFAULT_RX_FREQ,
+           DEFAULT_RX_GAIN);
+    exit(1);
+}
+
+/* Options */
+/*---------*/
+
+static struct option options[] = {
+    { "help",        no_argument,       NULL, 'h' },
+    { "samplerate",  required_argument, NULL, 's' },
+    { "bandwidth",   required_argument, NULL, 'b' },
+    { "rx_freq",     required_argument, NULL, 'f' },
+    { "rx_gain",     required_argument, NULL, 'g' },
+    { "channels",    required_argument, NULL, 'C' },
+    { "shm_path",    required_argument, NULL, 'p' },
+    { "buffer_time", required_argument, NULL, 't' },
+    { "num_samples", required_argument, NULL, 'n' },
+    { NULL },
+};
+
+/* Main */
+/*------*/
+
+int main(int argc, char **argv)
+{
+    int c;
+
+    /* Defaults */
+    uint32_t samplerate  = DEFAULT_SAMPLERATE;
+    int64_t  bandwidth   = DEFAULT_BANDWIDTH;
+    int64_t  rx_freq     = DEFAULT_RX_FREQ;
+    int64_t  rx_gain     = DEFAULT_RX_GAIN;
+    uint8_t  num_channels = 1;
+    uint8_t  quiet       = 0;
+
+    const char *shm_path = "/dev/shm/sdr_ringbuffer";
+    double   buffer_time = 3.0;
+    size_t   num_samples = 0;  /* 0 = infinite */
+
+    signal(SIGINT, intHandler);
+
+    /* Parse options */
+    for (;;) {
+        c = getopt_long_only(argc, argv, "hc:q", options, NULL);
+        if (c == -1)
+            break;
+
+        switch(c) {
+        case 'h':
+            help();
+            break;
+        case 'c':
+            m2sdr_device_num = atoi(optarg);
+            break;
+        case 'q':
+            quiet = 1;
+            break;
+        case 's':
+            samplerate = (uint32_t)strtod(optarg, NULL);
+            break;
+        case 'b':
+            bandwidth = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'f':
+            rx_freq = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'g':
+            rx_gain = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'C':
+            num_channels = (uint8_t)atoi(optarg);
+            if (num_channels != 1 && num_channels != 2) {
+                fprintf(stderr, "Error: channels must be 1 or 2\n");
+                exit(1);
+            }
+            break;
+        case 'p':
+            shm_path = optarg;
+            break;
+        case 't':
+            buffer_time = strtod(optarg, NULL);
+            break;
+        case 'n':
+            num_samples = (size_t)strtoull(optarg, NULL, 0);
+            break;
+        default:
+            exit(1);
+        }
+    }
+
+    /* Select device */
+    snprintf(m2sdr_device, sizeof(m2sdr_device), "/dev/m2sdr%d", m2sdr_device_num);
+
+    printf("M2SDR Stream to Shared Memory\n");
+    printf("=============================\n");
+    printf("Device: %s\n", m2sdr_device);
+    printf("Sample rate: %.2f MHz\n", samplerate / 1e6);
+    printf("RX frequency: %.2f MHz\n", rx_freq / 1e6);
+    printf("RX gain: %ld dB\n", rx_gain);
+    printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);
+    printf("Channels: %d (%s)\n", num_channels, num_channels == 2 ? "2T2R" : "1T1R");
+    printf("Shared memory: %s\n", shm_path);
+    printf("Buffer time: %.1f seconds\n", buffer_time);
+    if (num_samples > 0)
+        printf("Num samples: %zu\n", num_samples);
+    else
+        printf("Num samples: infinite (Ctrl+C to stop)\n");
+    printf("\n");
+
+    /* Initialize RF */
+    m2sdr_rf_init(samplerate, bandwidth, rx_freq, rx_gain, num_channels);
+
+    /* Create shared memory - chunk size = DMA buffer size (no rechunking) */
+    shm_ring_buffer_t *shm = shm_create(shm_path, DMA_BUFFER_SIZE,
+                                         num_channels, buffer_time, samplerate);
+    if (!shm) {
+        fprintf(stderr, "Failed to create shared memory\n");
+        return 1;
+    }
+
+    /* Stream to shared memory */
+    m2sdr_stream_to_shm(m2sdr_device, shm, num_samples, quiet);
+
+    /* Cleanup */
+    shm_destroy(shm);
+
+    return 0;
+}

--- a/litex_m2sdr/software/user/m2sdr_shm.h
+++ b/litex_m2sdr/software/user/m2sdr_shm.h
@@ -1,0 +1,284 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * M2SDR Shared Memory Ring Buffer.
+ *
+ * Unified SHM ring buffer used by both RX and TX streaming executables.
+ * RX and TX use separate SHM files, so shared fields can have
+ * direction-dependent meaning (e.g. error_count = overflow for RX,
+ * underflow for TX).
+ *
+ * Shared Memory Header Layout (64 bytes, cache-line aligned):
+ *   Bytes  0-7:   write_index (uint64_t)        — next slot to write (producer)
+ *   Bytes  8-15:  read_index (uint64_t)          — next slot to read (consumer)
+ *   Bytes 16-23:  error_count (uint64_t)         — RX: DMA overflows; TX: DMA underflows
+ *   Bytes 24-27:  chunk_size (uint32_t)          — samples per chunk per channel
+ *   Bytes 28-31:  num_slots (uint32_t)           — number of slots in ring buffer
+ *   Bytes 32-33:  num_channels (uint16_t)        — 1 or 2
+ *   Bytes 34-35:  flags (uint16_t)               — bit 0 = writer_done
+ *   Bytes 36-39:  sample_size (uint32_t)         — bytes per sample (4 for Complex{Int16})
+ *   Bytes 40-47:  buffer_stall_count (uint64_t)  — RX: buffer-full waits; TX: buffer-empty events
+ *   Bytes 48-63:  reserved (16 bytes)
+ *
+ * This file is part of LiteX-M2SDR project.
+ *
+ * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
+ */
+
+#ifndef M2SDR_SHM_H
+#define M2SDR_SHM_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+/*
+ * Header Layout
+ */
+#define SHM_HEADER_SIZE              64
+#define SHM_OFFSET_WRITE_INDEX       0
+#define SHM_OFFSET_READ_INDEX        8
+#define SHM_OFFSET_ERROR_COUNT       16
+#define SHM_OFFSET_CHUNK_SIZE        24
+#define SHM_OFFSET_NUM_SLOTS         28
+#define SHM_OFFSET_NUM_CHANNELS      32
+#define SHM_OFFSET_FLAGS             34
+#define SHM_OFFSET_SAMPLE_SIZE       36
+#define SHM_OFFSET_BUFFER_STALL      40
+
+#define SHM_FLAG_WRITER_DONE         (1 << 0)
+
+/* Sample size for Complex{Int16} (I + Q, each int16) */
+#define SHM_BYTES_PER_COMPLEX        4
+
+/*
+ * Ring Buffer Struct
+ */
+typedef struct {
+    uint8_t  *base;          /* mmap base pointer */
+    size_t    total_size;    /* total mmap size */
+    uint32_t  num_slots;     /* number of slots */
+    uint32_t  chunk_size;    /* samples per chunk per channel */
+    uint32_t  chunk_bytes;   /* bytes per chunk (all channels) */
+    uint16_t  num_channels;  /* 1 or 2 */
+} shm_buffer_t;
+
+/*
+ * Atomic Accessors
+ */
+static inline uint64_t shm_load_write_index(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), __ATOMIC_ACQUIRE);
+}
+
+static inline void shm_store_write_index(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_WRITE_INDEX), val, __ATOMIC_RELEASE);
+}
+
+static inline uint64_t shm_load_read_index(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_READ_INDEX), __ATOMIC_ACQUIRE);
+}
+
+static inline void shm_store_read_index(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_READ_INDEX), val, __ATOMIC_RELEASE);
+}
+
+static inline uint64_t shm_load_error_count(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_ERROR_COUNT), __ATOMIC_RELAXED);
+}
+
+static inline void shm_store_error_count(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_ERROR_COUNT), val, __ATOMIC_RELAXED);
+}
+
+static inline uint64_t shm_load_buffer_stall(shm_buffer_t *shm) {
+    return __atomic_load_n((uint64_t *)(shm->base + SHM_OFFSET_BUFFER_STALL), __ATOMIC_RELAXED);
+}
+
+static inline void shm_store_buffer_stall(shm_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((uint64_t *)(shm->base + SHM_OFFSET_BUFFER_STALL), val, __ATOMIC_RELAXED);
+}
+
+static inline void shm_set_flags(shm_buffer_t *shm, uint16_t flags) {
+    __atomic_store_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), flags, __ATOMIC_RELEASE);
+}
+
+static inline uint16_t shm_get_flags(shm_buffer_t *shm) {
+    return __atomic_load_n((uint16_t *)(shm->base + SHM_OFFSET_FLAGS), __ATOMIC_ACQUIRE);
+}
+
+/*
+ * Ring Buffer Helpers
+ */
+
+/* Get pointer to slot data */
+static inline uint8_t *shm_slot_ptr(shm_buffer_t *shm, uint64_t index) {
+    size_t slot_offset = SHM_HEADER_SIZE + (index % shm->num_slots) * shm->chunk_bytes;
+    return shm->base + slot_offset;
+}
+
+/* Check if producer can write (ring buffer not full) */
+static inline bool shm_can_write(shm_buffer_t *shm, uint64_t write_idx) {
+    uint64_t read_idx = shm_load_read_index(shm);
+    return (write_idx - read_idx) < shm->num_slots;
+}
+
+/* Check if consumer can read (data available) */
+static inline bool shm_can_read(shm_buffer_t *shm) {
+    uint64_t write_idx = shm_load_write_index(shm);
+    uint64_t read_idx = shm_load_read_index(shm);
+    return read_idx < write_idx;
+}
+
+/* Check if writer has signaled done */
+static inline bool shm_is_writer_done(shm_buffer_t *shm) {
+    return (shm_get_flags(shm) & SHM_FLAG_WRITER_DONE) != 0;
+}
+
+/* Signal writer done */
+static inline void shm_set_writer_done(shm_buffer_t *shm) {
+    shm_set_flags(shm, shm_get_flags(shm) | SHM_FLAG_WRITER_DONE);
+}
+
+/*
+ * Create shared memory ring buffer (producer role)
+ */
+static inline shm_buffer_t *shm_create(const char *path, uint32_t chunk_bytes,
+                                         uint16_t num_channels, double buffer_seconds,
+                                         uint32_t sample_rate)
+{
+    shm_buffer_t *shm = calloc(1, sizeof(shm_buffer_t));
+    if (!shm) {
+        perror("calloc");
+        return NULL;
+    }
+
+    shm->num_channels = num_channels;
+    shm->chunk_bytes = chunk_bytes;
+    shm->chunk_size = chunk_bytes / (SHM_BYTES_PER_COMPLEX * num_channels);
+
+    /* Calculate number of slots for requested buffer duration */
+    uint64_t bytes_per_second = (uint64_t)sample_rate * SHM_BYTES_PER_COMPLEX * num_channels;
+    uint64_t total_buffer_bytes = (uint64_t)(bytes_per_second * buffer_seconds);
+    shm->num_slots = (total_buffer_bytes + chunk_bytes - 1) / chunk_bytes;
+    if (shm->num_slots < 16)
+        shm->num_slots = 16;
+
+    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * shm->chunk_bytes;
+
+    /* Create/open shared memory file */
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0) {
+        perror(path);
+        free(shm);
+        return NULL;
+    }
+
+    if (ftruncate(fd, shm->total_size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        free(shm);
+        return NULL;
+    }
+
+    shm->base = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (shm->base == MAP_FAILED) {
+        perror("mmap");
+        free(shm);
+        return NULL;
+    }
+
+    /* Initialize header */
+    memset(shm->base, 0, SHM_HEADER_SIZE);
+    *(uint32_t *)(shm->base + SHM_OFFSET_CHUNK_SIZE)   = shm->chunk_size;
+    *(uint32_t *)(shm->base + SHM_OFFSET_NUM_SLOTS)    = shm->num_slots;
+    *(uint16_t *)(shm->base + SHM_OFFSET_NUM_CHANNELS) = num_channels;
+    *(uint32_t *)(shm->base + SHM_OFFSET_SAMPLE_SIZE)  = SHM_BYTES_PER_COMPLEX;
+
+    printf("Created shared memory ring buffer:\n");
+    printf("  Path: %s\n", path);
+    printf("  Chunk size: %u bytes (%u samples/channel)\n", chunk_bytes, shm->chunk_size);
+    printf("  Num channels: %u\n", num_channels);
+    printf("  Num slots: %u\n", shm->num_slots);
+    printf("  Buffer size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
+    printf("  Buffer time: %.2f seconds\n", (double)shm->num_slots * shm->chunk_size / sample_rate);
+
+    return shm;
+}
+
+/*
+ * Open existing shared memory ring buffer (consumer role)
+ */
+static inline shm_buffer_t *shm_open_existing(const char *path)
+{
+    shm_buffer_t *shm = calloc(1, sizeof(shm_buffer_t));
+    if (!shm) {
+        perror("calloc");
+        return NULL;
+    }
+
+    int fd = open(path, O_RDWR);
+    if (fd < 0) {
+        perror(path);
+        free(shm);
+        return NULL;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) < 0) {
+        perror("fstat");
+        close(fd);
+        free(shm);
+        return NULL;
+    }
+    shm->total_size = st.st_size;
+
+    shm->base = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (shm->base == MAP_FAILED) {
+        perror("mmap");
+        free(shm);
+        return NULL;
+    }
+
+    /* Read header metadata */
+    shm->chunk_size   = *(uint32_t *)(shm->base + SHM_OFFSET_CHUNK_SIZE);
+    shm->num_slots    = *(uint32_t *)(shm->base + SHM_OFFSET_NUM_SLOTS);
+    shm->num_channels = *(uint16_t *)(shm->base + SHM_OFFSET_NUM_CHANNELS);
+    uint32_t sample_size = *(uint32_t *)(shm->base + SHM_OFFSET_SAMPLE_SIZE);
+    if (sample_size == 0)
+        sample_size = SHM_BYTES_PER_COMPLEX; /* fallback for legacy SHM files */
+    shm->chunk_bytes  = shm->chunk_size * sample_size * shm->num_channels;
+
+    printf("Opened shared memory ring buffer:\n");
+    printf("  Path: %s\n", path);
+    printf("  Chunk size: %u samples/channel (%u bytes)\n", shm->chunk_size, shm->chunk_bytes);
+    printf("  Num channels: %u\n", shm->num_channels);
+    printf("  Num slots: %u\n", shm->num_slots);
+    printf("  Sample size: %u bytes\n", sample_size);
+    printf("  Total size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
+
+    return shm;
+}
+
+/*
+ * Destroy shared memory ring buffer
+ */
+static inline void shm_destroy(shm_buffer_t *shm) {
+    if (shm) {
+        if (shm->base && shm->base != MAP_FAILED) {
+            shm_set_writer_done(shm);
+            munmap(shm->base, shm->total_size);
+        }
+        free(shm);
+    }
+}
+
+#endif /* M2SDR_SHM_H */

--- a/litex_m2sdr/software/user/m2sdr_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_stream_shm.c
@@ -1,0 +1,709 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * M2SDR Full-Duplex Stream Shared Memory Utility.
+ *
+ * Configures the AD9361 RF frontend and simultaneously streams:
+ *   - RX data to a shared memory ring buffer (producer)
+ *   - TX data from a separate shared memory ring buffer (consumer)
+ *
+ * Uses two separate DMA control structs on a shared file descriptor,
+ * following the SoapySDR driver pattern for full-duplex operation.
+ *
+ * Data Format:
+ *   - Samples are Complex{Int16} (4 bytes per sample per channel)
+ *   - Multi-channel data is interleaved: I0,Q0,I1,Q1,I0,Q0,I1,Q1,...
+ *   - 12-bit ADC RX samples are sign-extended to 16-bit
+ *
+ * This file is part of LiteX-M2SDR project.
+ *
+ * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdint.h>
+#include <poll.h>
+
+#include "m2sdr_shm.h"
+#include "m2sdr_common.h"
+
+/*
+ * Global state
+ */
+static char g_device_path[256];
+static int g_device_num = 0;
+
+/*
+ * RF Initialization (Full-Duplex: combined RX + TX)
+ *
+ * Single ad9361_init() call with both RX and TX frequency hints,
+ * followed by direction-specific configuration.
+ */
+static void rf_init(int fd, uint32_t samplerate, int64_t bandwidth,
+                    int64_t rx_freq, int64_t rx_gain, uint8_t agc_mode,
+                    int64_t tx_freq, int64_t tx_gain,
+                    uint8_t num_channels)
+{
+    /* Common AD9361 setup (SI5351, power-up, SPI, mode, bitmode, sync, loopback) */
+    m2sdr_rf_common_init(fd, num_channels);
+
+    /* Set both RX and TX synthesizer frequency hints before init */
+    default_init_param.rx_synthesizer_frequency_hz = rx_freq;
+    default_init_param.rf_rx_bandwidth_hz          = bandwidth;
+    default_init_param.tx_synthesizer_frequency_hz = tx_freq;
+    default_init_param.rf_tx_bandwidth_hz          = bandwidth;
+
+    ad9361_init(&ad9361_phy, &default_init_param, 1);
+
+    /* Configure channel mode (required for TX signal quality) */
+    printf("Configuring AD9361 channel mode...\n");
+    m2sdr_writel((void *)(intptr_t)fd, CSR_AD9361_PHY_CONTROL_ADDR, num_channels == 1 ? 1 : 0);
+    ad9361_phy->pdata->rx2tx2 = (num_channels == 2);
+    if (num_channels == 1) {
+        ad9361_phy->pdata->rx1tx1_mode_use_tx_num = TX_1;
+    } else {
+        ad9361_phy->pdata->rx1tx1_mode_use_tx_num = TX_1 | TX_2;
+    }
+    struct ad9361_phy_platform_data *pd = ad9361_phy->pdata;
+    pd->port_ctrl.pp_conf[0] &= ~(1 << 2);
+    if (num_channels == 2)
+        pd->port_ctrl.pp_conf[0] |= (1 << 2);
+    ad9361_set_no_ch_mode(ad9361_phy, num_channels);
+
+    /* --- RX Configuration --- */
+
+    printf("Setting RX sample rate to %.2f MSPS...\n", samplerate / 1e6);
+    ad9361_set_rx_sampling_freq(ad9361_phy, samplerate);
+
+    printf("Setting RX bandwidth to %.2f MHz...\n", bandwidth / 1e6);
+    ad9361_set_rx_rf_bandwidth(ad9361_phy, bandwidth);
+
+    printf("Setting RX LO frequency to %.2f MHz...\n", rx_freq / 1e6);
+    ad9361_set_rx_lo_freq(ad9361_phy, rx_freq);
+
+    ad9361_set_rx_fir_config(ad9361_phy, rx_fir_config);
+
+    printf("Setting RX AGC mode to %s...\n", agc_mode_str(agc_mode));
+    ad9361_set_rx_gain_control_mode(ad9361_phy, 0, agc_mode);
+    if (num_channels == 2)
+        ad9361_set_rx_gain_control_mode(ad9361_phy, 1, agc_mode);
+
+    printf("Setting RX gain to %ld dB%s...\n", rx_gain,
+           agc_mode != RF_GAIN_MGC ? " (initial, AGC active)" : "");
+    ad9361_set_rx_rf_gain(ad9361_phy, 0, rx_gain);
+    if (num_channels == 2)
+        ad9361_set_rx_rf_gain(ad9361_phy, 1, rx_gain);
+
+    /* --- TX Configuration --- */
+
+    printf("Setting TX sample rate to %.2f MSPS...\n", samplerate / 1e6);
+    if (samplerate < 1250000) {
+        printf("Setting TX FIR Interpolation to 4 (< 1.25 Msps).\n");
+        ad9361_phy->tx_fir_int    = 4;
+        ad9361_phy->bypass_tx_fir = 0;
+        AD9361_TXFIRConfig tx_fir_cfg = tx_fir_config;
+        tx_fir_cfg.tx_int = 4;
+        ad9361_set_tx_fir_config(ad9361_phy, tx_fir_cfg);
+        ad9361_set_tx_fir_en_dis(ad9361_phy, 1);
+    } else if (samplerate < 2500000) {
+        printf("Setting TX FIR Interpolation to 2 (< 2.5 Msps).\n");
+        ad9361_phy->tx_fir_int    = 2;
+        ad9361_phy->bypass_tx_fir = 0;
+        AD9361_TXFIRConfig tx_fir_cfg = tx_fir_config;
+        tx_fir_cfg.tx_int = 2;
+        ad9361_set_tx_fir_config(ad9361_phy, tx_fir_cfg);
+        ad9361_set_tx_fir_en_dis(ad9361_phy, 1);
+    } else {
+        ad9361_set_tx_fir_config(ad9361_phy, tx_fir_config);
+    }
+
+    ad9361_set_tx_sampling_freq(ad9361_phy, samplerate);
+
+    printf("Setting TX bandwidth to %.2f MHz...\n", bandwidth / 1e6);
+    ad9361_set_tx_rf_bandwidth(ad9361_phy, bandwidth);
+
+    printf("Setting TX LO frequency to %.2f MHz...\n", tx_freq / 1e6);
+    ad9361_set_tx_lo_freq(ad9361_phy, tx_freq);
+
+    int32_t attenuation_mdb = (int32_t)(-tx_gain * 1000);
+    printf("Setting TX attenuation to %ld dB (%" PRId32 " mdB)...\n", -tx_gain, attenuation_mdb);
+    ad9361_set_tx_attenuation(ad9361_phy, 0, attenuation_mdb);
+    if (num_channels == 2)
+        ad9361_set_tx_attenuation(ad9361_phy, 1, attenuation_mdb);
+
+    /* --- Header and Crossbar Configuration --- */
+
+    /* RX header control (disabled - raw samples only) */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_HEADER_RX_CONTROL_ADDR,
+        (1 << CSR_HEADER_RX_CONTROL_ENABLE_OFFSET) |
+        (0 << CSR_HEADER_RX_CONTROL_HEADER_ENABLE_OFFSET));
+
+    /* TX header control (disabled) */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_HEADER_TX_CONTROL_ADDR,
+        (1 << CSR_HEADER_TX_CONTROL_ENABLE_OFFSET) |
+        (0 << CSR_HEADER_TX_CONTROL_HEADER_ENABLE_OFFSET));
+
+    /* Crossbar: PCIe for both RX and TX */
+    m2sdr_writel((void *)(intptr_t)fd, CSR_CROSSBAR_DEMUX_SEL_ADDR, 0);
+    m2sdr_writel((void *)(intptr_t)fd, CSR_CROSSBAR_MUX_SEL_ADDR, 0);
+}
+
+/*
+ * Sign-extend 12-bit samples to 16-bit in-place
+ */
+static inline void sign_extend_12bit_buffer(int16_t *data, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        data[i] = (int16_t)(data[i] << 4) >> 4;
+    }
+}
+
+/*
+ * Full-Duplex DMA Streaming
+ *
+ * Uses two DMA control structs on a shared fd (SoapySDR pattern):
+ *   - rx_dma: writer from FPGA perspective (FPGA writes RX data, CPU reads)
+ *   - tx_dma: reader from FPGA perspective (CPU writes TX data, FPGA reads)
+ *
+ * Single-threaded with poll(POLLIN|POLLOUT) multiplexing both directions.
+ */
+static void stream_duplex(shm_buffer_t *rx_shm, shm_buffer_t *tx_shm,
+                          size_t num_samples, uint8_t quiet)
+{
+    /* Open device */
+    int fd = open(g_device_path, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open %s\n", g_device_path);
+        return;
+    }
+
+    /* --- RX DMA Setup --- */
+    struct litepcie_dma_ctrl rx_dma;
+    memset(&rx_dma, 0, sizeof(rx_dma));
+    rx_dma.fds.fd     = fd;
+    rx_dma.use_writer = 1;
+    rx_dma.use_reader = 0;
+    rx_dma.loopback   = 0;
+    rx_dma.zero_copy  = 1;
+    rx_dma.shared_fd  = 1;
+
+    if (litepcie_dma_init(&rx_dma, "", 1) < 0) {
+        fprintf(stderr, "RX DMA init failed\n");
+        close(fd);
+        return;
+    }
+
+    /* --- TX DMA Setup --- */
+    struct litepcie_dma_ctrl tx_dma;
+    memset(&tx_dma, 0, sizeof(tx_dma));
+    tx_dma.fds.fd     = fd;
+    tx_dma.use_reader = 1;
+    tx_dma.use_writer = 0;
+    tx_dma.loopback   = 0;
+    tx_dma.zero_copy  = 1;
+    tx_dma.shared_fd  = 1;
+
+    if (litepcie_dma_init(&tx_dma, "", 1) < 0) {
+        fprintf(stderr, "TX DMA init failed\n");
+        litepcie_dma_cleanup(&rx_dma);
+        close(fd);
+        return;
+    }
+
+    /* --- DMA Buffer Info --- */
+    uint32_t rx_buf_size  = rx_dma.mmap_dma_info.dma_rx_buf_size;
+    uint32_t rx_buf_count = rx_dma.mmap_dma_info.dma_rx_buf_count;
+    uint32_t tx_buf_size  = tx_dma.mmap_dma_info.dma_tx_buf_size;
+    uint32_t tx_buf_count = tx_dma.mmap_dma_info.dma_tx_buf_count;
+
+    size_t rx_samples_per_dma = rx_buf_size / (SHM_BYTES_PER_COMPLEX * rx_shm->num_channels);
+    size_t rx_int16_per_dma   = rx_buf_size / sizeof(int16_t);
+
+    if (tx_dma.buf_wr == NULL || tx_dma.buf_wr == MAP_FAILED) {
+        fprintf(stderr, "TX DMA buffer not mapped correctly\n");
+        litepcie_dma_cleanup(&rx_dma);
+        litepcie_dma_cleanup(&tx_dma);
+        close(fd);
+        return;
+    }
+
+    printf("DMA configuration:\n");
+    printf("  RX: %u bytes/buf x %u bufs (%zu samples/channel/buf)\n",
+           rx_buf_size, rx_buf_count, rx_samples_per_dma);
+    printf("  TX: %u bytes/buf x %u bufs\n", tx_buf_size, tx_buf_count);
+
+    /* Verify chunk sizes match DMA buffer sizes */
+    if (tx_shm->chunk_bytes != tx_buf_size) {
+        fprintf(stderr, "Warning: TX SHM chunk size (%u) != DMA buffer size (%u)\n",
+                tx_shm->chunk_bytes, tx_buf_size);
+    }
+
+    /* --- Reset and Enable DMA Counters --- */
+    int64_t rx_hw_count = 0, rx_sw_count = 0;
+    litepcie_dma_writer(fd, 0, &rx_hw_count, &rx_sw_count);
+    int64_t rx_user_count = 0;
+
+    int64_t tx_hw_count = 0, tx_sw_count_init = 0;
+    litepcie_dma_reader(fd, 0, &tx_hw_count, &tx_sw_count_init);
+    int64_t tx_user_count = tx_hw_count;
+
+    printf("Starting full-duplex DMA streaming...\n");
+
+    /* Enable DMA for both directions */
+    litepcie_dma_writer(fd, 1, &rx_hw_count, &rx_sw_count);
+    litepcie_dma_reader(fd, 1, &tx_hw_count, &tx_sw_count_init);
+
+    /* --- Statistics --- */
+    uint64_t rx_shm_write_idx   = 0;
+    uint64_t rx_chunks_written  = 0;
+    uint64_t rx_overflow_count  = 0;
+    uint64_t rx_buffer_full_waits = 0;
+    size_t   rx_total_samples   = 0;
+
+    uint64_t tx_chunks_read       = 0;
+    uint64_t tx_underflow_count   = 0;
+    uint64_t tx_buffer_empty_count = 0;
+    size_t   tx_total_samples     = 0;
+
+    int64_t last_stats_time    = get_time_ms();
+    int64_t last_rx_user_count = 0;
+    int64_t last_tx_hw_count   = 0;
+    int stats_line = 0;
+
+    /* --- Main Loop --- */
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN | POLLOUT;
+
+    while (g_keep_running) {
+        if (num_samples > 0 && rx_total_samples >= num_samples)
+            break;
+
+        int ret = poll(&pfd, 1, 100);
+        if (ret < 0) {
+            if (g_keep_running)
+                perror("poll");
+            break;
+        }
+        if (ret == 0)
+            continue;
+
+        /* === RX Processing === */
+        if (pfd.revents & POLLIN) {
+            litepcie_dma_writer(fd, 1, &rx_hw_count, &rx_sw_count);
+            int64_t rx_buffers_available = rx_hw_count - rx_user_count;
+
+            /* Overflow detection */
+            if ((rx_hw_count - rx_sw_count) > (int64_t)(rx_buf_count / 2)) {
+                rx_overflow_count++;
+                shm_store_error_count(rx_shm, rx_overflow_count);
+                if (!quiet) {
+                    fprintf(stderr, "\nRX OVERFLOW #%" PRIu64 ": hw=%" PRId64 " sw=%" PRId64
+                            " (gap=%" PRId64 ")\n",
+                            rx_overflow_count, rx_hw_count, rx_sw_count,
+                            rx_hw_count - rx_sw_count);
+                }
+                /* Drain all buffers */
+                struct litepcie_ioctl_mmap_dma_update update;
+                update.sw_count = rx_hw_count;
+                ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
+                rx_user_count = rx_hw_count;
+                rx_sw_count = rx_hw_count;
+                rx_buffers_available = 0;
+            }
+
+            /* Process available RX buffers */
+            while (rx_buffers_available > 0 && g_keep_running) {
+                /* Wait for RX SHM space */
+                while (!shm_can_write(rx_shm, rx_shm_write_idx)) {
+                    rx_buffer_full_waits++;
+                    shm_store_buffer_stall(rx_shm, rx_buffer_full_waits);
+                    usleep(10);
+                    if (!g_keep_running)
+                        goto done;
+
+                    /* Check for overflow while waiting */
+                    litepcie_dma_writer(fd, 1, &rx_hw_count, &rx_sw_count);
+                    if ((rx_hw_count - rx_sw_count) > (int64_t)(rx_buf_count / 2)) {
+                        rx_overflow_count++;
+                        shm_store_error_count(rx_shm, rx_overflow_count);
+                        if (!quiet)
+                            fprintf(stderr, "\nRX OVERFLOW #%" PRIu64 " (while waiting for SHM)\n",
+                                    rx_overflow_count);
+                        struct litepcie_ioctl_mmap_dma_update update;
+                        update.sw_count = rx_hw_count;
+                        ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
+                        rx_user_count = rx_hw_count;
+                        rx_sw_count = rx_hw_count;
+                        rx_buffers_available = 0;
+                        break;
+                    }
+                }
+
+                if (rx_buffers_available == 0)
+                    break;
+
+                /* Copy DMA buffer to RX SHM slot */
+                int rx_buf_idx = rx_user_count % rx_buf_count;
+                char *dma_buf = rx_dma.buf_rd + rx_buf_idx * rx_buf_size;
+                uint8_t *shm_slot = shm_slot_ptr(rx_shm, rx_shm_write_idx);
+
+                memcpy(shm_slot, dma_buf, rx_buf_size);
+                sign_extend_12bit_buffer((int16_t *)shm_slot, rx_int16_per_dma);
+
+                /* Advance counters */
+                rx_user_count++;
+                rx_buffers_available--;
+
+                struct litepcie_ioctl_mmap_dma_update update;
+                update.sw_count = rx_user_count;
+                ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &update);
+
+                rx_shm_write_idx++;
+                shm_store_write_index(rx_shm, rx_shm_write_idx);
+
+                rx_chunks_written++;
+                rx_total_samples += rx_samples_per_dma;
+
+                if (num_samples > 0 && rx_total_samples >= num_samples)
+                    break;
+            }
+        }
+
+        /* === TX Processing === */
+        if (pfd.revents & POLLOUT) {
+            int64_t tx_sw_count_tmp = 0;
+            litepcie_dma_reader(fd, 1, &tx_hw_count, &tx_sw_count_tmp);
+
+            /* Underflow detection */
+            if (tx_hw_count > tx_user_count) {
+                tx_underflow_count++;
+                shm_store_error_count(tx_shm, tx_underflow_count);
+                if (!quiet)
+                    fprintf(stderr, "\nTX UNDERFLOW #%" PRIu64 "\n", tx_underflow_count);
+                tx_user_count = tx_hw_count;
+            }
+
+            /* Calculate available TX DMA buffers */
+            int64_t tx_buffers_pending = tx_user_count - tx_hw_count;
+            int64_t tx_buffers_available = (int64_t)tx_buf_count - tx_buffers_pending;
+
+            /* Fill available TX DMA buffers from SHM */
+            while (tx_buffers_available > 0) {
+                if (!shm_can_read(tx_shm)) {
+                    /* Check if producer is done */
+                    if (shm_is_writer_done(tx_shm)) {
+                        printf("TX producer signaled done.\n");
+                        g_keep_running = 0;
+                        break;
+                    }
+                    /* No data yet. If enough headroom, wait */
+                    int64_t current_pending = tx_user_count - tx_hw_count;
+                    if (current_pending >= 8)
+                        break;
+                    /* Running low - send zeros to prevent underflow */
+                    tx_buffer_empty_count++;
+                    shm_store_buffer_stall(tx_shm, tx_buffer_empty_count);
+                    if (!quiet)
+                        fprintf(stderr, "\nTX BUF_EMPTY #%" PRIu64 " (pending=%" PRId64 ")\n",
+                                tx_buffer_empty_count, current_pending);
+                    int buf_offset = tx_user_count % tx_buf_count;
+                    char *buf_wr = tx_dma.buf_wr + buf_offset * tx_buf_size;
+                    memset(buf_wr, 0, tx_buf_size);
+                } else {
+                    /* Copy data from TX SHM slot to DMA buffer */
+                    int buf_offset = tx_user_count % tx_buf_count;
+                    char *buf_wr = tx_dma.buf_wr + buf_offset * tx_buf_size;
+                    uint64_t read_idx = shm_load_read_index(tx_shm);
+                    uint8_t *src = shm_slot_ptr(tx_shm, read_idx);
+
+                    size_t copy_size = (tx_shm->chunk_bytes < tx_buf_size) ?
+                                        tx_shm->chunk_bytes : tx_buf_size;
+                    memcpy(buf_wr, src, copy_size);
+                    if (copy_size < tx_buf_size)
+                        memset(buf_wr + copy_size, 0, tx_buf_size - copy_size);
+
+                    tx_chunks_read++;
+                    tx_total_samples += tx_shm->chunk_size;
+                    shm_store_read_index(tx_shm, read_idx + 1);
+                }
+
+                __sync_synchronize();
+
+                tx_user_count++;
+                struct litepcie_ioctl_mmap_dma_update mmap_dma_update;
+                mmap_dma_update.sw_count = tx_user_count;
+                checked_ioctl(fd, LITEPCIE_IOCTL_MMAP_DMA_READER_UPDATE, &mmap_dma_update);
+
+                tx_buffers_available--;
+            }
+        }
+
+        /* === Statistics Display === */
+        int64_t now = get_time_ms();
+        int64_t elapsed = now - last_stats_time;
+        if (!quiet && elapsed >= 200) {
+            double rx_speed = (double)(rx_user_count - last_rx_user_count) * rx_buf_size * 8 / (elapsed * 1e6);
+            double tx_speed = (double)(tx_hw_count - last_tx_hw_count) * tx_buf_size * 8 / (elapsed * 1e6);
+
+            if (stats_line % 10 == 0) {
+                fprintf(stderr, "\n\033[1m%8s %8s %8s %8s  %8s %8s %8s %8s\033[0m\n",
+                        "RX Gbps", "RX_CHKS", "RX_OVFL", "SHM_WAIT",
+                        "TX Gbps", "TX_CHKS", "TX_UNFL", "BUF_EMPT");
+            }
+            stats_line++;
+
+            fprintf(stderr, "%8.2f %8" PRIu64 " %8" PRIu64 " %8" PRIu64
+                           "  %8.2f %8" PRIu64 " %8" PRIu64 " %8" PRIu64 "\n",
+                    rx_speed, rx_chunks_written, rx_overflow_count, rx_buffer_full_waits,
+                    tx_speed, tx_chunks_read, tx_underflow_count, tx_buffer_empty_count);
+
+            last_stats_time = now;
+            last_rx_user_count = rx_user_count;
+            last_tx_hw_count = tx_hw_count;
+        }
+    }
+
+done:
+    /* Disable DMA */
+    litepcie_dma_writer(fd, 0, &rx_hw_count, &rx_sw_count);
+    litepcie_dma_reader(fd, 0, &tx_hw_count, &tx_sw_count_init);
+    litepcie_dma_cleanup(&rx_dma);
+    litepcie_dma_cleanup(&tx_dma);
+    close(fd);
+
+    printf("\nFull-duplex stream complete:\n");
+    printf("  RX: %" PRIu64 " chunks, %zu samples, %" PRIu64 " overflows, %" PRIu64 " SHM waits\n",
+           rx_chunks_written, rx_total_samples, rx_overflow_count, rx_buffer_full_waits);
+    printf("  TX: %" PRIu64 " chunks, %zu samples, %" PRIu64 " underflows, %" PRIu64 " buffer empty\n",
+           tx_chunks_read, tx_total_samples, tx_underflow_count, tx_buffer_empty_count);
+}
+
+/*
+ * Help
+ */
+static void print_help(void)
+{
+    printf("M2SDR Full-Duplex Stream Shared Memory\n"
+           "Usage: m2sdr_stream_shm [options]\n"
+           "\n"
+           "Options:\n"
+           "  -h                         Show this help\n"
+           "  -c device_num              Select device (default: 0)\n"
+           "  -q                         Quiet mode\n"
+           "  -w                         Wait for TX SHM to be created\n"
+           "\n"
+           "RF Configuration (shared):\n"
+           "  -samplerate Hz             Sample rate (default: %d)\n"
+           "  -bandwidth Hz              RF bandwidth (default: %d)\n"
+           "  -channels N                Number of channels: 1 or 2 (default: 1)\n"
+           "\n"
+           "RX Configuration:\n"
+           "  -rx_freq Hz                RX frequency (default: %" PRId64 ")\n"
+           "  -rx_gain dB                RX gain (default: %d)\n"
+           "  -agc_mode mode             AGC: manual, fast_attack, slow_attack, hybrid\n"
+           "\n"
+           "TX Configuration:\n"
+           "  -tx_freq Hz                TX frequency (default: %" PRId64 ")\n"
+           "  -tx_gain dB                TX gain (default: %d, negative = attenuation)\n"
+           "\n"
+           "Shared Memory:\n"
+           "  -rx_shm_path path          RX SHM path (default: /dev/shm/sdr_ringbuffer)\n"
+           "  -tx_shm_path path          TX SHM path (default: /dev/shm/sdr_tx_ringbuffer)\n"
+           "  -rx_buffer_time seconds    RX buffer duration (default: 3.0)\n"
+           "  -tx_buffer_time seconds    TX buffer duration (default: 3.0)\n"
+           "  -num_samples N             Samples to stream (default: 0 = infinite)\n",
+           DEFAULT_SAMPLERATE,
+           DEFAULT_BANDWIDTH,
+           DEFAULT_RX_FREQ,
+           DEFAULT_RX_GAIN,
+           DEFAULT_TX_FREQ,
+           DEFAULT_TX_GAIN);
+    exit(0);
+}
+
+static struct option long_options[] = {
+    {"help",           no_argument,       NULL, 'h'},
+    {"samplerate",     required_argument, NULL, 's'},
+    {"bandwidth",      required_argument, NULL, 'b'},
+    {"rx_freq",        required_argument, NULL, 'R'},
+    {"rx_gain",        required_argument, NULL, 'G'},
+    {"agc_mode",       required_argument, NULL, 'a'},
+    {"tx_freq",        required_argument, NULL, 'T'},
+    {"tx_gain",        required_argument, NULL, 'A'},
+    {"channels",       required_argument, NULL, 'C'},
+    {"rx_shm_path",    required_argument, NULL, 'r'},
+    {"tx_shm_path",    required_argument, NULL, 't'},
+    {"rx_buffer_time", required_argument, NULL, 'B'},
+    {"tx_buffer_time", required_argument, NULL, 'D'},
+    {"num_samples",    required_argument, NULL, 'n'},
+    {NULL, 0, NULL, 0}
+};
+
+int main(int argc, char **argv)
+{
+    /* Defaults */
+    uint32_t samplerate  = DEFAULT_SAMPLERATE;
+    int64_t  bandwidth   = DEFAULT_BANDWIDTH;
+    int64_t  rx_freq     = DEFAULT_RX_FREQ;
+    int64_t  rx_gain     = DEFAULT_RX_GAIN;
+    uint8_t  agc_mode    = RF_GAIN_MGC;
+    int64_t  tx_freq     = DEFAULT_TX_FREQ;
+    int64_t  tx_gain     = DEFAULT_TX_GAIN;
+    uint8_t  num_channels = 1;
+    uint8_t  quiet       = 0;
+    uint8_t  wait_for_tx_shm = 0;
+
+    const char *rx_shm_path = "/dev/shm/sdr_ringbuffer";
+    const char *tx_shm_path = "/dev/shm/sdr_tx_ringbuffer";
+    double   rx_buffer_time = 3.0;
+    double   tx_buffer_time = 3.0;
+    size_t   num_samples    = 0;
+
+    m2sdr_install_signal_handlers();
+
+    int c;
+    while ((c = getopt_long_only(argc, argv, "hc:qw", long_options, NULL)) != -1) {
+        switch (c) {
+        case 'h':
+            print_help();
+            break;
+        case 'c':
+            g_device_num = atoi(optarg);
+            break;
+        case 'q':
+            quiet = 1;
+            break;
+        case 'w':
+            wait_for_tx_shm = 1;
+            break;
+        case 's':
+            samplerate = (uint32_t)strtod(optarg, NULL);
+            break;
+        case 'b':
+            bandwidth = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'R':
+            rx_freq = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'G':
+            rx_gain = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'a':
+            agc_mode = parse_agc_mode(optarg);
+            break;
+        case 'T':
+            tx_freq = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'A':
+            tx_gain = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'C':
+            num_channels = (uint8_t)atoi(optarg);
+            if (num_channels != 1 && num_channels != 2) {
+                fprintf(stderr, "Channels must be 1 or 2\n");
+                return 1;
+            }
+            break;
+        case 'r':
+            rx_shm_path = optarg;
+            break;
+        case 't':
+            tx_shm_path = optarg;
+            break;
+        case 'B':
+            rx_buffer_time = strtod(optarg, NULL);
+            break;
+        case 'D':
+            tx_buffer_time = strtod(optarg, NULL);
+            break;
+        case 'n':
+            num_samples = (size_t)strtoull(optarg, NULL, 0);
+            break;
+        default:
+            return 1;
+        }
+    }
+
+    snprintf(g_device_path, sizeof(g_device_path), "/dev/m2sdr%d", g_device_num);
+
+    printf("M2SDR Full-Duplex Stream\n");
+    printf("========================\n");
+    printf("Device: %s\n", g_device_path);
+    printf("Sample rate: %.2f MHz\n", samplerate / 1e6);
+    printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);
+    printf("Channels: %d (%s)\n", num_channels, num_channels == 2 ? "2T2R" : "1T1R");
+    printf("RX: freq=%.2f MHz, gain=%ld dB, AGC=%s\n",
+           rx_freq / 1e6, rx_gain, agc_mode_str(agc_mode));
+    printf("TX: freq=%.2f MHz, gain=%ld dB\n", tx_freq / 1e6, tx_gain);
+    printf("RX SHM: %s (%.1fs buffer)\n", rx_shm_path, rx_buffer_time);
+    printf("TX SHM: %s (%.1fs buffer)\n", tx_shm_path, tx_buffer_time);
+    if (num_samples > 0)
+        printf("Samples: %zu\n", num_samples);
+    else
+        printf("Samples: infinite (Ctrl+C to stop)\n");
+    printf("\n");
+
+    /* Open device for RF init */
+    int fd = open(g_device_path, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open %s\n", g_device_path);
+        return 1;
+    }
+
+    /* Initialize RF (combined RX + TX) */
+    rf_init(fd, samplerate, bandwidth, rx_freq, rx_gain, agc_mode,
+            tx_freq, tx_gain, num_channels);
+    close(fd);
+
+    /* Create RX shared memory (this process is the RX producer) */
+    shm_buffer_t *rx_shm = shm_create(rx_shm_path, DMA_BUFFER_SIZE, num_channels,
+                                        rx_buffer_time, samplerate);
+    if (!rx_shm) {
+        fprintf(stderr, "Failed to create RX shared memory\n");
+        return 1;
+    }
+
+    /* Open or create TX shared memory (this process is the TX consumer) */
+    shm_buffer_t *tx_shm = NULL;
+
+    if (wait_for_tx_shm) {
+        printf("Waiting for TX shared memory at %s...\n", tx_shm_path);
+        while (!tx_shm && g_keep_running) {
+            tx_shm = shm_open_existing(tx_shm_path);
+            if (!tx_shm)
+                sleep(1);
+        }
+        if (!g_keep_running) {
+            printf("Interrupted while waiting.\n");
+            shm_destroy(rx_shm);
+            return 1;
+        }
+    } else {
+        tx_shm = shm_open_existing(tx_shm_path);
+        if (!tx_shm) {
+            printf("Creating new TX shared memory...\n");
+            tx_shm = shm_create(tx_shm_path, DMA_BUFFER_SIZE, num_channels,
+                                 tx_buffer_time, samplerate);
+        }
+    }
+
+    if (!tx_shm) {
+        fprintf(stderr, "Failed to open/create TX shared memory\n");
+        shm_destroy(rx_shm);
+        return 1;
+    }
+
+    /* Run full-duplex streaming */
+    stream_duplex(rx_shm, tx_shm, num_samples, quiet);
+
+    /* Cleanup */
+    shm_destroy(rx_shm);
+    shm_destroy(tx_shm);
+
+    return 0;
+}

--- a/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
@@ -398,6 +398,10 @@ static void m2sdr_rf_init(
      * performs a full AD9361 reconfiguration including calibrations.
      * Without this, TX signal quality may be degraded. */
     printf("Configuring AD9361 channel mode...\n");
+
+    /* PHY control register must be set right before ad9361_set_no_ch_mode() */
+    m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, num_channels == 1 ? 1 : 0);
+
     ad9361_phy->pdata->rx2tx2 = (num_channels == 2);
     if (num_channels == 1) {
         ad9361_phy->pdata->rx1tx1_mode_use_tx_num = TX_1;

--- a/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
@@ -386,11 +386,13 @@ static void m2sdr_rf_init(
         m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 1);  /* 1T1R */
     }
 
-    default_init_param.reference_clk_rate = 40000000;  /* 40 MHz */
-    default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
-    default_init_param.gpio_sync          = -1;
-    default_init_param.gpio_cal_sw1       = -1;
-    default_init_param.gpio_cal_sw2       = -1;
+    default_init_param.reference_clk_rate          = 40000000;  /* 40 MHz */
+    default_init_param.gpio_resetb                 = AD9361_GPIO_RESET_PIN;
+    default_init_param.gpio_sync                   = -1;
+    default_init_param.gpio_cal_sw1                = -1;
+    default_init_param.gpio_cal_sw2                = -1;
+    default_init_param.tx_synthesizer_frequency_hz = tx_freq;
+    default_init_param.rf_tx_bandwidth_hz          = bandwidth;
 
     ad9361_init(&ad9361_phy, &default_init_param, 1);
 

--- a/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
+++ b/litex_m2sdr/software/user/m2sdr_tx_stream_shm.c
@@ -1,0 +1,745 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * M2SDR Play from Shared Memory Utility.
+ *
+ * This utility configures the AD9361 RF frontend and streams TX data
+ * from a shared memory ring buffer. Designed to run as a separate
+ * process from Julia signal processing to avoid GC pause interference.
+ *
+ * Data Format:
+ *   - Each slot contains sample data to be transmitted
+ *   - Samples are Complex{Int16} (4 bytes per sample per channel)
+ *   - Multi-channel data is interleaved: I0,Q0,I1,Q1,I0,Q0,I1,Q1,...
+ *
+ * Shared Memory Header Layout (64 bytes):
+ *   Bytes 0-7:   write_index (uint64_t) - next slot to write (Julia producer)
+ *   Bytes 8-15:  read_index (uint64_t) - next slot to read (C consumer)
+ *   Bytes 16-23: chunks_written (uint64_t) - total chunks written by producer
+ *   Bytes 24-31: chunks_read (uint64_t) - total chunks read by consumer
+ *   Bytes 32-35: chunk_size (uint32_t) - samples per chunk (per channel)
+ *   Bytes 36-39: sample_size (uint32_t) - bytes per sample (4 for Complex{Int16})
+ *   Bytes 40-43: num_slots (uint32_t) - number of slots in buffer
+ *   Bytes 44-45: num_channels (uint16_t) - number of channels (1 or 2)
+ *   Bytes 46-47: flags (uint16_t) - bit 0 = writer_done
+ *   Bytes 48-55: underflow_count (uint64_t) - number of TX underflows
+ *   Bytes 56-63: padding
+ *
+ * Slot Layout (no per-chunk header for TX - simpler than RX):
+ *   [sample data...]
+ *
+ * This file is part of LiteX-M2SDR project.
+ *
+ * Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "ad9361/platform.h"
+#include "ad9361/ad9361.h"
+#include "ad9361/ad9361_api.h"
+
+#include "m2sdr_config.h"
+
+#include "liblitepcie.h"
+#include "libm2sdr.h"
+
+/* Shared memory header offsets (0-indexed for C) */
+#define SHM_HEADER_SIZE         64
+#define OFFSET_WRITE_INDEX      0
+#define OFFSET_READ_INDEX       8
+#define OFFSET_CHUNKS_WRITTEN   16
+#define OFFSET_CHUNKS_READ      24
+#define OFFSET_CHUNK_SIZE       32
+#define OFFSET_SAMPLE_SIZE      36
+#define OFFSET_NUM_SLOTS        40
+#define OFFSET_NUM_CHANNELS     44
+#define OFFSET_FLAGS            46
+#define OFFSET_UNDERFLOW_COUNT  48
+#define OFFSET_BUFFER_EMPTY_COUNT 56  /* TX: count of times SHM buffer was empty */
+
+/* Flag bits */
+#define FLAG_WRITER_DONE        1
+
+/* Sample size for Complex{Int16} (real + imag, each int16) */
+#define SAMPLE_SIZE_COMPLEX_INT16 4
+
+/* Variables */
+/*-----------*/
+
+static char m2sdr_device[1024];
+static int m2sdr_device_num = 0;
+
+sig_atomic_t keep_running = 1;
+
+void intHandler(int dummy) {
+    (void)dummy;
+    keep_running = 0;
+}
+
+/* forward (provided in tree elsewhere; used here) */
+extern int64_t get_time_ms(void);
+
+/* AD9361 */
+/*--------*/
+
+#define AD9361_GPIO_RESET_PIN 0
+
+struct ad9361_rf_phy *ad9361_phy;
+
+static void * m2sdr_open(void) {
+    int fd = open(m2sdr_device, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open device %s\n", m2sdr_device);
+        exit(1);
+    }
+    return (void *)(intptr_t)fd;
+}
+
+static void m2sdr_close(void *conn) {
+    close((int)(intptr_t)conn);
+}
+
+int spi_write_then_read(struct spi_device *spi,
+                        const unsigned char *txbuf, unsigned n_tx,
+                        unsigned char *rxbuf, unsigned n_rx)
+{
+    void *conn = m2sdr_open();
+
+    if (n_tx == 2 && n_rx == 1) {
+        rxbuf[0] = m2sdr_ad9361_spi_read(conn, txbuf[0] << 8 | txbuf[1]);
+    } else if (n_tx == 3 && n_rx == 0) {
+        m2sdr_ad9361_spi_write(conn, txbuf[0] << 8 | txbuf[1], txbuf[2]);
+    } else {
+        fprintf(stderr, "Unsupported SPI transfer n_tx=%d n_rx=%d\n", n_tx, n_rx);
+        m2sdr_close(conn);
+        exit(1);
+    }
+
+    m2sdr_close(conn);
+    return 0;
+}
+
+void udelay(unsigned long usecs) { usleep(usecs); }
+void mdelay(unsigned long msecs) { usleep(msecs * 1000); }
+unsigned long msleep_interruptible(unsigned int msecs) { usleep(msecs * 1000); return 0; }
+
+bool gpio_is_valid(int number) {
+    return (number == AD9361_GPIO_RESET_PIN);
+}
+
+void gpio_set_value(unsigned gpio, int value) {
+    (void)gpio; (void)value;
+}
+
+/* Shared Memory Ring Buffer */
+/*---------------------------*/
+
+typedef struct {
+    uint8_t *data;
+    size_t   total_size;
+    uint32_t num_slots;
+    uint32_t chunk_size;      /* samples per chunk (per channel) */
+    uint32_t chunk_bytes;     /* bytes per chunk (all channels) */
+    uint16_t num_channels;
+} shm_ring_buffer_t;
+
+static inline uint64_t shm_get_write_index(shm_ring_buffer_t *shm) {
+    /* Use atomic load with acquire semantics to ensure we see all data written
+     * by the Julia producer before the write_index was updated.
+     * The producer issues a release fence before updating write_index. */
+    return __atomic_load_n((volatile uint64_t *)(shm->data + OFFSET_WRITE_INDEX), __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t shm_get_read_index(shm_ring_buffer_t *shm) {
+    return __atomic_load_n((volatile uint64_t *)(shm->data + OFFSET_READ_INDEX), __ATOMIC_RELAXED);
+}
+
+static inline void shm_set_read_index(shm_ring_buffer_t *shm, uint64_t val) {
+    /* Use atomic store with release semantics to ensure our memcpy from the slot
+     * is complete before the Julia producer sees the updated read_index and
+     * potentially overwrites the slot. */
+    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_READ_INDEX), val, __ATOMIC_RELEASE);
+}
+
+static inline void shm_set_chunks_read(shm_ring_buffer_t *shm, uint64_t val) {
+    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_CHUNKS_READ), val, __ATOMIC_RELAXED);
+}
+
+static inline void shm_set_underflow_count(shm_ring_buffer_t *shm, uint64_t val) {
+    /* Use atomic store so Julia can safely read this counter */
+    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_UNDERFLOW_COUNT), val, __ATOMIC_RELAXED);
+}
+
+static inline void shm_set_buffer_empty_count(shm_ring_buffer_t *shm, uint64_t val) {
+    /* Use atomic store so Julia can safely read this counter */
+    __atomic_store_n((volatile uint64_t *)(shm->data + OFFSET_BUFFER_EMPTY_COUNT), val, __ATOMIC_RELAXED);
+}
+
+static inline uint16_t shm_get_flags(shm_ring_buffer_t *shm) {
+    return *(volatile uint16_t *)(shm->data + OFFSET_FLAGS);
+}
+
+static inline bool shm_is_writer_done(shm_ring_buffer_t *shm) {
+    return (shm_get_flags(shm) & FLAG_WRITER_DONE) != 0;
+}
+
+static inline bool shm_can_read(shm_ring_buffer_t *shm) {
+    uint64_t write_idx = shm_get_write_index(shm);
+    uint64_t read_idx = shm_get_read_index(shm);
+    return read_idx < write_idx;
+}
+
+/* Get pointer to sample data for a slot */
+static inline uint8_t *shm_slot_ptr(shm_ring_buffer_t *shm, uint64_t slot) {
+    size_t offset = SHM_HEADER_SIZE + (slot % shm->num_slots) * shm->chunk_bytes;
+    return shm->data + offset;
+}
+
+/* Open existing shared memory ring buffer created by Julia producer */
+static shm_ring_buffer_t *shm_ringbuf_open(const char *path)
+{
+    shm_ring_buffer_t *shm = calloc(1, sizeof(shm_ring_buffer_t));
+    if (!shm) {
+        perror("calloc");
+        return NULL;
+    }
+
+    /* Open existing shared memory file */
+    int fd = open(path, O_RDWR);
+    if (fd < 0) {
+        perror(path);
+        free(shm);
+        return NULL;
+    }
+
+    /* Get file size */
+    struct stat st;
+    if (fstat(fd, &st) < 0) {
+        perror("fstat");
+        close(fd);
+        free(shm);
+        return NULL;
+    }
+    shm->total_size = st.st_size;
+
+    /* Memory map the file */
+    shm->data = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (shm->data == MAP_FAILED) {
+        perror("mmap");
+        free(shm);
+        return NULL;
+    }
+
+    /* Read header metadata */
+    shm->chunk_size = *(uint32_t *)(shm->data + OFFSET_CHUNK_SIZE);
+    uint32_t sample_size = *(uint32_t *)(shm->data + OFFSET_SAMPLE_SIZE);
+    shm->num_slots = *(uint32_t *)(shm->data + OFFSET_NUM_SLOTS);
+    shm->num_channels = *(uint16_t *)(shm->data + OFFSET_NUM_CHANNELS);
+    shm->chunk_bytes = shm->chunk_size * sample_size * shm->num_channels;
+
+    printf("Opened shared memory ring buffer:\n");
+    printf("  Path: %s\n", path);
+    printf("  Chunk size: %u samples/channel (%u bytes)\n", shm->chunk_size, shm->chunk_bytes);
+    printf("  Num channels: %u\n", shm->num_channels);
+    printf("  Num slots: %u\n", shm->num_slots);
+    printf("  Sample size: %u bytes\n", sample_size);
+    printf("  Total size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
+
+    return shm;
+}
+
+/* Create shared memory ring buffer (for when Julia hasn't created it yet) */
+static shm_ring_buffer_t *shm_ringbuf_create(const char *path, uint32_t chunk_size,
+                                      uint16_t num_channels, double buffer_seconds,
+                                      uint32_t sample_rate)
+{
+    shm_ring_buffer_t *shm = calloc(1, sizeof(shm_ring_buffer_t));
+    if (!shm) {
+        perror("calloc");
+        return NULL;
+    }
+
+    shm->num_channels = num_channels;
+    shm->chunk_size = chunk_size;
+    shm->chunk_bytes = chunk_size * SAMPLE_SIZE_COMPLEX_INT16 * num_channels;
+
+    /* Calculate number of slots for requested buffer time */
+    uint64_t bytes_per_second = (uint64_t)sample_rate * SAMPLE_SIZE_COMPLEX_INT16 * num_channels;
+    uint64_t total_buffer_bytes = (uint64_t)(bytes_per_second * buffer_seconds);
+    shm->num_slots = (total_buffer_bytes + shm->chunk_bytes - 1) / shm->chunk_bytes;
+    if (shm->num_slots < 16) shm->num_slots = 16;  /* minimum slots */
+
+    shm->total_size = SHM_HEADER_SIZE + (size_t)shm->num_slots * shm->chunk_bytes;
+
+    /* Create shared memory file */
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0) {
+        perror(path);
+        free(shm);
+        return NULL;
+    }
+
+    if (ftruncate(fd, shm->total_size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        free(shm);
+        return NULL;
+    }
+
+    shm->data = mmap(NULL, shm->total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (shm->data == MAP_FAILED) {
+        perror("mmap");
+        free(shm);
+        return NULL;
+    }
+
+    /* Initialize header */
+    memset(shm->data, 0, SHM_HEADER_SIZE);
+    *(uint32_t *)(shm->data + OFFSET_CHUNK_SIZE) = shm->chunk_size;
+    *(uint32_t *)(shm->data + OFFSET_SAMPLE_SIZE) = SAMPLE_SIZE_COMPLEX_INT16;
+    *(uint32_t *)(shm->data + OFFSET_NUM_SLOTS) = shm->num_slots;
+    *(uint16_t *)(shm->data + OFFSET_NUM_CHANNELS) = num_channels;
+
+    printf("Created shared memory ring buffer:\n");
+    printf("  Path: %s\n", path);
+    printf("  Chunk size: %u samples/channel (%u bytes)\n", chunk_size, shm->chunk_bytes);
+    printf("  Num channels: %u\n", num_channels);
+    printf("  Num slots: %u\n", shm->num_slots);
+    printf("  Buffer size: %.1f MB\n", shm->total_size / 1024.0 / 1024.0);
+    printf("  Buffer time: %.2f seconds\n",
+           (double)shm->num_slots * shm->chunk_size / sample_rate);
+
+    return shm;
+}
+
+static void shm_ringbuf_destroy(shm_ring_buffer_t *shm) {
+    if (shm) {
+        if (shm->data && shm->data != MAP_FAILED) {
+            munmap(shm->data, shm->total_size);
+        }
+        free(shm);
+    }
+}
+
+/* RF Initialization */
+/*-------------------*/
+
+static void m2sdr_rf_init(
+    uint32_t samplerate,
+    int64_t  bandwidth,
+    int64_t  tx_freq,
+    int64_t  tx_gain,
+    uint8_t  num_channels
+) {
+    void *conn = m2sdr_open();
+
+#ifdef CSR_SI5351_BASE
+    /* Initialize SI5351 Clocking with internal XO */
+    printf("Initializing SI5351 Clocking...\n");
+    m2sdr_writel(conn, CSR_SI5351_CONTROL_ADDR,
+        SI5351B_VERSION * (1 << CSR_SI5351_CONTROL_VERSION_OFFSET));
+    m2sdr_si5351_i2c_config(conn, SI5351_I2C_ADDR,
+        si5351_xo_40m_config,
+        sizeof(si5351_xo_40m_config)/sizeof(si5351_xo_40m_config[0]));
+#endif
+
+    /* Power-up AD9361 */
+    printf("Powering up AD9361...\n");
+    m2sdr_writel(conn, CSR_AD9361_CONFIG_ADDR, 0b11);
+
+    /* Initialize AD9361 SPI */
+    printf("Initializing AD9361 SPI...\n");
+    m2sdr_ad9361_spi_init(conn, 1);
+
+    /* Initialize AD9361 RFIC */
+    if (num_channels == 2) {
+        printf("Initializing AD9361 RFIC (2T2R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 1;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 1;
+        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 0);  /* 2T2R */
+    } else {
+        printf("Initializing AD9361 RFIC (1T1R mode)...\n");
+        default_init_param.two_rx_two_tx_mode_enable     = 0;
+        default_init_param.one_rx_one_tx_mode_use_rx_num = 0;
+        default_init_param.one_rx_one_tx_mode_use_tx_num = 0;
+        default_init_param.two_t_two_r_timing_enable     = 0;
+        m2sdr_writel(conn, CSR_AD9361_PHY_CONTROL_ADDR, 1);  /* 1T1R */
+    }
+
+    default_init_param.reference_clk_rate = 40000000;  /* 40 MHz */
+    default_init_param.gpio_resetb        = AD9361_GPIO_RESET_PIN;
+    default_init_param.gpio_sync          = -1;
+    default_init_param.gpio_cal_sw1       = -1;
+    default_init_param.gpio_cal_sw2       = -1;
+
+    ad9361_init(&ad9361_phy, &default_init_param, 1);
+
+    /* Configure AD9361 Samplerate */
+    printf("Setting TX Samplerate to %.2f MSPS.\n", samplerate/1e6);
+    ad9361_set_tx_sampling_freq(ad9361_phy, samplerate);
+
+    /* Configure AD9361 TX Bandwidth */
+    printf("Setting TX Bandwidth to %.2f MHz.\n", bandwidth/1e6);
+    ad9361_set_tx_rf_bandwidth(ad9361_phy, bandwidth);
+
+    /* Configure AD9361 TX Frequency */
+    printf("Setting TX LO Freq to %.2f MHz.\n", tx_freq/1e6);
+    ad9361_set_tx_lo_freq(ad9361_phy, tx_freq);
+
+    /* Configure AD9361 TX FIR */
+    ad9361_set_tx_fir_config(ad9361_phy, tx_fir_config);
+
+    /* Configure AD9361 TX Attenuation (same for both channels)
+     * Note: tx_gain is negative dB attenuation (e.g., -10 means 10dB attenuation)
+     */
+    int32_t attenuation_mdb = (int32_t)(-tx_gain * 1000);  /* Convert to milli-dB */
+    printf("Setting TX Attenuation to %ld dB (%" PRId32 " mdB).\n", -tx_gain, attenuation_mdb);
+    ad9361_set_tx_attenuation(ad9361_phy, 0, attenuation_mdb);
+    if (num_channels == 2) {
+        ad9361_set_tx_attenuation(ad9361_phy, 1, attenuation_mdb);
+    }
+
+    /* 16-bit mode (samples in 16-bit words) */
+    m2sdr_writel(conn, CSR_AD9361_BITMODE_ADDR, 0);
+
+    m2sdr_close(conn);
+}
+
+/* Play from Shared Memory */
+/*-------------------------*/
+
+static void m2sdr_play_from_shm(
+    const char *device_name,
+    shm_ring_buffer_t *shm,
+    size_t num_samples,  /* 0 for infinite */
+    uint8_t quiet
+) {
+    static struct litepcie_dma_ctrl dma = {.use_reader = 1};
+
+    int i = 0;
+    size_t samples_transmitted = 0;
+    int64_t last_time;
+    int64_t reader_sw_count_last = 0;
+    uint64_t chunks_read = 0;
+    uint64_t underflow_count = 0;
+    uint64_t buffer_empty_count = 0;
+
+    /* Samples per DMA buffer (accounting for all channels) */
+    size_t samples_per_dma = DMA_BUFFER_SIZE / (SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels);
+
+    /* Initialize DMA */
+    if (litepcie_dma_init(&dma, device_name, 0))  /* zero_copy = 0 */
+        exit(1);
+    dma.reader_enable = 1;
+
+    /* Crossbar Mux: select PCIe streaming for TX */
+    m2sdr_writel(dma.fds.fd, CSR_CROSSBAR_MUX_SEL_ADDR, 0);
+
+    printf("Starting DMA play from shared memory...\n");
+    printf("  DMA buffer size: %d bytes (%zu samples/channel)\n",
+           DMA_BUFFER_SIZE, samples_per_dma);
+    printf("  SHM chunk size: %u bytes (%u samples/channel)\n",
+           shm->chunk_bytes, shm->chunk_size);
+
+    /* Verify chunk sizes match */
+    if (shm->chunk_bytes != DMA_BUFFER_SIZE) {
+        fprintf(stderr, "Warning: SHM chunk size (%u) != DMA buffer size (%d)\n",
+                shm->chunk_bytes, DMA_BUFFER_SIZE);
+        fprintf(stderr, "         Data will be copied with potential mismatch!\n");
+    }
+
+    last_time = get_time_ms();
+
+    for (;;) {
+        if (!keep_running)
+            break;
+
+        if (num_samples > 0 && samples_transmitted >= num_samples)
+            break;
+
+        /* Update DMA status */
+        litepcie_dma_process(&dma);
+
+        /* Detect DMA underflow */
+        if (dma.reader_sw_count - dma.reader_hw_count < 0) {
+            underflow_count++;
+            shm_set_underflow_count(shm, underflow_count);
+            if (!quiet) {
+                fprintf(stderr, "\rUNDERFLOW #%" PRIu64 "\n", underflow_count);
+            }
+        }
+
+        /* Write to DMA from shared memory */
+        while (1) {
+            /* Get DMA write buffer */
+            char *buf_wr = litepcie_dma_next_write_buffer(&dma);
+            if (!buf_wr)
+                break;
+
+            /* Check if data available in shared memory */
+            if (!shm_can_read(shm)) {
+                /* Check if producer is done */
+                if (shm_is_writer_done(shm)) {
+                    printf("Producer signaled done.\n");
+                    keep_running = 0;
+                    break;
+                }
+                /* No data yet - send zeros to maintain continuous TX.
+                 * This causes SNR fluctuations but preserves code phase for CDMA tracking.
+                 * Track the count so Julia can monitor buffer health. */
+                buffer_empty_count++;
+                shm_set_buffer_empty_count(shm, buffer_empty_count);
+                memset(buf_wr, 0, DMA_BUFFER_SIZE);
+            } else {
+                /* Copy data from shared memory to DMA buffer */
+                uint64_t read_idx = shm_get_read_index(shm);
+                uint8_t *src = shm_slot_ptr(shm, read_idx);
+
+                /* Handle size mismatch: copy min of both sizes */
+                size_t copy_size = (shm->chunk_bytes < DMA_BUFFER_SIZE) ?
+                                    shm->chunk_bytes : DMA_BUFFER_SIZE;
+                memcpy(buf_wr, src, copy_size);
+
+                /* Zero-pad if SHM chunk is smaller than DMA buffer */
+                if (copy_size < DMA_BUFFER_SIZE) {
+                    memset(buf_wr + copy_size, 0, DMA_BUFFER_SIZE - copy_size);
+                }
+
+                /* Update read index */
+                chunks_read++;
+                samples_transmitted += shm->chunk_size;
+                shm_set_read_index(shm, read_idx + 1);
+                shm_set_chunks_read(shm, chunks_read);
+            }
+        }
+
+        /* Statistics every 200ms */
+        int64_t duration = get_time_ms() - last_time;
+        if (!quiet && duration > 200) {
+            double speed = (double)(dma.reader_sw_count - reader_sw_count_last) * DMA_BUFFER_SIZE * 8 / ((double)duration * 1e6);
+            uint64_t size_mb = (samples_transmitted * SAMPLE_SIZE_COMPLEX_INT16 * shm->num_channels) / 1024 / 1024;
+
+            if (i % 10 == 0) {
+                fprintf(stderr, "\e[1m%10s %12s %9s %10s %12s\e[0m\n",
+                    "SPEED(Gbps)", "CHUNKS", "SIZE(MB)", "UNDERFLOWS", "BUF_EMPTY");
+            }
+            i++;
+
+            fprintf(stderr, "%11.2f %12" PRIu64 " %9" PRIu64 " %10" PRIu64 " %12" PRIu64 "\n",
+                speed, chunks_read, size_mb, underflow_count, buffer_empty_count);
+
+            last_time = get_time_ms();
+            reader_sw_count_last = dma.reader_sw_count;
+        }
+    }
+
+    litepcie_dma_cleanup(&dma);
+
+    printf("\nPlay complete:\n");
+    printf("  Chunks read: %" PRIu64 "\n", chunks_read);
+    printf("  Samples transmitted: %zu\n", samples_transmitted);
+    printf("  Underflows: %" PRIu64 "\n", underflow_count);
+    printf("  Buffer empty events: %" PRIu64 "\n", buffer_empty_count);
+}
+
+/* Help */
+/*------*/
+
+static void help(void)
+{
+    printf("M2SDR Play from Shared Memory Utility\n"
+           "usage: m2sdr_play_shm [options]\n"
+           "\n"
+           "Options:\n"
+           "  -h                     Show this help message and exit.\n"
+           "  -c device_num          Select the device (default: 0).\n"
+           "  -q                     Quiet mode (suppress statistics).\n"
+           "  -w                     Wait for shared memory to be created.\n"
+           "\n"
+           "RF Configuration:\n"
+           "  -samplerate sps        Set RF samplerate in Hz (default: %d).\n"
+           "  -bandwidth bw          Set the RF bandwidth in Hz (default: %d).\n"
+           "  -tx_freq freq          Set the TX frequency in Hz (default: %" PRId64 ").\n"
+           "  -tx_gain gain          Set the TX gain in dB (default: %d, negative = attenuation).\n"
+           "  -channels n            Number of TX channels: 1 or 2 (default: 1).\n"
+           "\n"
+           "Shared Memory Configuration:\n"
+           "  -shm_path path         Shared memory path (default: /dev/shm/sdr_tx_ringbuffer).\n"
+           "  -buffer_time seconds   Ring buffer duration if creating (default: 3.0).\n"
+           "  -num_samples count     Number of samples to transmit (default: 0 = infinite).\n",
+           DEFAULT_SAMPLERATE,
+           DEFAULT_BANDWIDTH,
+           DEFAULT_TX_FREQ,
+           DEFAULT_TX_GAIN);
+    exit(1);
+}
+
+/* Options */
+/*---------*/
+
+static struct option options[] = {
+    { "help",        no_argument,       NULL, 'h' },
+    { "samplerate",  required_argument, NULL, 's' },
+    { "bandwidth",   required_argument, NULL, 'b' },
+    { "tx_freq",     required_argument, NULL, 'f' },
+    { "tx_gain",     required_argument, NULL, 'g' },
+    { "channels",    required_argument, NULL, 'C' },
+    { "shm_path",    required_argument, NULL, 'p' },
+    { "buffer_time", required_argument, NULL, 't' },
+    { "num_samples", required_argument, NULL, 'n' },
+    { NULL },
+};
+
+/* Main */
+/*------*/
+
+int main(int argc, char **argv)
+{
+    int c;
+
+    /* Defaults */
+    uint32_t samplerate  = DEFAULT_SAMPLERATE;
+    int64_t  bandwidth   = DEFAULT_BANDWIDTH;
+    int64_t  tx_freq     = DEFAULT_TX_FREQ;
+    int64_t  tx_gain     = DEFAULT_TX_GAIN;
+    uint8_t  num_channels = 1;
+    uint8_t  quiet       = 0;
+    uint8_t  wait_for_shm = 0;
+
+    const char *shm_path = "/dev/shm/sdr_tx_ringbuffer";
+    double   buffer_time = 3.0;
+    size_t   num_samples = 0;  /* 0 = infinite */
+
+    signal(SIGINT, intHandler);
+
+    /* Parse options */
+    for (;;) {
+        c = getopt_long_only(argc, argv, "hc:qw", options, NULL);
+        if (c == -1)
+            break;
+
+        switch(c) {
+        case 'h':
+            help();
+            break;
+        case 'c':
+            m2sdr_device_num = atoi(optarg);
+            break;
+        case 'q':
+            quiet = 1;
+            break;
+        case 'w':
+            wait_for_shm = 1;
+            break;
+        case 's':
+            samplerate = (uint32_t)strtod(optarg, NULL);
+            break;
+        case 'b':
+            bandwidth = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'f':
+            tx_freq = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'g':
+            tx_gain = (int64_t)strtod(optarg, NULL);
+            break;
+        case 'C':
+            num_channels = (uint8_t)atoi(optarg);
+            if (num_channels != 1 && num_channels != 2) {
+                fprintf(stderr, "Error: channels must be 1 or 2\n");
+                exit(1);
+            }
+            break;
+        case 'p':
+            shm_path = optarg;
+            break;
+        case 't':
+            buffer_time = strtod(optarg, NULL);
+            break;
+        case 'n':
+            num_samples = (size_t)strtoull(optarg, NULL, 0);
+            break;
+        default:
+            exit(1);
+        }
+    }
+
+    /* Select device */
+    snprintf(m2sdr_device, sizeof(m2sdr_device), "/dev/m2sdr%d", m2sdr_device_num);
+
+    printf("M2SDR Play from Shared Memory\n");
+    printf("=============================\n");
+    printf("Device: %s\n", m2sdr_device);
+    printf("Sample rate: %.2f MHz\n", samplerate / 1e6);
+    printf("TX frequency: %.2f MHz\n", tx_freq / 1e6);
+    printf("TX gain: %ld dB\n", tx_gain);
+    printf("Bandwidth: %.2f MHz\n", bandwidth / 1e6);
+    printf("Channels: %d (%s)\n", num_channels, num_channels == 2 ? "2T2R" : "1T1R");
+    printf("Shared memory: %s\n", shm_path);
+    if (num_samples > 0)
+        printf("Num samples: %zu\n", num_samples);
+    else
+        printf("Num samples: infinite (Ctrl+C to stop)\n");
+    printf("\n");
+
+    /* Initialize RF */
+    m2sdr_rf_init(samplerate, bandwidth, tx_freq, tx_gain, num_channels);
+
+    /* Open or create shared memory */
+    shm_ring_buffer_t *shm = NULL;
+
+    if (wait_for_shm) {
+        printf("Waiting for shared memory at %s...\n", shm_path);
+        while (!shm && keep_running) {
+            shm = shm_ringbuf_open(shm_path);
+            if (!shm) {
+                sleep(1);
+            }
+        }
+        if (!keep_running) {
+            printf("Interrupted while waiting.\n");
+            return 1;
+        }
+    } else {
+        /* Try to open existing, otherwise create new */
+        shm = shm_ringbuf_open(shm_path);
+        if (!shm) {
+            printf("Creating new shared memory...\n");
+            /* Use DMA buffer size as chunk size for simplicity */
+            uint32_t chunk_size = DMA_BUFFER_SIZE / (SAMPLE_SIZE_COMPLEX_INT16 * num_channels);
+            shm = shm_ringbuf_create(shm_path, chunk_size, num_channels, buffer_time, samplerate);
+        }
+    }
+
+    if (!shm) {
+        fprintf(stderr, "Failed to open/create shared memory\n");
+        return 1;
+    }
+
+    /* Play from shared memory */
+    m2sdr_play_from_shm(m2sdr_device, shm, num_samples, quiet);
+
+    /* Cleanup */
+    shm_ringbuf_destroy(shm);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add `m2sdr_rx_stream_shm`, `m2sdr_tx_stream_shm`, and `m2sdr_stream_shm` (full-duplex) utilities for high-performance sample streaming between C and GC'd languages (e.g. Julia) via shared memory ring buffers.

## Motivation

When using Julia for SDR signal processing, the garbage collector (GC) can pause execution for several milliseconds. During DMA transfers, these pauses cause buffer overflows/underflows because the application can't keep up with the hardware's data rate.

The standard solution would be to increase the DMA buffer size in the FPGA to tolerate longer pauses. However, this requires rebuilding the FPGA bitstream with Vivado, which is:
- A proprietary Xilinx tool with significant licensing/installation requirements
- A 30-60 minute build process
- Non-trivial to configure correctly

Instead, this PR implements a **shared memory architecture** where:
1. A dedicated C process handles all DMA transfers (immune to Julia's GC)
2. Julia reads/writes samples via a lock-free shared memory ring buffer
3. The ring buffer provides sufficient headroom to absorb GC pauses

This approach works with the existing FPGA bitstream and requires no hardware changes.

## New Files

- **`m2sdr_shm.h`** — Lock-free POSIX shared memory ring buffer (atomic indices, 64-byte cache-line aligned header)
- **`m2sdr_common.h`** — Shared RF initialization, signal handling, and AD9361 configuration extracted from the streaming executables
- **`m2sdr_rx_stream_shm.c`** — RX DMA to shared memory
- **`m2sdr_tx_stream_shm.c`** — Shared memory to TX DMA
- **`m2sdr_stream_shm.c`** — Full-duplex RX+TX on a shared file descriptor with multiplexed poll()

## Key Features

- **AGC mode support** in RX streaming (manual, fast_attack, slow_attack, hybrid)
- **FIR interpolation** for low sample rates (< 2.5 Msps) in TX streaming
- **SoapySDR-matching DMA patterns** for overflow/underflow detection and recovery
- **Atomic operations** for ARM correctness (lock-free producer-consumer)
- **Full-duplex streaming** with shared FD and multiplexed poll() in a single process
- **AD9361 init improvements**: set target frequency/bandwidth in init params to avoid PLL retune, set PHY control register and `ad9361_set_no_ch_mode()` to match SoapySDR `setupStream()` behavior

## Shared Memory Format

- 64-byte header with write/read indices, chunk metadata, and overflow statistics
- 8-byte per-chunk header tracking samples lost before each chunk
- Complex{Int16} samples (4 bytes per sample per channel), interleaved for multi-channel

## Commit Walkthrough

1. **Add shared memory RX/TX streaming utilities** — Initial implementation of `m2sdr_rx_stream_shm` and `m2sdr_tx_stream_shm`
2. **Add `ad9361_set_no_ch_mode()` call** — Match SoapySDR `setupStream()` behavior for correct channel configuration
3. **Set PHY control register before `ad9361_set_no_ch_mode()`** — Ensure PHY is configured before channel mode switch
4. **Add FIR interpolation config for low sample rates in TX** — Enable TX FIR filter for sample rates below 2.5 Msps
5. **Fix CN0 fluctuations in TX shared memory streaming** — Stabilize carrier-to-noise ratio during TX
6. **Add atomic operations to RX shared memory for ARM correctness** — Use `__atomic_load_n`/`__atomic_store_n` for lock-free ring buffer on ARM
7. **Add AGC mode support to `m2sdr_rx_stream_shm`** — Configurable AGC: manual, fast_attack, slow_attack, hybrid
8. **Add SoapySDR-matching DMA initialization** — Align DMA setup with SoapySDR driver patterns
9. **Fix overflow detection during SHM buffer-full wait** — Correct hw_count/sw_count tracking when SHM ring is full
10. **Rewrite RX shared memory streaming to match SoapySDR DMA patterns** — Adopt the same overflow detection and drain/recovery strategy as the SoapySDR driver
11. **Set target frequency/bandwidth in AD9361 init params** — Avoid unnecessary PLL retune after initialization
12. **Extract shared code into reusable headers** — Factor out `m2sdr_common.h` and `m2sdr_shm.h` from the streaming executables
13. **Add SHM streaming binaries to `.gitignore`**
14. **Add full-duplex `m2sdr_stream_shm` executable** — Combined RX+TX streaming in a single process using shared FD