### PR TITLE
libm2sdr: improved RFIC overclock for ~100 MHz analog bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,30 @@ Ethernet-only baseboard builds can also enable SATA storage with `--with-sata`, 
 
 When built with `--with-eth --with-eth-ptp`, LiteEth PTP disciplines the existing `time_gen` timebase instead of replacing it. This keeps PPS generation, VRT timestamps, RX/TX headers, and the PCIe PTM/PHC view on the same logical board clock while sourcing that time from Ethernet PTP. Runtime servo tuning, master/sourcePortIdentity reporting, and live status/counter monitoring are available from the host side. Ethernet PTP and White Rabbit are mutually exclusive. For SI5351C boards, `--with-eth-ptp-rfic-clock` adds an optional low-bandwidth PTP-to-FPGA-10MHz discipline loop; software must still select the FPGA clock input with `--sync fpga` / `clock_source=fpga` before the AD9361 reference is derived from that path.
 
+[> Wide Analog Bandwidth (RFIC Overclock)
+------------------------------------------
+
+The AD9361's analog baseband filters are normally limited to ~56 MHz. Requesting a sample rate above 61.44 MSPS (up to 122.88) selects the wide-bandwidth mode automatically:
+
+```bash
+m2sdr_rf --channel-layout 1t1r --sample-rate 122.88e6 ...
+```
+
+Converter half-band stages are bypassed so the data port runs at 2x rate, and the TX/RX baseband filters are force-widened with tuned register words, opening a true ~100 MHz analog passband at 122.88 MSPS. The interface DATA_CLK follows the channel layout: 245.76 MHz in 1T1R (stock gateware) and 491.52 MHz in 2T2R (gateware built with `--with-rfic-oversampling`). The doubled-rate interface framing can come up misaligned, so the configuration PRBS-verifies the interface and retries the clock programming in place until it is aligned (typically 1-2 attempts).
+
+Measured (loopback TX1->RX1 with 40 dB pad + external-receiver cross-check, 3.6 GHz, 100 MHz NR-FR1-TM3.1 64QAM test model):
+
+| Metric                          | Wide (overclock)        | Stock ~56 MHz       |
+|---------------------------------|-------------------------|---------------------|
+| Usable analog bandwidth         | ~100 MHz                | ~56 MHz             |
+| EVM, 100 MHz NR TM3.1 (PDSCH)   | ~10% RMS (*)            | n/a (BW > filter)   |
+| EVM, 10 MHz NR TM3.1            | ~3% RMS                 | ~3% RMS             |
+| No-signal RX floor (rx-gain 55) | -31.6 dBFS              | -34 dBFS            |
+| TX image rejection, tx-att 0    | ~30 dB                  | ~42 dB              |
+| TX image rejection, tx-att >=10 | ~44-58 dB               | ~44-58 dB           |
+
+(*) With TX magnitude pre-emphasis flattening the widened-filter rolloff the per-band effective SNR is uniform (+/-50 MHz); the ~10% ceiling decomposes into ~7% TX (reference/LO phase noise) and ~8.5% RX (widened-BBF noise floor). Best EVM is obtained on the internal clock reference; an external 10 MHz reference costs ~6% EVM through the Si5351's higher multiplication ratio (N=84 vs N=34).
+
 [> Getting Started
 ------------------
 <a id="quick-start"></a>

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -686,9 +686,6 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
         do_init = args.at("bypass_init")[0] == '0';
     }
 
-    if (args.count("oversampling") > 0) {
-        _oversampling = std::stoi(args.at("oversampling"));
-    }
     if (args.count("ad9361_fir_profile") > 0) {
         _ad9361_fir_profile = args.at("ad9361_fir_profile");
     } else if (args.count("fir_profile") > 0) {
@@ -1617,38 +1614,17 @@ void SoapyLiteXM2SDR::setSampleRate(
         rate / 1e6);
 
     uint32_t sample_rate = static_cast<uint32_t>(rate);
-    _rateMult = 1.0;
 
-    if (isLitePCIe()) {
-        /* For PCIe, if the sample rate is above 61.44 MSPS, force 8-bit mode + oversampling. */
-        if (rate > LITEPCIE_8BIT_THRESHOLD) {
-            if (_bitMode != 8) {
-                SoapySDR::logf(SOAPY_SDR_WARNING,
-                    "Sample rate %.2f MSPS requires 8-bit + oversampling on PCIe, overriding bitmode",
-                    rate / 1e6);
-            }
-            _bitMode      = 8;
-            _oversampling = 1;
-        } else {
-            _oversampling = 0;
-        }
-    } else if (isLiteEth()) {
+    if (isLiteEth()) {
         /* For Ethernet, if the sample rate is above 20 MSPS, switch to 8-bit mode. */
         if (rate > LITEETH_8BIT_THRESHOLD) {
-            _bitMode      = 8;
-            _oversampling = 0;
+            _bitMode = 8;
         } else {
-            _bitMode      = 16;
-            _oversampling = 0;
+            _bitMode = 16;
         }
     }
 
-    /* If oversampling is enabled, double the rate multiplier. */
-    if (_oversampling) {
-        _rateMult = 2.0;
-    }
-
-    int64_t hw_sample_rate = static_cast<int64_t>(sample_rate / _rateMult);
+    int64_t hw_sample_rate = static_cast<int64_t>(sample_rate);
 
     if (direction == SOAPY_SDR_TX) {
         _tx_stream.samplerate = rate;
@@ -1665,7 +1641,6 @@ void SoapyLiteXM2SDR::setSampleRate(
     if (_sampleRateHwApplied &&
         _sampleRateHw == hw_sample_rate &&
         _sampleRateHwBitMode == _bitMode &&
-        _sampleRateHwOversampling == _oversampling &&
         _sampleRateHwFirProfile == _ad9361_fir_profile) {
         setSampleMode();
         if (direction == SOAPY_SDR_RX && _rx_stream.opened) {
@@ -1682,9 +1657,8 @@ void SoapyLiteXM2SDR::setSampleRate(
     LiteEthRfOpTimeout timeout("setSampleRate");
 #endif
     /* Check and set FIR decimation/interpolation if actual rate is below 2.5 Msps */
-    double actual_rate = rate / _rateMult;
-    if (actual_rate < 1250000.0) {
-        SoapySDR::logf(SOAPY_SDR_DEBUG, "Setting FIR decimation/interpolation to 4 for rate %f < 1.25 Msps", actual_rate);
+    if (rate < 1250000.0) {
+        SoapySDR::logf(SOAPY_SDR_DEBUG, "Setting FIR decimation/interpolation to 4 for rate %f < 1.25 Msps", rate);
         ad9361_phy->rx_fir_dec    = 4;
         ad9361_phy->tx_fir_int    = 4;
         ad9361_phy->bypass_rx_fir = 0;
@@ -1698,8 +1672,8 @@ void SoapyLiteXM2SDR::setSampleRate(
         ad9361_set_rx_fir_en_dis(ad9361_phy, 1);
         ad9361_set_tx_fir_en_dis(ad9361_phy, 1);
     }
-    else if (actual_rate < 2500000.0) {
-        SoapySDR::logf(SOAPY_SDR_DEBUG, "Setting FIR decimation/interpolation to 2 for rate %f < 2.5 Msps", actual_rate);
+    else if (rate < 2500000.0) {
+        SoapySDR::logf(SOAPY_SDR_DEBUG, "Setting FIR decimation/interpolation to 2 for rate %f < 2.5 Msps", rate);
         ad9361_phy->rx_fir_dec    = 2;
         ad9361_phy->tx_fir_int    = 2;
         ad9361_phy->bypass_rx_fir = 0;
@@ -1742,7 +1716,6 @@ void SoapyLiteXM2SDR::setSampleRate(
             _sampleRateHwApplied = true;
             _sampleRateHw = hw_sample_rate;
             _sampleRateHwBitMode = _bitMode;
-            _sampleRateHwOversampling = _oversampling;
             _sampleRateHwFirProfile = _ad9361_fir_profile;
         }
     }
@@ -1750,13 +1723,6 @@ void SoapyLiteXM2SDR::setSampleRate(
     timeout.throw_if_timed_out();
 #endif
 
-    /* If oversampling is enabled, enable oversampling on the hardware. */
-    if (_oversampling) {
-        ad9361_enable_oversampling(ad9361_phy);
-#if USE_LITEETH
-        timeout.throw_if_timed_out();
-#endif
-    }
 
     /* Finally, update the sample mode (bit depth) based on the new configuration. */
     setSampleMode();
@@ -1795,7 +1761,7 @@ double SoapyLiteXM2SDR::getSampleRate(
         return 0.0;
     }
 
-    return _rateMult * static_cast<double>(sample_rate);
+    return static_cast<double>(sample_rate);
 }
 
 std::vector<double> SoapyLiteXM2SDR::listSampleRates(

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -627,10 +627,12 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
     } else {
         _bitMode = 16;
     }
+    if (_bitMode != 8 && _bitMode != 16)
+        throw std::runtime_error("Invalid bitmode: " + std::to_string(_bitMode) + " (supported: 8, 16)");
 
     /* Configure Mode based on _bitMode */
     SoapySDR::log(SOAPY_SDR_INFO, "Configuring bitmode");
-    m2sdr_set_bitmode(_dev, _bitMode == 8);
+    setSampleMode();
 
 
     /* Configure PCIe Synchronizer and DMA Headers. */
@@ -1621,6 +1623,17 @@ void SoapyLiteXM2SDR::setSampleRate(
             _bitMode = 8;
         } else {
             _bitMode = 16;
+        }
+    } else if (isLitePCIe() && rate > LITEPCIE_8BIT_THRESHOLD) {
+        if (_bitMode == 8) {
+            SoapySDR::logf(SOAPY_SDR_INFO,
+                "PCIe sample rate %.2f MSPS is using 8-bit sample packing",
+                rate / 1e6);
+        } else {
+            SoapySDR::logf(SOAPY_SDR_WARNING,
+                "PCIe sample rate %.2f MSPS keeps 16-bit sample packing; "
+                "use bitmode=8 or a CS8 stream to reduce DMA bandwidth",
+                rate / 1e6);
         }
     }
 

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
@@ -44,7 +44,8 @@ enum class SoapyLiteXM2SDREthernetMode {
  * insertion remains experimental. */
 //#define _TX_DMA_HEADER_TEST
 
-/* Thresholds above which we switch to 8-bit mode: */
+/* Thresholds relevant to 8-bit sample-packing policy. */
+#define LITEPCIE_8BIT_THRESHOLD  61.44e6
 #define LITEETH_8BIT_THRESHOLD   20.0e6
 
 #define DLL_EXPORT __attribute__ ((visibility ("default")))

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
@@ -45,7 +45,6 @@ enum class SoapyLiteXM2SDREthernetMode {
 //#define _TX_DMA_HEADER_TEST
 
 /* Thresholds above which we switch to 8-bit mode: */
-#define LITEPCIE_8BIT_THRESHOLD  61.44e6
 #define LITEETH_8BIT_THRESHOLD   20.0e6
 
 #define DLL_EXPORT __attribute__ ((visibility ("default")))
@@ -478,7 +477,6 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
     bool _sampleRateHwApplied = false;
     int64_t _sampleRateHw = 0;
     uint32_t _sampleRateHwBitMode = 0;
-    uint32_t _sampleRateHwOversampling = 0;
     std::string _sampleRateHwFirProfile;
     bool _bandwidthHwApplied = false;
     uint32_t _bandwidthHw = 0;
@@ -589,13 +587,11 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
     uint8_t _spi_id = 0;
 
     uint32_t _bitMode           = 16;
-    uint32_t _oversampling      = 0;
     uint32_t _nChannels         = 2;
     uint32_t _samplesPerComplex = 2;
     uint32_t _bytesPerSample    = 2;
     uint32_t _bytesPerComplex   = 4;
     float    _samplesScaling    = 2047.0f;
-    float    _rateMult          = 1.0f;
 
     // register protection
     /* Serializes the RF control entry points (set/get rate, frequency,

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRRegistration.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRRegistration.cpp
@@ -134,7 +134,6 @@ SoapySDR::Kwargs createDeviceKwargs(
         {"identification", info.identification},
         {"version",        "1234"},
         {"label",          ""},
-        {"oversampling",   "0"},
     };
     if (addr.transport == M2SDR_TRANSPORT_KIND_LITEETH)
         dev["eth_ip"] = addr.ip;

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
@@ -67,7 +67,7 @@ static std::vector<size_t> parse_channel_list(const std::string &channels_str)
     return chans;
 }
 
-static enum m2sdr_format soapy_stream_format_to_m2sdr(const std::string &format);
+static enum m2sdr_format soapy_stream_format_to_m2sdr(const std::string &format, uint32_t bit_mode);
 
 static std::string get_kwargs_string(
     const SoapySDR::Kwargs &stream_args,
@@ -381,7 +381,7 @@ SoapySDR::Stream *SoapyLiteXM2SDR::setupStream(
                 setSampleMode();
             }
 
-            enum m2sdr_format m2fmt = soapy_stream_format_to_m2sdr(format);
+            enum m2sdr_format m2fmt = soapy_stream_format_to_m2sdr(format, _bitMode);
             m2sdr_stream_config_t config;
             struct m2sdr_stream_info info;
 
@@ -504,7 +504,7 @@ SoapySDR::Stream *SoapyLiteXM2SDR::setupStream(
                 setSampleMode();
             }
 
-            enum m2sdr_format m2fmt = soapy_stream_format_to_m2sdr(format);
+            enum m2sdr_format m2fmt = soapy_stream_format_to_m2sdr(format, _bitMode);
             m2sdr_stream_config_t config;
             struct m2sdr_stream_info info;
 
@@ -982,9 +982,10 @@ static inline int timeout_us_to_ms(long timeout_us)
     return static_cast<int>((timeout_us + 999) / 1000);
 }
 
-static enum m2sdr_format soapy_stream_format_to_m2sdr(const std::string &format)
+static enum m2sdr_format soapy_stream_format_to_m2sdr(const std::string &format, uint32_t bit_mode)
 {
-    return format == SOAPY_SDR_CS8 ? M2SDR_FORMAT_SC8_Q7 : M2SDR_FORMAT_SC16_Q11;
+    return (format == SOAPY_SDR_CS8 || bit_mode == 8) ?
+        M2SDR_FORMAT_SC8_Q7 : M2SDR_FORMAT_SC16_Q11;
 }
 
 void SoapyLiteXM2SDR::refreshTimedTxDefaults()

--- a/litex_m2sdr/software/soapysdr/README.md
+++ b/litex_m2sdr/software/soapysdr/README.md
@@ -70,9 +70,10 @@ You can pass device arguments to configure the driver. These are most useful whe
   The driver intentionally exposes only the board-connected RF ports, not the full AD9361 antenna enum.
 - **Per-channel antenna**: `rx_antenna0=A_BALANCED`, `rx_antenna1=A_BALANCED`, `tx_antenna0=A`, `tx_antenna1=A`
 - **Bit mode**: `bitmode=8|16`
-- **Oversampling**: `oversampling=0|1`
 - **AD9361 1x FIR profile**: `ad9361_fir_profile=legacy|bypass|match|wide`
-  - Useful for `122.88 MSPS` oversampling experiments (these profiles affect the AD9361 `1x` FIR path used above `61.44 MSPS`).
+  - Rates above `61.44 MSPS` automatically use the wide-bandwidth data-port mode; these profiles affect the AD9361 `1x` FIR path used by that mode.
+- **PCIe high-rate packing**: `bitmode=8`
+  - Useful above `61.44 MSPS` when DMA bandwidth matters. The driver no longer silently overrides PCIe to 8-bit mode, so request `bitmode=8` or a `CS8` stream explicitly.
 - **Clock source**: `clock_source=internal|external|fpga`
   - `internal` keeps the local XO path.
   - `external` selects the SI5351C `10MHz` CLKIN from the uFL connector.
@@ -97,12 +98,12 @@ You can pass device arguments to configure the driver. These are most useful whe
 
 Example:
 ```bash
-SoapySDRUtil --probe="driver=LiteXM2SDR,rx_agc_mode=fast,bitmode=8,oversampling=1"
+SoapySDRUtil --probe="driver=LiteXM2SDR,rx_agc_mode=fast,bitmode=8"
 ```
 
 Example (122.88 MSPS edge-flatness A/B test):
 ```bash
-SoapySDRUtil --probe="driver=LiteXM2SDR,bitmode=8,oversampling=1,ad9361_fir_profile=wide"
+SoapySDRUtil --probe="driver=LiteXM2SDR,bitmode=8,ad9361_fir_profile=wide"
 ```
 
 Example (Etherbone control + Soapy RX over FPGA VRT):

--- a/litex_m2sdr/software/user/ad9361/ad9361.c
+++ b/litex_m2sdr/software/user/ad9361/ad9361.c
@@ -7468,57 +7468,154 @@ int32_t ad9361_rssi_gain_step_calib(struct ad9361_rf_phy *phy)
  *  More information:
  *  - https://www.nuand.com/2023-02-release-122-88mhz-bandwidth
  *  - https://destevez.net/2023/02/running-the-ad9361-at-122-88-msps
- *
- * One key difference from BladeRF is that M2SDR, in X4 mode, has sufficient bandwidth on the
- * PCIe link to avoid truncating data from 12-bit to 8-bit.
- *
- * When operating in 2T2R mode, the FPGA to RFIC interface is overclocked from 245.76MHz to
- * 491.52MHz. Surprisingly, this seems to work well with updated timing constraints. However,
- * switching to 1T1R mode avoids overclocking this interface and limits overclocking to the
- * AD9631 part.
- *
  */
+
+/* AD9361 oversampling + baseband-filter widening (wide-bandwidth mode).
+ *
+ * The AD9361's analog baseband filters calibrate to ~56 MHz at most. This
+ * function bypasses converter half-band stages so the data port runs at 2x
+ * the configured rate, and force-widens the TX/RX baseband filters by
+ * driving the BBF resistor/capacitor words to their extreme values
+ * (caps -> 0 = minimum capacitance = maximum bandwidth), opening the analog
+ * passband to ~100 MHz at 122.88 MSPS.
+ *
+ * Apply AFTER the normal RF configuration. The LVDS framing follows the
+ * number of enabled channels (UG-570 Table 50), so at 122.88 MSPS DATA_CLK
+ * is 245.76 MHz with one channel enabled and 491.52 MHz with two; callers
+ * must ensure the channel enables in 0x002/0x003 (preserved by this
+ * function) match what the connected interface supports.
+ *
+ * Measured characteristics vs the stock ~56 MHz path (loopback +
+ * external-receiver verified, 3.6 GHz): RX noise floor ~2.5-3 dB higher
+ * (widened-BBF self-noise); TX image rejection ~30 dB at tx-att 0 vs ~42 dB
+ * stock, matching stock (~44-58 dB) at tx-att >= 10 (the gain dependence is
+ * the AD9361's attenuation-dependent TX quad cal, present in both modes).
+ *
+ * References: AD9361 Register Map (doc/ad9361/ad9361_register_map.pdf) for
+ * the per-register field layouts; UG-570 (doc/ad9361/ad9361_user_guide.pdf)
+ * for the LVDS framing (Table 50), BBF architecture and delay registers.
+ * "Measured" notes below come from A/B experiments on a 100 MHz NR-FR1-TM3.1
+ * loopback (per-band coherence effective SNR + MATLAB 5G Toolbox EVM),
+ * cross-checked against an external receiver. */
 void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
 {
-    /* OC Register: General oversampling control. */
-    ad9361_spi_write(phy->spi, 0x003, 0x54);
+    /* Filter-control registers: halve the decimation/interpolation so the data
+     * port runs at 2x the configured rate (the converters themselves keep their
+     * BBPLL-derived clocks; "overclock" only removes digital filter stages).
+     * IMPORTANT: bits [7:6] of 0x002/0x003 are the TX/RX channel enables and
+     * determine the LVDS framing (UG-570 Table 50): 2 channels enabled forces
+     * 2R2T timing, doubling DATA_CLK again (491.52 MHz at 122.88 MSPS - beyond
+     * both the AD9361 LVDS spec and the stock 245.76 MHz gateware). So preserve
+     * the channel enables via read-modify-write rather than writing fixed
+     * 2-channel values. */
+    {
+        /* Bits [7:6] of 0x002/0x003 are the TX/RX channel enables and select
+         * the LVDS framing (UG-570 Table 50); they are preserved here - the
+         * caller decides how many channels the interface can carry. */
+        uint8_t rx_ctrl = ad9361_spi_read(phy->spi, 0x003);
+        uint8_t tx_ctrl = ad9361_spi_read(phy->spi, 0x002);
+        /* 0x003 (Rx Enable & Filter Ctrl) low bits 0x14: RHB3 dec2 ([5:4]=01),
+         * RHB2 bypassed ([3]=0), RHB1 dec2 ([2]=1), RX FIR off ([1:0]=00):
+         * total decimation 4 from a 4x-rate ADC clock = 2x port rate. */
+        ad9361_spi_write(phy->spi, 0x003, (rx_ctrl & 0xC0) | 0x14);
+        /* 0x002 (Tx Enable & Filter Ctrl) low bits 0x00: all THB stages and
+         * the TX FIR bypassed - the DAC runs directly at the port rate. */
+        ad9361_spi_write(phy->spi, 0x002, (tx_ctrl & 0xC0) | 0x00);
+    }
 
-#if 0 /* Note: Creates a symmetry in the spectrum for some gains values...*/
-    /* TX Register Assignments: Configuring TX path for oversampling. */
-    ad9361_spi_write(phy->spi, 0x02, 0xc0);  /* TX Enable and Filter Control. */
-    ad9361_spi_write(phy->spi, 0xc2, 0x9f);  /* TX BBF (Baseband Filter) R1.  */
-    ad9361_spi_write(phy->spi, 0xc3, 0x9f);  /* TX BBF R2.                    */
-    ad9361_spi_write(phy->spi, 0xc4, 0x9f);  /* TX BBF R3.                    */
-    ad9361_spi_write(phy->spi, 0xc5, 0x9f);  /* TX BBF R4.                    */
-    ad9361_spi_write(phy->spi, 0xc6, 0x9f);  /* TX BBF Real Pole Word.        */
-    ad9361_spi_write(phy->spi, 0xc7, 0x00);  /* TX BBF Capacitor C1.          */
-    ad9361_spi_write(phy->spi, 0xc8, 0x00);  /* TX BBF Capacitor C2.          */
-    ad9361_spi_write(phy->spi, 0xc9, 0x00);  /* TX BBF Real Pole Word.        */
-#endif
+    /* TX baseband filter (3rd-order Butterworth, corner ~ 1/(2.pi.R.C)):
+     * resistor words to 0x9f = override-enable bit (0x80) + maximum code
+     * (0x1f), capacitor words to 0x00 = minimum C; both push the corner as
+     * high as it goes. 0x0c2..0x0cb are pure override registers - the normal
+     * calibration never rewrites them. Measured: with the RX side already
+     * widened, adding the TX widening took 100 MHz NR EVM from 20.6% to 14%
+     * (pre-emphasis included); without it the outer ~20 MHz of TX rolls off
+     * behind the calibrated ~56 MHz corner. */
+    ad9361_spi_write(phy->spi, 0x0c2, 0x9f); /* TX BBF R1.            */
+    ad9361_spi_write(phy->spi, 0x0c3, 0x9f); /* TX BBF R2.            */
+    ad9361_spi_write(phy->spi, 0x0c4, 0x9f); /* TX BBF R3.            */
+    ad9361_spi_write(phy->spi, 0x0c5, 0x9f); /* TX BBF R4.            */
+    ad9361_spi_write(phy->spi, 0x0c6, 0x9f); /* TX BBF real pole word.*/
+    ad9361_spi_write(phy->spi, 0x0c7, 0x00); /* TX BBF C1 -> 0.       */
+    ad9361_spi_write(phy->spi, 0x0c8, 0x00); /* TX BBF C2 -> 0.       */
+    ad9361_spi_write(phy->spi, 0x0c9, 0x00); /* TX BBF real pole word.*/
+    /* R2B is part of the same override set (0x0c2..0x0cb); maxing it
+     * measures ~+1 dB effective SNR at the band edges. */
+    ad9361_spi_write(phy->spi, 0x0cb, 0x1f); /* TX BBF R2B (max).     */
 
-#if 0 /* Note: Creates a symmetry in the spectrum for some gains values... */
-    /* RX Register Assignments: Configuring RX path for oversampling. */
-    ad9361_spi_write(phy->spi, 0x1e0, 0xBF);
-    ad9361_spi_write(phy->spi, 0x1e4, 0xFF);
-    ad9361_spi_write(phy->spi, 0x1f2, 0xFF);
-#endif
+    /* TX secondary (post-BBF single-pole) filter capacitor word: the driver's
+     * ad9361_tx_bb_second_filter_calib() places this pole at 2.5 x BBBW and
+     * BBBW is clamped to 20 MHz, so it calibrates to ~50 MHz - right on a
+     * 100 MHz carrier's band edge. Cap word 0 = minimum C = highest corner.
+     * Measured: ~+0.5 dB effective SNR at the band edges. */
+    ad9361_spi_write(phy->spi, 0x0d2, 0x00); /* TX secondary LPF cap -> 0. */
 
-#if 0 /* Note: Improves RF Bandwidth but creates a symmetry in the spectrum for some gains values... */
-    /* Miller and BBF capacitors settings. */
-    ad9361_spi_write(phy->spi, 0x1e7, 0x00);
-    ad9361_spi_write(phy->spi, 0x1e8, 0x00);
-    ad9361_spi_write(phy->spi, 0x1e9, 0x00);
-    ad9361_spi_write(phy->spi, 0x1ea, 0x00);
-    ad9361_spi_write(phy->spi, 0x1eb, 0x00);
-    ad9361_spi_write(phy->spi, 0x1ec, 0x00);
-    ad9361_spi_write(phy->spi, 0x1ed, 0x00);
-    ad9361_spi_write(phy->spi, 0x1ee, 0x00);
-    ad9361_spi_write(phy->spi, 0x1ef, 0x00);
-    ad9361_spi_write(phy->spi, 0x1e0, 0xBF);
-#endif
+    /* RX baseband filter (bi-quad + pole, UG-570 RX BBF chapter). NOTE the
+     * polarity is OPPOSITE to TX: the RX gain-setting resistors (R1A, R5)
+     * must be driven to their MAXIMUM while only the capacitors go to zero.
+     * R1A is the DENOMINATOR of the bi-quad gain (R4/R1A) and R5 of the pole
+     * gain (R6/R5); zeroing them (as a naive copy of the TX recipe does)
+     * collapses the RX path - measured as "no signal, ~0 dB IQ image". */
+    {
+        ad9361_spi_write(phy->spi, 0x1e0, 0xbf); /* RX BBF R1A: force + 0x3f (max). */
+        ad9361_spi_write(phy->spi, 0x1e4, 0xff); /* RX BBF R5 (max).      */
+        /* R5 tune (0x1f2) must be ZERO while R5 (0x1e4/0x1e5) is nonzero
+         * (UG-570: the two gain paths are mutually exclusive). The inverse
+         * configuration (R5=0, R5-tune=0xff) was measured to collapse the
+         * passband entirely. */
+        ad9361_spi_write(phy->spi, 0x1f2, 0x00);
+        /* R2346 (R2/R3/R4/R6) forced to maximum: R4 and R6 are the NUMERATORS
+         * of the bi-quad (R4/R1A) and pole (R6/R5) gains, so maxing them buys
+         * back the gain lost to the forced-max R1A/R5 denominators. Measured:
+         * ~+10 dB effective SNR at the +/-44-49 MHz band edges (and a flatter
+         * passband) on a 100 MHz NR carrier vs leaving it calibrated. */
+        ad9361_spi_write(phy->spi, 0x1e6, 0x87);
+        ad9361_spi_write(phy->spi, 0x1e7, 0x00); /* RX BBF C1 MSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1e8, 0x00); /* RX BBF C1 LSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1e9, 0x00); /* RX BBF C2 MSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1ea, 0x00); /* RX BBF C2 LSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1eb, 0x00); /* RX BBF C3 MSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1ec, 0x00); /* RX BBF C3 LSB -> 0.   */
+        ad9361_spi_write(phy->spi, 0x1ed, 0x00); /* RX BBF CC1 ctr -> 0.  */
+        ad9361_spi_write(phy->spi, 0x1ee, 0x60); /* Register map: "must be 0x60"; the
+                                                  * chip also calibrates it to 0x60.
+                                                  * Zeroing it was part of the old
+                                                  * disabled recipe's artifact. */
+        ad9361_spi_write(phy->spi, 0x1ef, 0x00); /* RX BBF CC2 ctr -> 0.  */
+        ad9361_spi_write(phy->spi, 0x1e0, 0xbf); /* RX BBF R1A (re-asserted per doc). */
+    }
 
-#if 0 /* Note: Hidden feature? Does not seems to impact spectrum. */
-    /* BIST and Data Port Test Config: Must be set to 0x03. */
+    /* 0x3F6 (BIST and Data Port Test Config): register map requires the low
+     * bits set this way for normal data-port operation at this rate. */
     ad9361_spi_write(phy->spi, 0x3f6, 0x03);
-#endif
+
+    /* Interface clock/data delays (UG-570 digital-interface delay registers
+     * 0x006/0x007, ~0.3 ns per tap). The init-table delays were chosen for
+     * DATA_CLK <= 122.88 MHz; at the doubled 245.76 MHz the DDR unit interval
+     * is ~2 ns and the measured RX eye is only 4 of 16 taps wide, with the
+     * defaults at its edge - the cause of intermittently misaligned
+     * (full-scale noise) captures. Values below are the eye midpoints from
+     * the PRBS delay scan (`m2sdr_rf --sample-rate 61.44e6 --calibrate-delay`,
+     * 61.44 MSPS 2T2R = electrically the same DATA_CLK 245.76 MHz): RX eye
+     * 4 taps -> clk 1/data 2; TX eye 14 taps -> clk 6/data 7. */
+    ad9361_spi_write(phy->spi, REG_RX_CLOCK_DATA_DELAY, 0x12); /* clk 1 / data 2 */
+    ad9361_spi_write(phy->spi, REG_TX_CLOCK_DATA_DELAY, 0x67); /* clk 6 / data 7 */
+
+    /* Per-board override of the interface delays from the environment
+     * (M2SDR_OC_RX_DELAY / M2SDR_OC_TX_DELAY, raw register byte: clk delay in
+     * [7:4], data delay in [3:0]) for boards whose eye differs. */
+    {
+        const char *s;
+        if ((s = getenv("M2SDR_OC_RX_DELAY")) != NULL) {
+            uint8_t v = (uint8_t)strtoul(s, NULL, 0);
+            ad9361_spi_write(phy->spi, REG_RX_CLOCK_DATA_DELAY, v);
+            printf("RFIC overclock: RX clock/data delay override 0x%02x.\n", v);
+        }
+        if ((s = getenv("M2SDR_OC_TX_DELAY")) != NULL) {
+            uint8_t v = (uint8_t)strtoul(s, NULL, 0);
+            ad9361_spi_write(phy->spi, REG_TX_CLOCK_DATA_DELAY, v);
+            printf("RFIC overclock: TX clock/data delay override 0x%02x.\n", v);
+        }
+    }
+
 }

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr.h
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr.h
@@ -528,7 +528,6 @@ struct m2sdr_config {
     bool    calibrate_interface_delay;
     int32_t bist_tone_freq;
     bool    enable_8bit_mode;
-    bool    enable_oversample;
     /* Preferred typed RF topology controls. */
     enum m2sdr_channel_layout channel_layout;
     enum m2sdr_clock_source clock_source;

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
@@ -392,7 +392,7 @@ static int m2sdr_apply_channel_layout(struct m2sdr_dev *dev,
  * both layouts. (An earlier dual-channel-enable bug made 1T1R appear to run
  * at twice the programmed rate; the port then carried both RX channels.) */
 static int m2sdr_stream_to_ad9361_sample_rate(int64_t stream_rate,
-                                              bool enable_oversample,
+                                              bool half_rate,
                                               uint32_t *ad9361_rate)
 {
     uint64_t divisor = 1;
@@ -401,7 +401,7 @@ static int m2sdr_stream_to_ad9361_sample_rate(int64_t stream_rate,
     if (!ad9361_rate || stream_rate <= 0 || stream_rate > UINT32_MAX)
         return M2SDR_ERR_RANGE;
 
-    if (enable_oversample)
+    if (half_rate)
         divisor *= 2;
 
     rounded = ((uint64_t)stream_rate + divisor / 2) / divisor;
@@ -530,22 +530,22 @@ static int m2sdr_configure_samplerate(struct ad9361_rf_phy *phy,
     M2SDR_LOGF("Setting TX/RX Samplerate to %f MSPS.\n", cfg->sample_rate / 1e6);
 
     (void)channel_layout;
+    /* Rates above the AD9361 clock-chain limit (61.44 MSPS, up to 122.88) run
+     * the chip's clock chain at half rate with the data port at 2x
+     * (wide-bandwidth mode, see ad9361_enable_oversampling()). */
     rc = m2sdr_stream_to_ad9361_sample_rate(cfg->sample_rate,
-        cfg->enable_oversample, &actual_samplerate);
+        cfg->sample_rate > 61440000, &actual_samplerate);
     if (rc != M2SDR_ERR_OK)
         return rc;
 
     if (actual_samplerate != (uint32_t)cfg->sample_rate) {
-        M2SDR_LOGF("Programming AD9361 Samplerate to %f MSPS with oversample.\n",
+        M2SDR_LOGF("Programming AD9361 Samplerate to %f MSPS (wide-bandwidth mode).\n",
             actual_samplerate / 1e6);
     }
 
     if (actual_samplerate > 61440000U) {
-        fprintf(stderr, "AD9361 programmed sample rate %.3f MSPS exceeds the clock-chain limit of 61.440 MSPS",
-            actual_samplerate / 1e6);
-        if (!cfg->enable_oversample)
-            fprintf(stderr, "; use --oversample for 122.88 MSPS effective FPGA rate");
-        fprintf(stderr, ".\n");
+        fprintf(stderr, "Requested sample rate %.3f MSPS exceeds the maximum of 122.880 MSPS.\n",
+            cfg->sample_rate / 1e6);
         return M2SDR_ERR_INVAL;
     }
 
@@ -591,6 +591,7 @@ static int m2sdr_configure_bandwidth(struct ad9361_rf_phy *phy, const struct m2s
         return M2SDR_ERR_IO;
     return M2SDR_ERR_OK;
 }
+
 
 /* Program the TX and RX local oscillator frequencies. */
 static int m2sdr_configure_frequencies(struct ad9361_rf_phy *phy, const struct m2sdr_config *cfg)
@@ -918,6 +919,109 @@ restore:
     return rc;
 }
 
+/* In-mode digital interface alignment verify for the wide-bandwidth mode.
+ *
+ * The doubled-DATA_CLK interface can come up misaligned (the capture lands
+ * on the wrong DDR/frame phase, yielding full-scale noise-like samples); the
+ * chip<->FPGA framing phase is re-rolled by each clock programming, so the
+ * caller retries the rate programming until this verify passes. Two probes,
+ * both read the FPGA PRBS RX checker:
+ *
+ *  1. AD9361 BIST PRBS injected at the RX path: validates RX capture framing
+ *     end-to-end. In 1R1T mode this requires the gateware's interleaved
+ *     (1R1T-aware) checker; on older gateware this probe never syncs and the
+ *     verify falls through to probe 2.
+ *  2. FPGA PRBS TX through the AD9361 data-port loopback: in 1R1T mode each
+ *     RX lane sees consecutive PRBS values, so the stock per-lane checkers
+ *     can sync; also exercises the TX direction. Acquisition is restarted a
+ *     few times (the checker must catch the seed state to lock).
+ *
+ * A synced verdict has shown no false positives; a failed verdict can be a
+ * false negative on probe-2-only gateware, costing one retry.
+ *
+ * Returns M2SDR_ERR_OK if aligned, M2SDR_ERR_IO if not (retry). */
+static int m2sdr_wide_bandwidth_verify(struct m2sdr_dev *dev)
+{
+    struct ad9361_rf_phy *phy;
+    uint32_t saved_prbs_tx = 0;
+    uint8_t obs, bist;
+    bool synced = false;
+    int attempt, i;
+    int rc;
+
+    rc = m2sdr_require_phy(dev, &phy);
+    if (rc != M2SDR_ERR_OK)
+        return rc;
+    if (m2sdr_reg_read(dev, CSR_AD9361_PRBS_TX_ADDR, &saved_prbs_tx) != 0)
+        return M2SDR_ERR_IO;
+    obs  = ad9361_spi_read(phy->spi, REG_OBSERVE_CONFIG);
+    bist = ad9361_spi_read(phy->spi, REG_BIST_CONFIG);
+
+    /* Probe 1: chip BIST PRBS -> RX path -> FPGA checker. */
+    (void)m2sdr_write_prbs_tx_ctrl(dev, 0);
+    ad9361_spi_write(phy->spi, REG_BIST_CONFIG, BIST_CTRL_POINT(2) | BIST_ENABLE);
+    for (i = 0; i < 40 && !synced; i++) {
+        mdelay(5);
+        (void)m2sdr_read_prbs_synced(dev, &synced);
+    }
+    ad9361_spi_write(phy->spi, REG_BIST_CONFIG, 0x00);
+    if (synced)
+        M2SDR_LOGF("Wide-bandwidth verify: RX BIST PRBS synced.\n");
+
+    /* Probe 2: FPGA PRBS TX -> chip data-port loopback -> FPGA checker. */
+    if (!synced) {
+        ad9361_spi_write(phy->spi, REG_OBSERVE_CONFIG,
+            (uint8_t)((obs & ~DATA_PORT_SP_HD_LOOP_TEST_OE) | DATA_PORT_LOOP_TEST_ENABLE));
+        for (attempt = 0; attempt < 4 && !synced; attempt++) {
+            (void)m2sdr_write_prbs_tx_ctrl(dev, 0);
+            mdelay(2);
+            (void)m2sdr_write_prbs_tx_ctrl(dev, 1u << CSR_AD9361_PRBS_TX_ENABLE_OFFSET);
+            for (i = 0; i < 10 && !synced; i++) {
+                mdelay(10);
+                (void)m2sdr_read_prbs_synced(dev, &synced);
+            }
+        }
+        ad9361_spi_write(phy->spi, REG_OBSERVE_CONFIG, obs);
+        if (synced)
+            M2SDR_LOGF("Wide-bandwidth verify: TX loopback PRBS synced.\n");
+    }
+
+    (void)m2sdr_write_prbs_tx_ctrl(dev, saved_prbs_tx);
+    ad9361_spi_write(phy->spi, REG_BIST_CONFIG, bist);
+
+    if (!synced)
+        M2SDR_LOGF("Wide-bandwidth verify: interface NOT aligned.\n");
+    return synced ? M2SDR_ERR_OK : M2SDR_ERR_IO;
+}
+
+/* Program the AD9361 sampling clocks for the wide-bandwidth mode and verify
+ * the doubled-rate interface, retrying in place: the interface framing phase
+ * is re-rolled by each clock programming, so a misaligned outcome is
+ * recovered by simply programming again. The verify briefly drives the chip
+ * BIST/loopback paths, so a concurrent stream glitches while this runs. */
+static int m2sdr_wide_bandwidth_bringup(struct m2sdr_dev *dev,
+                                        struct ad9361_rf_phy *phy,
+                                        uint32_t ad9361_rate)
+{
+    int rc = M2SDR_ERR_IO;
+    int try_;
+
+    for (try_ = 1; try_ <= 20; try_++) {
+        if (m2sdr_from_ad9361_rc(ad9361_set_tx_sampling_freq(phy, ad9361_rate)) != M2SDR_ERR_OK)
+            return M2SDR_ERR_IO;
+        if (m2sdr_from_ad9361_rc(ad9361_set_rx_sampling_freq(phy, ad9361_rate)) != M2SDR_ERR_OK)
+            return M2SDR_ERR_IO;
+        ad9361_enable_oversampling(phy);
+        rc = m2sdr_wide_bandwidth_verify(dev);
+        if (rc == M2SDR_ERR_OK) {
+            M2SDR_LOGF("Wide-bandwidth interface verified aligned (try %d).\n", try_);
+            return M2SDR_ERR_OK;
+        }
+    }
+    M2SDR_LOGF("Wide-bandwidth interface failed to align.\n");
+    return rc;
+}
+
 static int m2sdr_run_bist(const struct m2sdr_config *cfg, struct m2sdr_dev *dev, struct ad9361_rf_phy *phy)
 {
     if (cfg->bist_tx_tone) {
@@ -1050,7 +1154,6 @@ void m2sdr_config_init(struct m2sdr_config *cfg)
     cfg->bist_prbs         = false;
     cfg->calibrate_interface_delay = false;
     cfg->enable_8bit_mode  = false;
-    cfg->enable_oversample = false;
     cfg->channel_layout    = M2SDR_CHANNEL_LAYOUT_2T2R;
     cfg->clock_source      = M2SDR_CLOCK_SOURCE_INTERNAL;
     cfg->chan_mode         = NULL;
@@ -1150,7 +1253,8 @@ int m2sdr_apply_config(struct m2sdr_dev *dev, const struct m2sdr_config *cfg)
 
     dev->rf_channel_layout = channel_layout;
     dev->rf_channel_layout_valid = 1;
-    dev->rf_oversample_enabled = cfg->enable_oversample ? 1 : 0;
+    /* Wide-bandwidth (2x data port) is selected by the requested rate. */
+    dev->rf_oversample_enabled = (cfg->sample_rate > 61440000) ? 1 : 0;
 
     rc = m2sdr_configure_samplerate(phy, cfg, channel_layout);
     if (rc != M2SDR_ERR_OK)
@@ -1184,8 +1288,21 @@ int m2sdr_apply_config(struct m2sdr_dev *dev, const struct m2sdr_config *cfg)
     if (rc != M2SDR_ERR_OK)
         return rc;
 
-    if (cfg->enable_oversample)
-        ad9361_enable_oversampling(phy);
+    /* Applied last: above the AD9361 clock-chain limit the chip ran at half
+     * rate so far; now switch the data port to 2x and open the analog
+     * passband to ~100 MHz (wide-bandwidth mode), verified and retried in
+     * place until the doubled-rate interface comes up aligned. */
+    if (cfg->sample_rate > 61440000) {
+        uint32_t ad9361_rate;
+
+        M2SDR_LOGF("Applying wide-bandwidth mode (AD9361 oversampling + BBF widening).\n");
+        rc = m2sdr_stream_to_ad9361_sample_rate(cfg->sample_rate, true, &ad9361_rate);
+        if (rc != M2SDR_ERR_OK)
+            return rc;
+        rc = m2sdr_wide_bandwidth_bringup(dev, phy, ad9361_rate);
+        if (rc != M2SDR_ERR_OK)
+            return rc;
+    }
 
     return M2SDR_ERR_OK;
 }
@@ -1231,15 +1348,29 @@ int m2sdr_set_sample_rate(struct m2sdr_dev *dev, int64_t rate)
     if (rc != M2SDR_ERR_OK)
         return rc;
 
-    rc = m2sdr_stream_to_ad9361_sample_rate(rate,
-        dev->rf_oversample_enabled != 0, &actual_rate);
-    if (rc != M2SDR_ERR_OK)
-        return rc;
+    /* Rates above the AD9361 clock-chain limit select the wide-bandwidth
+     * mode (see ad9361_enable_oversampling()). Callers pass the STREAM rate;
+     * the halving is handled here. */
+    {
+        bool wide = rate > 61440000;
 
-    if (m2sdr_from_ad9361_rc(ad9361_set_tx_sampling_freq(phy, actual_rate)) != M2SDR_ERR_OK)
-        return M2SDR_ERR_IO;
-    if (m2sdr_from_ad9361_rc(ad9361_set_rx_sampling_freq(phy, actual_rate)) != M2SDR_ERR_OK)
-        return M2SDR_ERR_IO;
+        rc = m2sdr_stream_to_ad9361_sample_rate(rate, wide, &actual_rate);
+        if (rc != M2SDR_ERR_OK)
+            return rc;
+
+        if (wide) {
+            rc = m2sdr_wide_bandwidth_bringup(dev, phy, actual_rate);
+            if (rc != M2SDR_ERR_OK)
+                return rc;
+        } else {
+            if (m2sdr_from_ad9361_rc(ad9361_set_tx_sampling_freq(phy, actual_rate)) != M2SDR_ERR_OK)
+                return M2SDR_ERR_IO;
+            if (m2sdr_from_ad9361_rc(ad9361_set_rx_sampling_freq(phy, actual_rate)) != M2SDR_ERR_OK)
+                return M2SDR_ERR_IO;
+        }
+
+        dev->rf_oversample_enabled = wide ? 1 : 0;
+    }
     return M2SDR_ERR_OK;
 }
 

--- a/litex_m2sdr/software/user/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/m2sdr_rf.c
@@ -37,12 +37,13 @@ static void help(void)
            "  -p, --port PORT        Port number (default: 1234).\n"
            "      --format FMT       Sample format: sc16 or sc8 (default: sc16).\n"
            "      --8bit             Legacy alias for --format sc8.\n"
-           "      --oversample       Enable oversample mode.\n"
            "      --channel-layout M Channel mode: 1t1r or 2t2r (default: 2t2r).\n"
            "      --sync MODE        Clock source: internal, external, or fpga.\n"
            "\n"
            "      --refclk-freq HZ   Set the RefClk frequency in Hz (default: %" PRId64 ").\n"
-           "      --sample-rate SPS  Set RF sample rate in SPS (default: %d, accepts 30.72e6 or 20M).\n"
+           "      --sample-rate SPS  Set RF sample rate in SPS (default: %d, accepts 30.72e6\n"
+           "                         or 20M). Rates above 61.44 MSPS select the\n"
+           "                         wide-bandwidth mode (~100 MHz analog passband).\n"
            "      --bandwidth HZ     Set the RF bandwidth in Hz (default: %d).\n"
            "      --tx-freq HZ       Set the TX frequency in Hz (default: %" PRId64 ").\n"
            "      --rx-freq HZ       Set the RX frequency in Hz (default: %" PRId64 ").\n"
@@ -95,7 +96,6 @@ int main(int argc, char **argv)
         { "port", required_argument, NULL, 'p' },
         { "format", required_argument, NULL, 1 },
         { "8bit", no_argument, NULL, 2 },
-        { "oversample", no_argument, NULL, 3 },
         { "channel-layout", required_argument, NULL, 4 },
         { "chan", required_argument, NULL, 4 },
         { "sync", required_argument, NULL, 5 },
@@ -163,9 +163,6 @@ int main(int argc, char **argv)
             break;
         case 2:
             cfg.enable_8bit_mode = true;
-            break;
-        case 3:
-            cfg.enable_oversample = true;
             break;
         case 4:
             cfg.chan_mode = optarg;


### PR DESCRIPTION
Sample rates above the AD9361 clock-chain limit (61.44 MSPS, up to 122.88) now automatically select a wide-bandwidth mode that opens the analog passband past the standard ~56 MHz:

    m2sdr_rf --channel-layout 1t1r --sample-rate 122.88e6 ...

Previously such rates required --oversample (chip at half rate, data port at 2x, but analog filters still calibrated to ~56 MHz, so a 100 MHz signal lost its outer ~45 MHz). The --oversample flag and cfg.enable_oversample are removed; rate alone decides, in one place:

- ad9361_enable_oversampling() now implements the complete wide-bandwidth sequence (it previously wrote only the port-rate switch, with the filter-widening half disabled under "#if 0"). Per-register rationale, UG-570/register-map references and measured effects are documented in the code. The channel enables in 0x002/0x003 are preserved as configured by the channel-layout selection; the LVDS framing follows them (UG-570 Table 50), so at 122.88 MSPS DATA_CLK is 245.76 MHz in 1T1R (stock gateware) and 491.52 MHz in 2T2R (--with-rfic-oversampling gateware).
- The doubled-rate interface framing is re-rolled by each clock programming and can come up misaligned (full-scale noise-like samples), so the rate programming is PRBS-verified (reusing the --calibrate-delay PRBS helpers) and retried in place until aligned - typically 1-2 attempts. One shared bring-up path serves both m2sdr_apply_config() and runtime m2sdr_set_sample_rate() switches; no new public API, no caller involvement. The verify briefly drives the chip BIST/loopback paths, so a stream running across a rate switch glitches.
- Interface clock/data delays are set to the measured 245.76 MHz eye midpoints (RX eye is only 4 of 16 taps wide; the init-table defaults sat at its edge), overridable via M2SDR_OC_RX_DELAY / M2SDR_OC_TX_DELAY.
- SoapySDR: all oversampling logic removed (_oversampling, _rateMult, device-arg, direct ad9361_enable_oversampling() call, and the silent 8-bit override above 61.44 MSPS); the driver passes the stream rate to m2sdr_set_sample_rate() and libm2sdr handles the rest.
- README: document the mode with measured numbers.

Measured (loopback TX1->RX1 with 40 dB pad + external-receiver cross-check, 3.6 GHz, 100 MHz NR-FR1-TM3.1 64QAM): EVM ~10% PDSCH RMS with flat per-band effective SNR across the full 100 MHz (after TX magnitude pre-emphasis). No-signal RX floor -31.6 dBFS at rx-gain 55 (vs -34 dBFS stock). TX image rejection ~30 dB at tx-att 0 vs ~42 dB stock; at tx-att >= 10 it matches stock (~44-58 dB; the gain dependence is the AD9361's attenuation-dependent TX quad cal, present in both modes). Rates <= 61.44 MSPS are unaffected.