### PR TITLE
Improve `m2sdr_play` / `m2sdr_record` Host-Side Streaming Buffering for Pipe-Driven Runtimes.

### DIFF
--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -56,6 +56,7 @@ EXAMPLES = ../../doc/libm2sdr/example_sync_rx ../../doc/libm2sdr/example_sync_tx
            ../../doc/libm2sdr/example_tone_tx ../../doc/libm2sdr/example_rx_n
 CLI_OBJS = m2sdr_cli.o
 M2SDR_SIGMF_OBJS = lib/m2sdr_sigmf.o lib/m2sdr_json.o
+M2SDR_STREAM_OBJS = lib/m2sdr_host_ring.o
 TEST_PROGS = test_libm2sdr tests/test_m2sdr_sigmf tests/test_sigmf_capture_smoke tests/test_sigmf_info_cli
 
 LIBM2SDR_OBJS = \
@@ -171,11 +172,11 @@ m2sdr_rf: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_rf.o \
 	ad9361/ad9361.o ad9361/ad9361_api.o ad9361/ad9361_conv.o ad9361/util.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm2sdr -llitepcie
 
-m2sdr_play: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a libliteeth/libliteeth.a $(CLI_OBJS) m2sdr_play.o $(M2SDR_SIGMF_OBJS)
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -Llibliteeth -lm -lm2sdr -llitepcie -lliteeth
+m2sdr_play: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a libliteeth/libliteeth.a $(CLI_OBJS) m2sdr_play.o $(M2SDR_SIGMF_OBJS) $(M2SDR_STREAM_OBJS)
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -Llibliteeth -lm -lm2sdr -llitepcie -lliteeth -pthread
 
-m2sdr_record: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a libliteeth/libliteeth.a $(CLI_OBJS) m2sdr_record.o $(M2SDR_SIGMF_OBJS)
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -Llibliteeth -lm -lm2sdr -llitepcie -lliteeth
+m2sdr_record: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a libliteeth/libliteeth.a $(CLI_OBJS) m2sdr_record.o $(M2SDR_SIGMF_OBJS) $(M2SDR_STREAM_OBJS)
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -Llibliteeth -lm -lm2sdr -llitepcie -lliteeth -pthread
 
 m2sdr_sigmf_info: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_sigmf_info.o $(M2SDR_SIGMF_OBJS)
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie
@@ -211,11 +212,11 @@ m2sdr_gen: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_gen.o
 m2sdr_gpio: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_gpio.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie
 
-m2sdr_play: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_play.o $(M2SDR_SIGMF_OBJS)
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie
+m2sdr_play: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_play.o $(M2SDR_SIGMF_OBJS) $(M2SDR_STREAM_OBJS)
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie -pthread
 
-m2sdr_record: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_record.o $(M2SDR_SIGMF_OBJS)
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie
+m2sdr_record: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a $(CLI_OBJS) m2sdr_record.o $(M2SDR_SIGMF_OBJS) $(M2SDR_STREAM_OBJS)
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie -pthread
 
 m2sdr_sigmf_info: liblitepcie/liblitepcie.a libm2sdr/libm2sdr.a m2sdr_sigmf_info.o $(M2SDR_SIGMF_OBJS)
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $^ -Lliblitepcie -Llibm2sdr -lm -lm2sdr -llitepcie

--- a/litex_m2sdr/software/user/README.md
+++ b/litex_m2sdr/software/user/README.md
@@ -183,6 +183,7 @@ Example usage with PPS on GPIO pin 0:
 ### m2sdr_play
 Streams an I/Q samples file to the FPGA’s TX path (DMA TX). Supports piping from stdin with filename as `-`.
 This is the simplest utility to read when you want a file-backed `libm2sdr` TX example.
+For runtime-driven pipelines, it can also stage input through a host-side ring before feeding DMA.
 
 **Usage**:
 ~~~~
@@ -201,13 +202,20 @@ Example usage:
 ./m2sdr_play capture.sigmf-meta 10
 ./m2sdr_play --capture-index 1 capture.sigmf-meta 1
 ./m2sdr_play --capture-index 2 framed_capture.sigmf-meta 0
+./m2sdr_play --host-buffers 64 --prefill 16 - 1 < tx_file.bin
 ~~~~
+
+Useful streaming options:
+- `--host-buffers N`
+- `--prefill N`
+- `--stats-interval MS`
 
 ---
 
 ### m2sdr_record
 Streams samples from the FPGA’s RX path back to a file on the host (DMA RX). Supports piping to stdout with filename as `-`.
 This is the matching `libm2sdr` RX example, including optional timestamp/header handling.
+For pipe-driven workflows, it can decouple DMA RX from file/stdout writes with a host-side ring.
 
 **Usage**:
 ~~~~
@@ -236,6 +244,10 @@ Relevant options:
 - `--annotation-add`
 - `--annotate-ts-jumps`
 - `--ts-jump-threshold-pct`
+- `--host-buffers N`
+- `--drop-oldest`
+- `--drop-newest`
+- `--stats-interval MS`
 
 Example usage:
 ~~~~
@@ -244,9 +256,11 @@ Example usage:
 ./m2sdr_record --sigmf --sample-rate 30720000 --annotation-label burst --annotation-comment "loopback capture" capture 2000000
 ./m2sdr_record --sigmf --sample-rate 30720000 --annotation-label burst-a --annotation-start 0 --annotation-count 8192 --annotation-add --annotation-label burst-b --annotation-start 16384 --annotation-count 8192 capture 2000000
 ./m2sdr_record --sigmf --enable-header --strip-header --annotate-ts-jumps capture 2000000
+./m2sdr_record --host-buffers 64 - 0 | julia my_rx_pipeline.jl
 ~~~~
 
 Current SigMF support is intentionally minimal: it writes a `.sigmf-data` + `.sigmf-meta` pair and expects stripped sample payloads when DMA headers are enabled.
+When `--sigmf` is used, drop policies are intentionally rejected so the metadata always matches the written dataset.
 
 ---
 

--- a/litex_m2sdr/software/user/include/m2sdr_host_ring.h
+++ b/litex_m2sdr/software/user/include/m2sdr_host_ring.h
@@ -1,0 +1,56 @@
+#ifndef M2SDR_HOST_RING_H
+#define M2SDR_HOST_RING_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "m2sdr.h"
+
+enum m2sdr_host_ring_policy {
+    M2SDR_HOST_RING_BLOCK = 0,
+    M2SDR_HOST_RING_DROP_OLDEST,
+    M2SDR_HOST_RING_DROP_NEWEST,
+};
+
+struct m2sdr_host_ring {
+    uint8_t *storage;
+    size_t *lengths;
+    struct m2sdr_metadata *metadata;
+    uint8_t *has_metadata;
+    size_t slot_size;
+    unsigned capacity;
+    unsigned head;
+    unsigned tail;
+    unsigned count;
+    unsigned high_watermark;
+    uint64_t dropped;
+    bool writer_closed;
+    bool stop;
+    void *sync;
+};
+
+int m2sdr_host_ring_init(struct m2sdr_host_ring *ring, unsigned capacity, size_t slot_size);
+void m2sdr_host_ring_destroy(struct m2sdr_host_ring *ring);
+void m2sdr_host_ring_close_writer(struct m2sdr_host_ring *ring);
+void m2sdr_host_ring_stop(struct m2sdr_host_ring *ring);
+
+int m2sdr_host_ring_push(struct m2sdr_host_ring *ring,
+                         const void *data,
+                         size_t len,
+                         const struct m2sdr_metadata *meta,
+                         bool has_meta,
+                         enum m2sdr_host_ring_policy policy);
+
+int m2sdr_host_ring_pop(struct m2sdr_host_ring *ring,
+                        void *dst,
+                        size_t *len,
+                        struct m2sdr_metadata *meta,
+                        bool *has_meta);
+
+unsigned m2sdr_host_ring_count(struct m2sdr_host_ring *ring);
+unsigned m2sdr_host_ring_high_watermark(struct m2sdr_host_ring *ring);
+uint64_t m2sdr_host_ring_dropped(struct m2sdr_host_ring *ring);
+bool m2sdr_host_ring_writer_closed(struct m2sdr_host_ring *ring);
+
+#endif

--- a/litex_m2sdr/software/user/lib/m2sdr_host_ring.c
+++ b/litex_m2sdr/software/user/lib/m2sdr_host_ring.c
@@ -1,0 +1,248 @@
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "m2sdr_host_ring.h"
+
+struct m2sdr_host_ring_sync {
+    pthread_mutex_t mutex;
+    pthread_cond_t not_empty;
+    pthread_cond_t not_full;
+};
+
+static struct m2sdr_host_ring_sync *m2sdr_host_ring_sync(struct m2sdr_host_ring *ring)
+{
+    return (struct m2sdr_host_ring_sync *)ring->sync;
+}
+
+int m2sdr_host_ring_init(struct m2sdr_host_ring *ring, unsigned capacity, size_t slot_size)
+{
+    struct m2sdr_host_ring_sync *sync;
+
+    if (!ring || capacity == 0 || slot_size == 0)
+        return -1;
+
+    memset(ring, 0, sizeof(*ring));
+    ring->storage = calloc(capacity, slot_size);
+    ring->lengths = calloc(capacity, sizeof(*ring->lengths));
+    ring->metadata = calloc(capacity, sizeof(*ring->metadata));
+    ring->has_metadata = calloc(capacity, sizeof(*ring->has_metadata));
+    sync = calloc(1, sizeof(*sync));
+    if (!ring->storage || !ring->lengths || !ring->metadata || !ring->has_metadata || !sync) {
+        free(ring->storage);
+        free(ring->lengths);
+        free(ring->metadata);
+        free(ring->has_metadata);
+        free(sync);
+        memset(ring, 0, sizeof(*ring));
+        return -1;
+    }
+
+    pthread_mutex_init(&sync->mutex, NULL);
+    pthread_cond_init(&sync->not_empty, NULL);
+    pthread_cond_init(&sync->not_full, NULL);
+
+    ring->slot_size = slot_size;
+    ring->capacity = capacity;
+    ring->sync = sync;
+    return 0;
+}
+
+void m2sdr_host_ring_destroy(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+
+    if (!ring || !ring->sync)
+        return;
+
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_destroy(&sync->mutex);
+    pthread_cond_destroy(&sync->not_empty);
+    pthread_cond_destroy(&sync->not_full);
+    free(sync);
+    free(ring->storage);
+    free(ring->lengths);
+    free(ring->metadata);
+    free(ring->has_metadata);
+    memset(ring, 0, sizeof(*ring));
+}
+
+void m2sdr_host_ring_close_writer(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+
+    if (!ring || !ring->sync)
+        return;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    ring->writer_closed = true;
+    pthread_cond_broadcast(&sync->not_empty);
+    pthread_mutex_unlock(&sync->mutex);
+}
+
+void m2sdr_host_ring_stop(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+
+    if (!ring || !ring->sync)
+        return;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    ring->stop = true;
+    pthread_cond_broadcast(&sync->not_empty);
+    pthread_cond_broadcast(&sync->not_full);
+    pthread_mutex_unlock(&sync->mutex);
+}
+
+int m2sdr_host_ring_push(struct m2sdr_host_ring *ring,
+                         const void *data,
+                         size_t len,
+                         const struct m2sdr_metadata *meta,
+                         bool has_meta,
+                         enum m2sdr_host_ring_policy policy)
+{
+    struct m2sdr_host_ring_sync *sync;
+    unsigned idx;
+
+    if (!ring || !ring->sync || !data || len > ring->slot_size)
+        return -1;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+
+    while (!ring->stop && ring->count == ring->capacity && policy == M2SDR_HOST_RING_BLOCK)
+        pthread_cond_wait(&sync->not_full, &sync->mutex);
+    if (ring->stop) {
+        pthread_mutex_unlock(&sync->mutex);
+        return -1;
+    }
+
+    if (ring->count == ring->capacity) {
+        if (policy == M2SDR_HOST_RING_DROP_NEWEST) {
+            ring->dropped++;
+            pthread_mutex_unlock(&sync->mutex);
+            return 1;
+        }
+        if (policy == M2SDR_HOST_RING_DROP_OLDEST) {
+            ring->tail = (ring->tail + 1) % ring->capacity;
+            ring->count--;
+            ring->dropped++;
+        }
+    }
+
+    idx = ring->head;
+    memcpy(ring->storage + ((size_t)idx * ring->slot_size), data, len);
+    ring->lengths[idx] = len;
+    if (has_meta && meta) {
+        ring->metadata[idx] = *meta;
+        ring->has_metadata[idx] = 1;
+    } else {
+        memset(&ring->metadata[idx], 0, sizeof(ring->metadata[idx]));
+        ring->has_metadata[idx] = 0;
+    }
+    ring->head = (ring->head + 1) % ring->capacity;
+    ring->count++;
+    if (ring->count > ring->high_watermark)
+        ring->high_watermark = ring->count;
+
+    pthread_cond_signal(&sync->not_empty);
+    pthread_mutex_unlock(&sync->mutex);
+    return 0;
+}
+
+int m2sdr_host_ring_pop(struct m2sdr_host_ring *ring,
+                        void *dst,
+                        size_t *len,
+                        struct m2sdr_metadata *meta,
+                        bool *has_meta)
+{
+    struct m2sdr_host_ring_sync *sync;
+    unsigned idx;
+    size_t slot_len;
+
+    if (!ring || !ring->sync || !dst || !len)
+        return -1;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+
+    while (!ring->stop && ring->count == 0 && !ring->writer_closed)
+        pthread_cond_wait(&sync->not_empty, &sync->mutex);
+    if (ring->stop) {
+        pthread_mutex_unlock(&sync->mutex);
+        return -1;
+    }
+    if (ring->count == 0 && ring->writer_closed) {
+        pthread_mutex_unlock(&sync->mutex);
+        return 1;
+    }
+
+    idx = ring->tail;
+    slot_len = ring->lengths[idx];
+    memcpy(dst, ring->storage + ((size_t)idx * ring->slot_size), slot_len);
+    *len = slot_len;
+    if (has_meta)
+        *has_meta = ring->has_metadata[idx] ? true : false;
+    if (meta && ring->has_metadata[idx])
+        *meta = ring->metadata[idx];
+    ring->tail = (ring->tail + 1) % ring->capacity;
+    ring->count--;
+
+    pthread_cond_signal(&sync->not_full);
+    pthread_mutex_unlock(&sync->mutex);
+    return 0;
+}
+
+unsigned m2sdr_host_ring_count(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+    unsigned count = 0;
+
+    if (!ring || !ring->sync)
+        return 0;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    count = ring->count;
+    pthread_mutex_unlock(&sync->mutex);
+    return count;
+}
+
+unsigned m2sdr_host_ring_high_watermark(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+    unsigned high = 0;
+
+    if (!ring || !ring->sync)
+        return 0;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    high = ring->high_watermark;
+    pthread_mutex_unlock(&sync->mutex);
+    return high;
+}
+
+uint64_t m2sdr_host_ring_dropped(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+    uint64_t dropped = 0;
+
+    if (!ring || !ring->sync)
+        return 0;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    dropped = ring->dropped;
+    pthread_mutex_unlock(&sync->mutex);
+    return dropped;
+}
+
+bool m2sdr_host_ring_writer_closed(struct m2sdr_host_ring *ring)
+{
+    struct m2sdr_host_ring_sync *sync;
+    bool closed = false;
+
+    if (!ring || !ring->sync)
+        return true;
+    sync = m2sdr_host_ring_sync(ring);
+    pthread_mutex_lock(&sync->mutex);
+    closed = ring->writer_closed;
+    pthread_mutex_unlock(&sync->mutex);
+    return closed;
+}

--- a/litex_m2sdr/software/user/m2sdr_play.c
+++ b/litex_m2sdr/software/user/m2sdr_play.c
@@ -16,9 +16,12 @@
 #include <signal.h>
 #include <time.h>
 #include <getopt.h>
+#include <stdbool.h>
+#include <pthread.h>
 
 #include "m2sdr.h"
 #include "m2sdr_cli.h"
+#include "m2sdr_host_ring.h"
 #include "m2sdr_sigmf.h"
 #include "config.h"
 
@@ -29,9 +32,85 @@
 
 sig_atomic_t keep_running = 1;
 
+struct m2sdr_play_source {
+    struct m2sdr_host_ring ring;
+    FILE *fi;
+    pthread_t thread;
+    uint32_t loops;
+    uint32_t current_loop;
+    uint64_t start_offset_bytes;
+    uint64_t end_offset_bytes;
+    size_t frame_bytes;
+    bool close_fi;
+    bool enabled;
+    int error;
+};
+
 void intHandler(int dummy) {
     (void)dummy;
     keep_running = 0;
+}
+
+static void *m2sdr_play_source_worker(void *arg)
+{
+    struct m2sdr_play_source *source = (struct m2sdr_play_source *)arg;
+    uint8_t raw_buf[DMA_BUFFER_SIZE];
+
+    while (keep_running) {
+        uint64_t current_pos = 0;
+        size_t to_read = source->frame_bytes;
+        size_t len;
+
+        if (source->close_fi && source->end_offset_bytes > 0) {
+            current_pos = (uint64_t)ftello(source->fi);
+            if (current_pos >= source->end_offset_bytes) {
+                source->current_loop++;
+                if (source->loops != 0 && source->current_loop >= source->loops)
+                    break;
+                if (fseeko(source->fi, (off_t)source->start_offset_bytes, SEEK_SET) != 0) {
+                    perror("fseeko");
+                    source->error = 1;
+                    break;
+                }
+                current_pos = source->start_offset_bytes;
+            }
+            if (current_pos + to_read > source->end_offset_bytes)
+                to_read = (size_t)(source->end_offset_bytes - current_pos);
+        }
+
+        len = fread(raw_buf, 1, to_read, source->fi);
+        if (ferror(source->fi)) {
+            perror("fread");
+            source->error = 1;
+            break;
+        }
+        if (feof(source->fi)) {
+            source->current_loop++;
+            if (source->loops != 0 && source->current_loop >= source->loops)
+                break;
+            if (source->close_fi) {
+                if (fseeko(source->fi, (off_t)source->start_offset_bytes, SEEK_SET) != 0) {
+                    perror("fseeko");
+                    source->error = 1;
+                    break;
+                }
+                clearerr(source->fi);
+                len += fread(raw_buf + len, 1, source->frame_bytes - len, source->fi);
+            }
+        }
+
+        if (len < source->frame_bytes)
+            memset(raw_buf + len, 0, source->frame_bytes - len);
+
+        if (m2sdr_host_ring_push(&source->ring, raw_buf, source->frame_bytes, NULL, false,
+                                 M2SDR_HOST_RING_BLOCK) != 0) {
+            source->error = 1;
+            break;
+        }
+    }
+
+    m2sdr_host_ring_close_writer(&source->ring);
+    return NULL;
 }
 
 static int parse_m2sdr_dma_header(const uint8_t *buf, uint64_t *timestamp)
@@ -76,6 +155,9 @@ static void help(void)
            "  -q, --quiet           Quiet mode.\n"
            "  -t, --timed-start     Timed start (align to next second).\n"
            "      --capture-index N SigMF capture index to use (default: 0).\n"
+           "      --host-buffers N  Host-side ring depth for file/stdin sources.\n"
+           "      --prefill N       Wait for N queued host buffers before TX.\n"
+           "      --stats-interval MS Progress print interval in ms (default: 200).\n"
            "      --format FMT      Sample format: sc16 or sc8 (default: sc16).\n"
            "      --zero-copy       Legacy compatibility flag; ignored in sync API.\n"
            "      --8bit            Legacy alias for --format sc8.\n"
@@ -88,10 +170,14 @@ static void help(void)
 
 static void m2sdr_play(const char *device_id, const char *filename, uint32_t loops, uint8_t quiet,
                        uint8_t timed_start, enum m2sdr_format format, unsigned header_bytes,
-                       uint64_t start_offset_bytes, uint64_t end_offset_bytes)
+                       uint64_t start_offset_bytes, uint64_t end_offset_bytes,
+                       unsigned host_buffers, unsigned prefill_buffers,
+                       unsigned stats_interval_ms)
 {
     struct m2sdr_dev *dev = NULL;
+    struct m2sdr_play_source source;
     size_t frame_bytes;
+    memset(&source, 0, sizeof(source));
     if (m2sdr_open(&dev, device_id) != 0) {
         fprintf(stderr, "Could not open device: %s\n", device_id);
         exit(1);
@@ -149,6 +235,35 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
         }
         close_fi = 1;
     }
+    if (host_buffers > 0) {
+        if (m2sdr_host_ring_init(&source.ring, host_buffers, DMA_BUFFER_SIZE) != 0) {
+            fprintf(stderr, "Could not allocate host TX ring\n");
+            if (close_fi)
+                fclose(fi);
+            m2sdr_close(dev);
+            exit(1);
+        }
+        source.fi = fi;
+        source.loops = loops;
+        source.start_offset_bytes = start_offset_bytes;
+        source.end_offset_bytes = end_offset_bytes;
+        source.frame_bytes = frame_bytes;
+        source.close_fi = close_fi ? true : false;
+        source.enabled = true;
+        if (pthread_create(&source.thread, NULL, m2sdr_play_source_worker, &source) != 0) {
+            fprintf(stderr, "Could not start host TX reader thread\n");
+            m2sdr_host_ring_destroy(&source.ring);
+            if (close_fi)
+                fclose(fi);
+            m2sdr_close(dev);
+            exit(1);
+        }
+        while (keep_running &&
+               m2sdr_host_ring_count(&source.ring) < prefill_buffers &&
+               !m2sdr_host_ring_writer_closed(&source.ring)) {
+            usleep(1000);
+        }
+    }
 
     int i = 0;
     uint32_t current_loop = 0;
@@ -160,45 +275,60 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
     uint8_t raw_buf[DMA_BUFFER_SIZE];
     uint8_t payload_buf[DMA_BUFFER_SIZE];
     while (keep_running) {
-        uint64_t current_pos;
-        size_t to_read = frame_bytes;
         size_t len;
         struct m2sdr_metadata meta = {0};
+        if (source.enabled) {
+            if (m2sdr_host_ring_count(&source.ring) == 0)
+                sw_underflows++;
+            {
+                int pop_rc = m2sdr_host_ring_pop(&source.ring, raw_buf, &len, NULL, NULL);
+                if (pop_rc == 1)
+                    break;
+                if (pop_rc != 0) {
+                    fprintf(stderr, "Host TX ring stopped\n");
+                    break;
+                }
+            }
+            current_loop = source.current_loop;
+        } else {
+            uint64_t current_pos;
+            size_t to_read = frame_bytes;
 
-        if (close_fi && end_offset_bytes > 0) {
-            current_pos = (uint64_t)ftello(fi);
-            if (current_pos >= end_offset_bytes) {
+            if (close_fi && end_offset_bytes > 0) {
+                current_pos = (uint64_t)ftello(fi);
+                if (current_pos >= end_offset_bytes) {
+                    current_loop++;
+                    if (loops != 0 && current_loop >= loops)
+                        break;
+                    if (fseeko(fi, (off_t)start_offset_bytes, SEEK_SET) != 0) {
+                        perror("fseeko");
+                        break;
+                    }
+                    current_pos = start_offset_bytes;
+                }
+                if (current_pos + to_read > end_offset_bytes)
+                    to_read = (size_t)(end_offset_bytes - current_pos);
+            }
+
+            len = fread(raw_buf, 1, to_read, fi);
+            if (ferror(fi)) {
+                perror("fread");
+                break;
+            }
+            if (feof(fi)) {
                 current_loop++;
                 if (loops != 0 && current_loop >= loops)
                     break;
-                if (fseeko(fi, (off_t)start_offset_bytes, SEEK_SET) != 0) {
-                    perror("fseeko");
-                    break;
+                if (strcmp(filename, "-") != 0) {
+                    fseeko(fi, (off_t)start_offset_bytes, SEEK_SET);
+                    clearerr(fi);
+                    len += fread(raw_buf + len, 1, frame_bytes - len, fi);
                 }
-                current_pos = start_offset_bytes;
             }
-            if (current_pos + to_read > end_offset_bytes)
-                to_read = (size_t)(end_offset_bytes - current_pos);
-        }
 
-        len = fread(raw_buf, 1, to_read, fi);
-        if (ferror(fi)) {
-            perror("fread");
-            break;
+            if (len < frame_bytes)
+                memset(raw_buf + len, 0, frame_bytes - len);
         }
-        if (feof(fi)) {
-            current_loop++;
-            if (loops != 0 && current_loop >= loops)
-                break;
-            if (strcmp(filename, "-") != 0) {
-                fseeko(fi, (off_t)start_offset_bytes, SEEK_SET);
-                clearerr(fi);
-                len += fread(raw_buf + len, 1, frame_bytes - len, fi);
-            }
-        }
-
-        if (len < frame_bytes)
-            memset(raw_buf + len, 0, frame_bytes - len);
 
         if (header_bytes > 0) {
             if (len >= M2SDR_DMA_HEADER_SIZE && parse_m2sdr_dma_header(raw_buf, &meta.timestamp))
@@ -216,21 +346,39 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
         total_buffers++;
 
         int64_t duration = get_time_ms() - last_time;
-        if (!quiet && duration > 200) {
+        if (!quiet && duration > (int64_t)stats_interval_ms) {
             double speed  = (double)(total_buffers - last_buffers) * DMA_BUFFER_SIZE * 8 / ((double)duration * 1e6);
             uint64_t size = (total_buffers * DMA_BUFFER_SIZE) / 1024 / 1024;
+            unsigned host_fill = source.enabled ? m2sdr_host_ring_count(&source.ring) : 0;
 
-            if (i % 10 == 0)
-                fprintf(stderr, "\e[1mSPEED(Gbps)   BUFFERS   SIZE(MB)   LOOP UNDERFLOWS\e[0m\n");
+            if (i % 10 == 0) {
+                if (source.enabled)
+                    fprintf(stderr, "\e[1mSPEED(Gbps)   BUFFERS   SIZE(MB)   LOOP UNDERFLOWS  HOSTQ\e[0m\n");
+                else
+                    fprintf(stderr, "\e[1mSPEED(Gbps)   BUFFERS   SIZE(MB)   LOOP UNDERFLOWS\e[0m\n");
+            }
             i++;
 
-            fprintf(stderr, "%10.2f %10" PRIu64 " %10" PRIu64 " %6u %10" PRIu64 "\n",
-                    speed, total_buffers, size, current_loop, sw_underflows);
+            if (source.enabled) {
+                fprintf(stderr, "%10.2f %10" PRIu64 " %10" PRIu64 " %6u %10" PRIu64 " %6u\n",
+                        speed, total_buffers, size, current_loop, sw_underflows, host_fill);
+            } else {
+                fprintf(stderr, "%10.2f %10" PRIu64 " %10" PRIu64 " %6u %10" PRIu64 "\n",
+                        speed, total_buffers, size, current_loop, sw_underflows);
+            }
 
             last_time = get_time_ms();
             last_buffers = total_buffers;
             sw_underflows = 0;
         }
+    }
+
+    if (source.enabled) {
+        m2sdr_host_ring_stop(&source.ring);
+        pthread_join(source.thread, NULL);
+        if (source.error)
+            fprintf(stderr, "Host TX reader thread failed\n");
+        m2sdr_host_ring_destroy(&source.ring);
     }
 
     if (close_fi)
@@ -245,6 +393,9 @@ int main(int argc, char **argv)
     static uint8_t quiet = 0;
     static uint8_t timed_start = 0;
     static enum m2sdr_format format = M2SDR_FORMAT_SC16_Q11;
+    unsigned host_buffers = 0;
+    unsigned prefill_buffers = 0;
+    unsigned stats_interval_ms = 200;
     unsigned capture_index = 0;
     unsigned sigmf_header_bytes = 0;
     uint64_t start_offset_bytes = 0;
@@ -262,6 +413,9 @@ int main(int argc, char **argv)
         { "timed-start", no_argument, NULL, 't' },
         { "zero-copy", no_argument, NULL, 'z' },
         { "capture-index", required_argument, NULL, 3 },
+        { "host-buffers", required_argument, NULL, 4 },
+        { "prefill", required_argument, NULL, 5 },
+        { "stats-interval", required_argument, NULL, 6 },
         { "format", required_argument, NULL, 1 },
         { "8bit", no_argument, NULL, 2 },
         { NULL, 0, NULL, 0 }
@@ -303,6 +457,17 @@ int main(int argc, char **argv)
             break;
         case 3:
             capture_index = (unsigned)strtoul(optarg, NULL, 0);
+            break;
+        case 4:
+            host_buffers = (unsigned)strtoul(optarg, NULL, 0);
+            break;
+        case 5:
+            prefill_buffers = (unsigned)strtoul(optarg, NULL, 0);
+            break;
+        case 6:
+            stats_interval_ms = (unsigned)strtoul(optarg, NULL, 0);
+            if (stats_interval_ms == 0)
+                stats_interval_ms = 200;
             break;
         case 'q':
             quiet = 1;
@@ -385,7 +550,11 @@ int main(int argc, char **argv)
     if (!m2sdr_cli_finalize_device(&cli_dev))
         return 1;
 
+    if (prefill_buffers > host_buffers)
+        prefill_buffers = host_buffers;
+
     m2sdr_play(m2sdr_cli_device_id(&cli_dev), filename, loops, quiet, timed_start, format,
-               sigmf_header_bytes, start_offset_bytes, end_offset_bytes);
+               sigmf_header_bytes, start_offset_bytes, end_offset_bytes,
+               host_buffers, prefill_buffers, stats_interval_ms);
     return 0;
 }

--- a/litex_m2sdr/software/user/m2sdr_record.c
+++ b/litex_m2sdr/software/user/m2sdr_record.c
@@ -18,9 +18,11 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <math.h>
+#include <pthread.h>
 
 #include "m2sdr.h"
 #include "m2sdr_cli.h"
+#include "m2sdr_host_ring.h"
 #include "m2sdr_sigmf.h"
 #include "config.h"
 
@@ -28,9 +30,44 @@
 
 sig_atomic_t keep_running = 1;
 
+struct m2sdr_record_sink {
+    struct m2sdr_host_ring ring;
+    FILE *fo;
+    pthread_t thread;
+    bool enabled;
+    int error;
+    size_t bytes_written;
+};
+
 void intHandler(int dummy) {
     (void)dummy;
     keep_running = 0;
+}
+
+static void *m2sdr_record_sink_worker(void *arg)
+{
+    struct m2sdr_record_sink *sink = (struct m2sdr_record_sink *)arg;
+    uint8_t buf[DMA_BUFFER_SIZE];
+
+    while (1) {
+        size_t len = 0;
+        int rc = m2sdr_host_ring_pop(&sink->ring, buf, &len, NULL, NULL);
+        if (rc == 1)
+            break;
+        if (rc != 0) {
+            sink->error = 1;
+            break;
+        }
+        if (fwrite(buf, 1, len, sink->fo) != len) {
+            perror("fwrite");
+            sink->error = 1;
+            m2sdr_host_ring_stop(&sink->ring);
+            break;
+        }
+        sink->bytes_written += len;
+    }
+
+    return NULL;
 }
 
 static void help(void)
@@ -67,6 +104,10 @@ static void help(void)
            "      --annotation-add           Finalize current SigMF annotation.\n"
            "      --annotate-ts-jumps        Add SigMF annotations on RX timestamp jumps.\n"
            "      --ts-jump-threshold-pct P  Relative timestamp jump threshold (default: 5).\n"
+           "      --host-buffers N           Host-side ring depth for file/stdout sinks.\n"
+           "      --drop-oldest              On full host ring, discard oldest pending RX buffers.\n"
+           "      --drop-newest              On full host ring, discard newest RX buffers.\n"
+           "      --stats-interval MS        Progress print interval in ms (default: 200).\n"
            "      --zero-copy       Legacy compatibility flag; ignored in sync API.\n"
            "      --8bit            Legacy alias for --format sc8.\n"
            "\n"
@@ -203,11 +244,18 @@ static void sigmf_fill_defaults_from_device(struct m2sdr_dev *dev, struct m2sdr_
 static void m2sdr_record(const char *device_id, const char *filename, size_t size, uint8_t quiet,
                          uint8_t header, uint8_t strip_header, enum m2sdr_format format,
                          bool sigmf_enable, bool annotate_ts_jumps, double ts_jump_threshold_pct,
-                         struct m2sdr_sigmf_meta *sigmf_meta)
+                         struct m2sdr_sigmf_meta *sigmf_meta,
+                         unsigned host_buffers,
+                         enum m2sdr_host_ring_policy host_policy,
+                         unsigned stats_interval_ms)
 {
     struct m2sdr_dev *dev = NULL;
+    struct m2sdr_record_sink sink;
     char sigmf_data_path[1024] = {0};
     char sigmf_meta_path[1024] = {0};
+    size_t produced_len = 0;
+
+    memset(&sink, 0, sizeof(sink));
     if (m2sdr_open(&dev, device_id) != 0) {
         fprintf(stderr, "Could not open device: %s\n", device_id);
         exit(1);
@@ -251,6 +299,25 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
             }
         }
     }
+    if (fo && host_buffers > 0) {
+        if (m2sdr_host_ring_init(&sink.ring, host_buffers, DMA_BUFFER_SIZE) != 0) {
+            fprintf(stderr, "Could not allocate host RX ring\n");
+            if (fo != stdout)
+                fclose(fo);
+            m2sdr_close(dev);
+            exit(1);
+        }
+        sink.fo = fo;
+        sink.enabled = true;
+        if (pthread_create(&sink.thread, NULL, m2sdr_record_sink_worker, &sink) != 0) {
+            fprintf(stderr, "Could not start host RX writer thread\n");
+            m2sdr_host_ring_destroy(&sink.ring);
+            if (fo != stdout)
+                fclose(fo);
+            m2sdr_close(dev);
+            exit(1);
+        }
+    }
 
     int i = 0;
     size_t total_len = 0;
@@ -265,7 +332,7 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
     uint8_t buf[DMA_BUFFER_SIZE];
     while (keep_running) {
         struct m2sdr_metadata meta;
-        if (size > 0 && total_len >= size)
+        if (size > 0 && produced_len >= size)
             break;
 
         if (m2sdr_sync_rx(dev, buf, samples_per_buf, header ? &meta : NULL, 0) != 0) {
@@ -283,7 +350,7 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
                 if (nominal_dt == 0) {
                     nominal_dt = dt_ns;
                 } else if (m2sdr_sigmf_timestamp_jump_is_anomalous(nominal_dt, dt_ns, ts_jump_threshold_pct)) {
-                    uint64_t sample_start = sample_size ? (uint64_t)(total_len / sample_size) : 0;
+                    uint64_t sample_start = sample_size ? (uint64_t)(produced_len / sample_size) : 0;
                     sigmf_record_timestamp_jump(sigmf_meta, sample_start, samples_per_buf, dt_ns, nominal_dt);
                 }
             }
@@ -291,28 +358,44 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
         }
 
         size_t to_write = payload_bytes_per_buf;
-        if (size > 0 && to_write > size - total_len)
-            to_write = size - total_len;
+        if (size > 0 && to_write > size - produced_len)
+            to_write = size - produced_len;
 
         if (fo) {
-            if (fwrite(buf, 1, to_write, fo) != to_write) {
+            if (sink.enabled) {
+                int push_rc = m2sdr_host_ring_push(&sink.ring, buf, to_write, NULL, false, host_policy);
+                if (push_rc < 0) {
+                    fprintf(stderr, "Host RX ring stopped\n");
+                    break;
+                }
+            } else if (fwrite(buf, 1, to_write, fo) != to_write) {
                 perror("fwrite");
                 break;
             }
         }
-        total_len += to_write;
+        produced_len += to_write;
+        if (!sink.enabled)
+            total_len += to_write;
         total_buffers++;
 
         int64_t duration = get_time_ms() - last_time;
-        if (!quiet && duration > 200) {
+        if (!quiet && duration > (int64_t)stats_interval_ms) {
             double speed  = (double)(total_buffers - last_buffers) * DMA_BUFFER_SIZE * 8 / ((double)duration * 1e6);
             uint64_t size_mb = (total_buffers * DMA_BUFFER_SIZE) / 1024 / 1024;
+            unsigned host_fill = sink.enabled ? m2sdr_host_ring_count(&sink.ring) : 0;
+            uint64_t host_drop = sink.enabled ? m2sdr_host_ring_dropped(&sink.ring) : 0;
 
             if (i % 10 == 0) {
                 if (header) {
-                    fprintf(stderr, "\e[1m%10s %10s %8s %23s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "TIME");
+                    if (sink.enabled)
+                        fprintf(stderr, "\e[1m%10s %10s %8s %23s %6s %8s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "TIME", "HOSTQ", "DROPPED");
+                    else
+                        fprintf(stderr, "\e[1m%10s %10s %8s %23s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "TIME");
                 } else {
-                    fprintf(stderr, "\e[1m%10s %10s %9s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)");
+                    if (sink.enabled)
+                        fprintf(stderr, "\e[1m%10s %10s %9s %6s %8s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "HOSTQ", "DROPPED");
+                    else
+                        fprintf(stderr, "\e[1m%10s %10s %9s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)");
                 }
             }
             i++;
@@ -327,15 +410,34 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
 
                 gmtime_r(&sec_time, &tm);
                 strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", &tm);
-                fprintf(stderr, "%11.2f %10" PRIu64 " %8" PRIu64 " %19s.%03u\n",
-                        speed, total_buffers, size_mb, time_str, ms);
+                if (sink.enabled) {
+                    fprintf(stderr, "%11.2f %10" PRIu64 " %8" PRIu64 " %19s.%03u %6u %8" PRIu64 "\n",
+                            speed, total_buffers, size_mb, time_str, ms, host_fill, host_drop);
+                } else {
+                    fprintf(stderr, "%11.2f %10" PRIu64 " %8" PRIu64 " %19s.%03u\n",
+                            speed, total_buffers, size_mb, time_str, ms);
+                }
             } else {
-                fprintf(stderr, "%11.2f %10" PRIu64 " %9" PRIu64 "\n", speed, total_buffers, size_mb);
+                if (sink.enabled) {
+                    fprintf(stderr, "%11.2f %10" PRIu64 " %9" PRIu64 " %6u %8" PRIu64 "\n",
+                            speed, total_buffers, size_mb, host_fill, host_drop);
+                } else {
+                    fprintf(stderr, "%11.2f %10" PRIu64 " %9" PRIu64 "\n", speed, total_buffers, size_mb);
+                }
             }
 
             last_time = get_time_ms();
             last_buffers = total_buffers;
         }
+    }
+
+    if (sink.enabled) {
+        m2sdr_host_ring_close_writer(&sink.ring);
+        pthread_join(sink.thread, NULL);
+        total_len = sink.bytes_written;
+        if (sink.error)
+            fprintf(stderr, "Host RX writer thread failed\n");
+        m2sdr_host_ring_destroy(&sink.ring);
     }
 
     if (fo && fo != stdout)
@@ -373,6 +475,9 @@ int main(int argc, char **argv)
     static uint8_t strip_header = 0;
     static uint8_t annotate_ts_jumps = 0;
     static enum m2sdr_format format = M2SDR_FORMAT_SC16_Q11;
+    unsigned host_buffers = 0;
+    unsigned stats_interval_ms = 200;
+    enum m2sdr_host_ring_policy host_policy = M2SDR_HOST_RING_BLOCK;
     double ts_jump_threshold_pct = 5.0;
     struct m2sdr_sigmf_meta sigmf_meta;
     struct m2sdr_sigmf_annotation pending_annotation;
@@ -403,6 +508,10 @@ int main(int argc, char **argv)
         { "annotation-add", no_argument, NULL, 15 },
         { "annotate-ts-jumps", no_argument, NULL, 16 },
         { "ts-jump-threshold-pct", required_argument, NULL, 17 },
+        { "host-buffers", required_argument, NULL, 18 },
+        { "drop-oldest", no_argument, NULL, 19 },
+        { "drop-newest", no_argument, NULL, 20 },
+        { "stats-interval", required_argument, NULL, 21 },
         { "format", required_argument, NULL, 1 },
         { "8bit", no_argument, NULL, 2 },
         { NULL, 0, NULL, 0 }
@@ -510,6 +619,20 @@ int main(int argc, char **argv)
         case 17:
             ts_jump_threshold_pct = atof(optarg);
             break;
+        case 18:
+            host_buffers = (unsigned)strtoul(optarg, NULL, 0);
+            break;
+        case 19:
+            host_policy = M2SDR_HOST_RING_DROP_OLDEST;
+            break;
+        case 20:
+            host_policy = M2SDR_HOST_RING_DROP_NEWEST;
+            break;
+        case 21:
+            stats_interval_ms = (unsigned)strtoul(optarg, NULL, 0);
+            if (stats_interval_ms == 0)
+                stats_interval_ms = 200;
+            break;
         default:
             exit(1);
         }
@@ -547,6 +670,10 @@ int main(int argc, char **argv)
             fprintf(stderr, "--annotate-ts-jumps requires --enable-header\n");
             return 1;
         }
+        if (host_policy != M2SDR_HOST_RING_BLOCK) {
+            fprintf(stderr, "SigMF output does not support --drop-oldest/--drop-newest\n");
+            return 1;
+        }
         if (!datatype) {
             fprintf(stderr, "Unsupported SigMF datatype for selected format\n");
             return 1;
@@ -563,6 +690,7 @@ int main(int argc, char **argv)
     }
 
     m2sdr_record(m2sdr_cli_device_id(&cli_dev), filename, size, quiet, header, strip_header, format,
-                 sigmf_enable ? true : false, annotate_ts_jumps ? true : false, ts_jump_threshold_pct, &sigmf_meta);
+                 sigmf_enable ? true : false, annotate_ts_jumps ? true : false, ts_jump_threshold_pct, &sigmf_meta,
+                 host_buffers, host_policy, stats_interval_ms);
     return 0;
 }


### PR DESCRIPTION
This pull request improves the existing `m2sdr_play` and `m2sdr_record` user-space streaming tools with configurable **host-side buffering**, instead of introducing a parallel shared-memory-specific streaming stack.

The goal is to better tolerate stalls from pipe-driven or GC-managed runtimes such as Julia, while keeping one common streaming path in the project and preserving the current `libm2sdr`-based tooling model.

All changes are fully **backward compatible** with existing file, stdin, stdout, and SigMF workflows.

---

### Summary of Features

#### 1. Shared Host-Ring Buffering

- **New Shared Helper**
  - Added a reusable host-side ring buffer layer for sample transport staging between:
    - file/stdin/stdout I/O
    - DMA RX/TX sync calls

- **Single Common Path**
  - The new buffering support is shared by the existing tools instead of adding:
    - separate RX SHM binaries
    - separate TX SHM binaries
    - separate full-duplex SHM binaries

This keeps the project aligned with the current `libm2sdr` + user-tool architecture.

#### 2. `m2sdr_record` Streaming Improvements

- **Host Buffering**
  - Added `--host-buffers N` to decouple DMA RX from file/stdout writes.

- **Overflow Policy Controls**
  - Added:
    - `--drop-oldest`
    - `--drop-newest`

These are useful when piping into runtimes that may pause or process bursts unevenly.

- **Progress Controls**
  - Added `--stats-interval MS` to tune progress reporting cadence.

This makes `m2sdr_record` a more practical RX producer for pipe-based host workflows.

#### 3. `m2sdr_play` Streaming Improvements

- **Host Buffering**
  - Added `--host-buffers N` to stage input ahead of DMA TX.

- **Prefill Control**
  - Added `--prefill N` so TX can wait for a configurable amount of queued host data before starting.

This is especially useful when stdin or the producer process is bursty.

- **Progress Controls**
  - Added `--stats-interval MS`.

This makes `m2sdr_play` more resilient for streamed TX input without changing the FPGA data path.

#### 4. Documentation Updates

- Updated the user-space README to describe:
  - host-buffered `m2sdr_play`
  - host-buffered `m2sdr_record`
  - pipe-oriented workflows for external runtimes
  - example commands for staged stdin/stdout use

---

### Why This Approach

The motivation behind SHM-based external bridges is valid: some runtimes can pause long enough to cause RX overruns or TX underruns.

However, instead of adding a second streaming tool family, this PR extends the existing tools directly:
- `m2sdr_record` remains the RX producer
- `m2sdr_play` remains the TX consumer
- the new host ring is shared infrastructure
- the DMA/RF/streaming behavior stays in one code path

This reduces duplication and keeps future maintenance simpler.

---

### Validation

Validation was performed by:
- rebuilding `m2sdr_play`
- rebuilding `m2sdr_record`
- checking `--help` output for both tools
- confirming the new options are documented and exposed correctly

Hardware-level validation of bursty external-runtime behavior remains workflow-dependent, but the implementation is compile-validated and integrated into the existing toolchain.
