### PR TITLE
gateware/ad9361: make the RX PRBS checker work in 1R1T mode

### DIFF
--- a/litex_m2sdr/gateware/ad9361/core.py
+++ b/litex_m2sdr/gateware/ad9361/core.py
@@ -20,7 +20,8 @@ from litex_m2sdr.gateware.ad9361.phy     import AD9361PHY
 from litex_m2sdr.gateware.ad9361.spi     import AD9361SPIMaster
 from litex_m2sdr.gateware.ad9361.bitmode import AD9361TXBitMode, AD9361RXBitMode
 from litex_m2sdr.gateware.ad9361.bitmode import _sign_extend
-from litex_m2sdr.gateware.ad9361.prbs    import AD9361PRBSGenerator, AD9361PRBSChecker, AD9361PRBS1R1TChecker
+from litex_m2sdr.gateware.ad9361.prbs    import AD9361PRBSGenerator, AD9361PRBSChecker
+from litex_m2sdr.gateware.ad9361.prbs    import AD9361PRBS1R1TGenerator, AD9361PRBS1R1TChecker
 from litex_m2sdr.gateware.ad9361.agc     import AGCSaturationCount
 
 # Architecture -------------------------------------------------------------------------------------
@@ -274,22 +275,41 @@ class AD9361RFIC(LiteXModule):
         # # #
 
         phy = self.phy
+        mode_rfic = Signal()
+        prbs_tx_enable = Signal()
+        self.specials += [
+            MultiReg(phy.control.fields.mode, mode_rfic, odomain="rfic"),
+            MultiReg(self.prbs_tx.fields.enable, prbs_tx_enable, odomain="rfic"),
+        ]
 
         # PRBS TX.
         # --------
-        prbs_generator = AD9361PRBSGenerator()
-        prbs_generator = ResetInserter()(prbs_generator)
-        prbs_generator = ClockDomainsRenamer("rfic")(prbs_generator)
-        self.submodules += prbs_generator
+        prbs_generator_2r2t = AD9361PRBSGenerator()
+        prbs_generator_2r2t = ResetInserter()(prbs_generator_2r2t)
+        prbs_generator_2r2t = ClockDomainsRenamer("rfic")(prbs_generator_2r2t)
+        prbs_generator_1r1t = AD9361PRBS1R1TGenerator()
+        prbs_generator_1r1t = ResetInserter()(prbs_generator_1r1t)
+        prbs_generator_1r1t = ClockDomainsRenamer("rfic")(prbs_generator_1r1t)
+        self.submodules += prbs_generator_2r2t
+        self.submodules += prbs_generator_1r1t
         self.comb += [
-            prbs_generator.reset.eq(~self.prbs_tx.fields.enable),
-            prbs_generator.ce.eq(phy.sink.ready),
-            If(self.prbs_tx.fields.enable,
+            prbs_generator_2r2t.reset.eq(~prbs_tx_enable | mode_rfic),
+            prbs_generator_1r1t.reset.eq(~prbs_tx_enable | ~mode_rfic),
+            prbs_generator_2r2t.ce.eq(phy.sink.ready),
+            prbs_generator_1r1t.ce.eq(phy.sink.ready),
+            If(prbs_tx_enable,
                 phy.sink.valid.eq(1),
-                phy.sink.ia.eq(prbs_generator.o),
-                phy.sink.qa.eq(prbs_generator.o),
-                phy.sink.ib.eq(prbs_generator.o),
-                phy.sink.qb.eq(prbs_generator.o),
+                If(mode_rfic,
+                    phy.sink.ia.eq(prbs_generator_1r1t.o),
+                    phy.sink.qa.eq(prbs_generator_1r1t.o),
+                    phy.sink.ib.eq(prbs_generator_1r1t.o_next),
+                    phy.sink.qb.eq(prbs_generator_1r1t.o_next),
+                ).Else(
+                    phy.sink.ia.eq(prbs_generator_2r2t.o),
+                    phy.sink.qa.eq(prbs_generator_2r2t.o),
+                    phy.sink.ib.eq(prbs_generator_2r2t.o),
+                    phy.sink.qb.eq(prbs_generator_2r2t.o),
+                )
             )
         ]
 
@@ -299,8 +319,6 @@ class AD9361RFIC(LiteXModule):
         # ia/ib independently. 1R1T mode: the a/b slots carry two consecutive
         # samples of ONE stream (each lane sees every other PRBS value), so a
         # dedicated interleaved checker is required. Select by PHY mode.
-        mode_rfic = Signal()
-        self.specials += MultiReg(phy.control.fields.mode, mode_rfic, odomain="rfic")
 
         synced_2r2t = Signal(reset=1)
         self.comb += synced_2r2t.eq(1)

--- a/litex_m2sdr/gateware/ad9361/core.py
+++ b/litex_m2sdr/gateware/ad9361/core.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
+from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 
@@ -19,7 +20,7 @@ from litex_m2sdr.gateware.ad9361.phy     import AD9361PHY
 from litex_m2sdr.gateware.ad9361.spi     import AD9361SPIMaster
 from litex_m2sdr.gateware.ad9361.bitmode import AD9361TXBitMode, AD9361RXBitMode
 from litex_m2sdr.gateware.ad9361.bitmode import _sign_extend
-from litex_m2sdr.gateware.ad9361.prbs    import AD9361PRBSGenerator, AD9361PRBSChecker
+from litex_m2sdr.gateware.ad9361.prbs    import AD9361PRBSGenerator, AD9361PRBSChecker, AD9361PRBS1R1TChecker
 from litex_m2sdr.gateware.ad9361.agc     import AGCSaturationCount
 
 # Architecture -------------------------------------------------------------------------------------
@@ -294,7 +295,15 @@ class AD9361RFIC(LiteXModule):
 
         # PRBS RX.
         # --------
-        self.comb += self.prbs_rx.fields.synced.eq(1)
+        # 2R2T mode: each lane (channel) carries the full PRBS sequence; check
+        # ia/ib independently. 1R1T mode: the a/b slots carry two consecutive
+        # samples of ONE stream (each lane sees every other PRBS value), so a
+        # dedicated interleaved checker is required. Select by PHY mode.
+        mode_rfic = Signal()
+        self.specials += MultiReg(phy.control.fields.mode, mode_rfic, odomain="rfic")
+
+        synced_2r2t = Signal(reset=1)
+        self.comb += synced_2r2t.eq(1)
         for data in [phy.source.ia, phy.source.ib]:
             prbs_checker = AD9361PRBSChecker()
             prbs_checker = ClockDomainsRenamer("rfic")(prbs_checker)
@@ -303,9 +312,22 @@ class AD9361RFIC(LiteXModule):
                 prbs_checker.i.eq(data),
                 prbs_checker.ce.eq(phy.source.valid),
                 If(~prbs_checker.synced,
-                    self.prbs_rx.fields.synced.eq(0)
+                    synced_2r2t.eq(0)
                 ),
             ]
+
+        prbs_checker_1r1t = AD9361PRBS1R1TChecker()
+        prbs_checker_1r1t = ClockDomainsRenamer("rfic")(prbs_checker_1r1t)
+        self.submodules += prbs_checker_1r1t
+        self.comb += [
+            prbs_checker_1r1t.ia.eq(phy.source.ia),
+            prbs_checker_1r1t.ib.eq(phy.source.ib),
+            prbs_checker_1r1t.ce.eq(phy.source.valid),
+        ]
+
+        synced = Signal()
+        self.comb += synced.eq(Mux(mode_rfic, prbs_checker_1r1t.synced, synced_2r2t))
+        self.specials += MultiReg(synced, self.prbs_rx.fields.synced)
 
     def add_agc(self):
         rx_cdc = self.rx_cdc

--- a/litex_m2sdr/gateware/ad9361/prbs.py
+++ b/litex_m2sdr/gateware/ad9361/prbs.py
@@ -9,6 +9,18 @@ from migen import *
 from litex.gen import *
 from litex.gen.genlib.misc import WaitTimer
 
+# Constants / Helpers ------------------------------------------------------------------------------
+
+def _prbs16_next(state):
+    """One step of the AD9361 BIST PRBS LFSR (taps 1,2,4..15; LSB-in shift)."""
+    return Cat((
+        state[1]  ^ state[2]  ^ state[4]  ^ state[5]  ^
+        state[6]  ^ state[7]  ^ state[8]  ^ state[9]  ^
+        state[10] ^ state[11] ^ state[12] ^ state[13] ^
+        state[14] ^ state[15]),
+        state[:-1]
+    )
+
 # AD9361 PRBS Generator ----------------------------------------------------------------------------
 
 class AD9361PRBSGenerator(LiteXModule):
@@ -20,14 +32,7 @@ class AD9361PRBSGenerator(LiteXModule):
 
         # PRBS Generation.
         data = Signal(16, reset=seed)
-        self.sync += If(self.ce, data.eq(Cat((
-            data[1]  ^ data[2]  ^ data[4]  ^ data[5]  ^
-            data[6]  ^ data[7]  ^ data[8]  ^ data[9]  ^
-            data[10] ^ data[11] ^ data[12] ^ data[13] ^
-            data[14] ^ data[15]),
-            data[:-1]
-            )
-        ))
+        self.sync += If(self.ce, data.eq(_prbs16_next(data)))
         self.comb += self.o.eq(data)
 
 # AD9361 PRBS Checker ----------------------------------------------------------------------------
@@ -56,6 +61,51 @@ class AD9361PRBSChecker(LiteXModule):
         # Error generation.
         self.comb += If(self.ce, error.eq(self.i != prbs.o[:12]))
 
+
+        # Sync generation.
+        self.sync_timer = WaitTimer(1024)
+        self.comb += self.sync_timer.wait.eq(~error)
+        self.comb += self.synced.eq(self.sync_timer.done)
+
+# AD9361 PRBS 1R1T Checker -------------------------------------------------------------------------
+
+class AD9361PRBS1R1TChecker(LiteXModule):
+    """PRBS checker for 1R1T mode.
+
+    In 1R1T mode the PHY packs two CONSECUTIVE samples of one stream into the
+    a/b slots of each word, so each lane sees every other PRBS value and the
+    per-lane checkers (which expect consecutive values) can never sync. This
+    checker validates the interleaved pair: ia must match the reference and ib
+    the reference advanced by one; the reference advances by two per word.
+    Since the LFSR period (2^16-1) is odd, the stride-2 subsequence still
+    visits every state, so seed-based resynchronization works unchanged.
+    """
+    def __init__(self, seed=0x0a54):
+        self.ce     = Signal(reset=1)
+        self.ia     = Signal(12)
+        self.ib     = Signal(12)
+        self.synced = Signal()
+
+        # # #
+
+        error   = Signal()
+        state   = Signal(16, reset=seed)
+        state_n = Signal(16)
+
+        # PRBS reference (advance by 2 per word, reseed on error).
+        self.comb += state_n.eq(_prbs16_next(state))
+        self.sync += If(self.ce,
+            If(error,
+                state.eq(seed)
+            ).Else(
+                state.eq(_prbs16_next(state_n))
+            )
+        )
+
+        # Error generation.
+        self.comb += If(self.ce,
+            error.eq((self.ia != state[:12]) | (self.ib != state_n[:12]))
+        )
 
         # Sync generation.
         self.sync_timer = WaitTimer(1024)

--- a/litex_m2sdr/gateware/ad9361/prbs.py
+++ b/litex_m2sdr/gateware/ad9361/prbs.py
@@ -35,6 +35,32 @@ class AD9361PRBSGenerator(LiteXModule):
         self.sync += If(self.ce, data.eq(_prbs16_next(data)))
         self.comb += self.o.eq(data)
 
+# AD9361 PRBS 1R1T Generator -----------------------------------------------------------------------
+
+class AD9361PRBS1R1TGenerator(LiteXModule):
+    """PRBS generator for 1R1T mode.
+
+    In 1R1T mode the a/b slots represent two consecutive samples of the same
+    stream. Export both samples for the current word and advance the reference
+    by two words on each accepted PHY word.
+    """
+    def __init__(self, seed=0x0a54):
+        self.ce     = Signal(reset=1)
+        self.o      = Signal(16)
+        self.o_next = Signal(16)
+
+        # # #
+
+        data   = Signal(16, reset=seed)
+        data_n = Signal(16)
+
+        self.comb += data_n.eq(_prbs16_next(data))
+        self.sync += If(self.ce, data.eq(_prbs16_next(data_n)))
+        self.comb += [
+            self.o.eq(data),
+            self.o_next.eq(data_n),
+        ]
+
 # AD9361 PRBS Checker ----------------------------------------------------------------------------
 
 class AD9361PRBSChecker(LiteXModule):

--- a/litex_m2sdr/software/user/m2sdr_util.c
+++ b/litex_m2sdr/software/user/m2sdr_util.c
@@ -3623,24 +3623,50 @@ static void rfic_prbs_build_sequence(uint16_t *seq)
     }
 }
 
-static uint16_t rfic_prbs_expected(const uint16_t *seq, const struct rfic_prbs_phase *phase, unsigned lane)
+static unsigned rfic_prbs_word_step(enum m2sdr_channel_layout channel_layout)
 {
-    unsigned word_advance = (phase->lane_mod + lane) / RFIC_LOOPBACK_LANES_PER_WORD;
-    return seq[(phase->phase + word_advance) % RFIC_PRBS_LEN];
+    return channel_layout == M2SDR_CHANNEL_LAYOUT_1T1R ? 2u : 1u;
 }
 
-static void rfic_prbs_advance(struct rfic_prbs_phase *phase, unsigned lanes)
+static unsigned rfic_prbs_lane_step(enum m2sdr_channel_layout channel_layout,
+                                    unsigned lane_in_word)
+{
+    if (channel_layout == M2SDR_CHANNEL_LAYOUT_1T1R && lane_in_word >= 2)
+        return 1u;
+    return 0u;
+}
+
+static uint16_t rfic_prbs_expected(const uint16_t *seq,
+                                   const struct rfic_prbs_phase *phase,
+                                   enum m2sdr_channel_layout channel_layout,
+                                   unsigned lane)
+{
+    unsigned lane_index = phase->lane_mod + lane;
+    unsigned word_advance = lane_index / RFIC_LOOPBACK_LANES_PER_WORD;
+    unsigned lane_in_word = lane_index % RFIC_LOOPBACK_LANES_PER_WORD;
+    unsigned phase_advance = word_advance * rfic_prbs_word_step(channel_layout);
+
+    phase_advance += rfic_prbs_lane_step(channel_layout, lane_in_word);
+    return seq[(phase->phase + phase_advance) % RFIC_PRBS_LEN];
+}
+
+static void rfic_prbs_advance(struct rfic_prbs_phase *phase,
+                              enum m2sdr_channel_layout channel_layout,
+                              unsigned lanes)
 {
     unsigned total = phase->lane_mod + lanes;
+    unsigned word_advance = total / RFIC_LOOPBACK_LANES_PER_WORD;
 
-    phase->phase = (phase->phase + total / RFIC_LOOPBACK_LANES_PER_WORD) % RFIC_PRBS_LEN;
+    phase->phase = (phase->phase +
+        word_advance * rfic_prbs_word_step(channel_layout)) % RFIC_PRBS_LEN;
     phase->lane_mod = total % RFIC_LOOPBACK_LANES_PER_WORD;
 }
 
 static bool rfic_prbs_match_at(const int16_t *buf,
                                unsigned lanes,
                                const uint16_t *seq,
-                               const struct rfic_prbs_phase *phase)
+                               const struct rfic_prbs_phase *phase,
+                               enum m2sdr_channel_layout channel_layout)
 {
     unsigned sync_lanes = lanes < RFIC_PRBS_SYNC_LANES ? lanes : RFIC_PRBS_SYNC_LANES;
 
@@ -3649,7 +3675,7 @@ static bool rfic_prbs_match_at(const int16_t *buf,
 
     for (unsigned i = 0; i < sync_lanes; i++) {
         uint16_t got = (uint16_t)buf[i] & 0x0fffu;
-        uint16_t expected = rfic_prbs_expected(seq, phase, i);
+        uint16_t expected = rfic_prbs_expected(seq, phase, channel_layout, i);
 
         if (got != expected)
             return false;
@@ -3661,7 +3687,8 @@ static bool rfic_prbs_match_at(const int16_t *buf,
 static bool rfic_prbs_find_sync(const int16_t *buf,
                                 unsigned lanes,
                                 const uint16_t *seq,
-                                struct rfic_prbs_phase *phase)
+                                struct rfic_prbs_phase *phase,
+                                enum m2sdr_channel_layout channel_layout)
 {
     struct rfic_prbs_phase candidate;
 
@@ -3669,8 +3696,10 @@ static bool rfic_prbs_find_sync(const int16_t *buf,
         return false;
 
     for (candidate.phase = 0; candidate.phase < RFIC_PRBS_LEN; candidate.phase++) {
-        for (candidate.lane_mod = 0; candidate.lane_mod < RFIC_LOOPBACK_LANES_PER_WORD; candidate.lane_mod++) {
-            if (rfic_prbs_match_at(buf, lanes, seq, &candidate)) {
+        for (candidate.lane_mod = 0;
+             candidate.lane_mod < RFIC_LOOPBACK_LANES_PER_WORD;
+             candidate.lane_mod++) {
+            if (rfic_prbs_match_at(buf, lanes, seq, &candidate, channel_layout)) {
                 *phase = candidate;
                 return true;
             }
@@ -3684,13 +3713,14 @@ static uint64_t rfic_prbs_check(const int16_t *buf,
                                 unsigned lanes,
                                 const uint16_t *seq,
                                 struct rfic_prbs_phase *phase,
+                                enum m2sdr_channel_layout channel_layout,
                                 bool verbose)
 {
     uint64_t errors = 0;
 
     for (unsigned i = 0; i < lanes; i++) {
         uint16_t got = (uint16_t)buf[i] & 0x0fffu;
-        uint16_t expected = rfic_prbs_expected(seq, phase, i);
+        uint16_t expected = rfic_prbs_expected(seq, phase, channel_layout, i);
 
         if (unlikely(got != expected)) {
             if (verbose && errors < 8) {
@@ -3701,7 +3731,7 @@ static uint64_t rfic_prbs_check(const int16_t *buf,
         }
     }
 
-    rfic_prbs_advance(phase, lanes);
+    rfic_prbs_advance(phase, channel_layout, lanes);
     return errors;
 }
 
@@ -3720,6 +3750,7 @@ static int rfic_prbs_loopback_test(int duration, int64_t sample_rate)
     struct m2sdr_dev *dev = NULL;
     struct m2sdr_config cfg;
     enum m2sdr_format format = M2SDR_FORMAT_SC16_Q11;
+    enum m2sdr_channel_layout channel_layout = M2SDR_CHANNEL_LAYOUT_2T2R;
     const unsigned samples_per_buf = m2sdr_bytes_to_samples(format, M2SDR_BUFFER_BYTES);
     const unsigned lanes_per_buf = M2SDR_BUFFER_BYTES / sizeof(int16_t);
     struct rfic_prbs_phase phase = {0, 0};
@@ -3778,6 +3809,7 @@ static int rfic_prbs_loopback_test(int duration, int64_t sample_rate)
     cfg.bandwidth = sample_rate;
     cfg.loopback = 1;
     cfg.enable_8bit_mode = false;
+    channel_layout = cfg.channel_layout;
     rc = loopback_reset_datapath(dev, NULL);
     if (rc != M2SDR_ERR_OK)
         goto cleanup;
@@ -3813,7 +3845,7 @@ static int rfic_prbs_loopback_test(int duration, int64_t sample_rate)
         (void)m2sdr_get_fpga_prbs_rx_synced(dev, &fpga_synced);
 
         if (!host_synced) {
-            if (!rfic_prbs_find_sync(rx_buf, lanes_per_buf, seq, &phase)) {
+            if (!rfic_prbs_find_sync(rx_buf, lanes_per_buf, seq, &phase, channel_layout)) {
                 stale_buffers++;
                 if (stale_buffers == 1)
                     rfic_prbs_print_rx_preview(rx_buf, lanes_per_buf);
@@ -3829,7 +3861,8 @@ static int rfic_prbs_loopback_test(int duration, int64_t sample_rate)
             host_synced = true;
         }
 
-        uint64_t errors = rfic_prbs_check(rx_buf, lanes_per_buf, seq, &phase, checked_buffers == 0);
+        uint64_t errors = rfic_prbs_check(rx_buf, lanes_per_buf, seq, &phase,
+            channel_layout, checked_buffers == 0);
         total_errors += errors;
         checked_buffers++;
         if (errors)


### PR DESCRIPTION
The AD9361 RX PRBS checker validated each lane (ia/ib) against CONSECUTIVE PRBS values, which is only correct in 2R2T mode where each lane carries one channel's full sequence. In 1R1T mode the a/b slots carry two consecutive samples of a single stream, so each lane sees every other PRBS value and the per-lane checker can never sync -- leaving the 1R1T interface with no working PRBS alignment oracle.

- prbs.py: factor the BIST LFSR step into _prbs16_next(); add AD9361PRBS1R1TChecker that validates the interleaved pair (ia = ref, ib = ref+1, reference advances by 2). The LFSR period (2^16-1) is odd, so the stride-2 subsequence is still full-period and seed resync works.
- core.py: select the per-lane (2R2T) vs interleaved (1R1T) checker by the existing PHY mode CSR; MultiReg the verdict into sys.