### PR TITLE
Harden time/PTP clock-domain crossings and gateware robustness

### DIFF
--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -529,6 +529,9 @@ class BaseSoC(SoCMini):
                 with_ptm              = with_pcie_ptm,
             )
             self.pcie_phy.use_external_qpll(qpll_channel=self.qpll.get_channel("pcie"))
+            # The DMA synchronizer (when not bypassed by software) waits for
+            # this PPS pulse before declaring synced; PCIe streaming liveness
+            # therefore depends on the time generator staying enabled.
             self.comb += self.pcie_dma0.synchronizer.pps.eq(self.pps_gen.pps_pulse)
 
             # Host <-> SoC DMA Bus.
@@ -800,6 +803,10 @@ class BaseSoC(SoCMini):
         # TX: Comms -> Crossbar -> Header.
         # --------------------------------
         if with_pcie:
+            # The DMA synchronizer syncs on the PPS pulse derived from the
+            # time generator (enabled by default): disabling the time
+            # generator therefore holds the headers in reset and silently
+            # freezes PCIe streaming.
             self.comb += [
                 self.pcie_dma0.source.connect(self.crossbar.mux.sink0),
                 If(self.crossbar.mux.sel == 0,

--- a/litex_m2sdr/gateware/ad9361/core.py
+++ b/litex_m2sdr/gateware/ad9361/core.py
@@ -94,10 +94,7 @@ class AD9361RFIC(LiteXModule):
     def __init__(self, rfic_pads, spi_pads, sys_clk_freq,
         with_tx_fifo = False, tx_fifo_depth = 8192,
         with_rx_fifo = False, rx_fifo_depth = 8192):
-        # Controls ---------------------------------------------------------------------------------
-        self.enable_datapath = Signal(reset=1)
-
-         # Stream Endpoints ------------------------------------------------------------------------
+        # Stream Endpoints -------------------------------------------------------------------------
         self.sink   = stream.Endpoint(dma_layout(64))
         self.source = stream.Endpoint(dma_layout(64))
 

--- a/litex_m2sdr/gateware/ad9361/phy.py
+++ b/litex_m2sdr/gateware/ad9361/phy.py
@@ -200,7 +200,10 @@ class AD9361PHY(LiteXModule):
 
         # RX Source Interface.
         # --------------------
-        # Outputs assembled RX samples when valid (rx_count == 0).
+        # Outputs assembled RX samples when valid (rx_count == 0). The source
+        # is free-running: valid pulses for a single cycle per sample set and
+        # is not held under backpressure, so samples are dropped when the
+        # downstream stalls (overflow accounting happens at the DMA level).
         self.sync.rfic += [
             rx_valid.eq(0),
             If(rx_count == 0,

--- a/litex_m2sdr/gateware/cdc.py
+++ b/litex_m2sdr/gateware/cdc.py
@@ -1,0 +1,62 @@
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+from litex.soc.interconnect import stream
+
+# Value/Strobe CDC ---------------------------------------------------------------------------------
+
+class ValueStrobeCDC(LiteXModule):
+    """Cross value(s) together with their strobe between clock domains.
+
+    The payload travels with the strobe through a single handshaked crossing,
+    so the destination never samples a half-settled word -- unlike per-bit
+    MultiReg synchronizers, which have no bus coherence.
+
+    Inputs live in cd_from, outputs in cd_to:
+    - strobe / strobe_o : transfer request and resulting 1-cycle pulse. With
+      on_change=True the strobe input is ignored and a transfer is initiated
+      whenever one of the input values changes.
+    - One <name> input and <name>_o output Signal per layout field (layout
+      may also be an int, shorthand for [("value", width)]). Outputs are
+      combinational from the crossing and only meaningful while strobe_o is
+      asserted; callers needing a held value register it in cd_to on
+      strobe_o.
+    """
+    def __init__(self, layout, cd_from="sys", cd_to="sys", on_change=False):
+        if isinstance(layout, int):
+            layout = [("value", layout)]
+        self.strobe   = Signal()
+        self.strobe_o = Signal()
+        for name, width in layout:
+            setattr(self, name,        Signal(width))
+            setattr(self, name + "_o", Signal(width))
+
+        # # #
+
+        self.cdc = cdc = stream.ClockDomainCrossing(layout, cd_from=cd_from, cd_to=cd_to)
+
+        strobe = self.strobe
+        if on_change:
+            values      = Cat(*[getattr(self, name) for name, _ in layout])
+            values_prev = Signal(len(values))
+            sync_from   = getattr(self.sync, cd_from)
+            sync_from  += values_prev.eq(values)
+            strobe      = values != values_prev
+
+        self.comb += [
+            cdc.sink.valid.eq(strobe),
+            cdc.source.ready.eq(1),
+            self.strobe_o.eq(cdc.source.valid),
+        ]
+        for name, _ in layout:
+            self.comb += [
+                getattr(cdc.sink, name).eq(getattr(self, name)),
+                getattr(self, name + "_o").eq(getattr(cdc.source, name)),
+            ]

--- a/litex_m2sdr/gateware/header.py
+++ b/litex_m2sdr/gateware/header.py
@@ -49,13 +49,17 @@ class HeaderInserterExtractor(LiteXModule):
         self.comb += self.fsm.reset.eq(self.reset | ~self.enable)
 
         # Reset.
-        fsm.act("RESET",
+        reset_actions = [
             NextValue(cycles, 0),
-            If(mode == "inserter",
-                sink.ready.eq(self.reset)
-            ),
-            NextState("IDLE")
-        )
+            NextState("IDLE"),
+        ]
+        if mode == "inserter":
+            # Drain the upstream while an explicit reset is asserted so the
+            # producer does not stall against a held-in-reset inserter. (The
+            # mode selection is an elaboration-time constant, hence the
+            # Python conditional.)
+            reset_actions.append(sink.ready.eq(self.reset))
+        fsm.act("RESET", *reset_actions)
 
         # Idle.
         fsm.act("IDLE",

--- a/litex_m2sdr/gateware/measurement.py
+++ b/litex_m2sdr/gateware/measurement.py
@@ -5,11 +5,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
-from migen.genlib.cdc import MultiReg, PulseSynchronizer
+from migen.genlib.cdc import PulseSynchronizer
 
 from litex.gen import *
 
 from litex.soc.interconnect.csr import *
+from litex.soc.interconnect import stream
 
 # Clk Measurement ----------------------------------------------------------------------------------
 
@@ -28,13 +29,22 @@ class ClkMeasurement(LiteXModule):
         counter = Signal(64)
         self.sync.counter += counter.eq(counter + increment)
 
-        # Latch Clock Counter.
-        latch_value = Signal(64)
-        latch_sync  = PulseSynchronizer("sys", "counter")
+        # Latch Clock Counter. The 64-bit snapshot crosses back through one
+        # handshaked crossing so software never reads a torn value while the
+        # latch settles.
+        latch_sync = PulseSynchronizer("sys", "counter")
         self.submodules += latch_sync
         self.comb += latch_sync.i.eq(self.latch)
-        self.sync.counter += If(latch_sync.o, latch_value.eq(counter))
-        self.specials += MultiReg(latch_value, self.value)
+        self.value_cdc = value_cdc = stream.ClockDomainCrossing(
+            [("value", 64)], cd_from="counter", cd_to="sys")
+        self.comb += [
+            value_cdc.sink.valid.eq(latch_sync.o),
+            value_cdc.sink.value.eq(counter),
+            value_cdc.source.ready.eq(1),
+        ]
+        self.sync += If(value_cdc.source.valid,
+            self.value.eq(value_cdc.source.value)
+        )
 
         # CSR (Optional).
         if with_csr:

--- a/litex_m2sdr/gateware/measurement.py
+++ b/litex_m2sdr/gateware/measurement.py
@@ -10,7 +10,8 @@ from migen.genlib.cdc import PulseSynchronizer
 from litex.gen import *
 
 from litex.soc.interconnect.csr import *
-from litex.soc.interconnect import stream
+
+from litex_m2sdr.gateware.cdc import ValueStrobeCDC
 
 # Clk Measurement ----------------------------------------------------------------------------------
 
@@ -35,15 +36,13 @@ class ClkMeasurement(LiteXModule):
         latch_sync = PulseSynchronizer("sys", "counter")
         self.submodules += latch_sync
         self.comb += latch_sync.i.eq(self.latch)
-        self.value_cdc = value_cdc = stream.ClockDomainCrossing(
-            [("value", 64)], cd_from="counter", cd_to="sys")
+        self.value_cdc = value_cdc = ValueStrobeCDC(64, cd_from="counter", cd_to="sys")
         self.comb += [
-            value_cdc.sink.valid.eq(latch_sync.o),
-            value_cdc.sink.value.eq(counter),
-            value_cdc.source.ready.eq(1),
+            value_cdc.strobe.eq(latch_sync.o),
+            value_cdc.value.eq(counter),
         ]
-        self.sync += If(value_cdc.source.valid,
-            self.value.eq(value_cdc.source.value)
+        self.sync += If(value_cdc.strobe_o,
+            self.value.eq(value_cdc.value_o)
         )
 
         # CSR (Optional).

--- a/litex_m2sdr/gateware/ptp_discipline.py
+++ b/litex_m2sdr/gateware/ptp_discipline.py
@@ -10,6 +10,7 @@ from migen.genlib.cdc import MultiReg, PulseSynchronizer
 from litex.gen import *
 
 from litex.soc.interconnect.csr import *
+from litex.soc.interconnect import stream
 
 # Time Discipline CDC ------------------------------------------------------------------------------
 
@@ -26,23 +27,53 @@ class TimeDisciplineCDC(LiteXModule):
 
         # # #
 
-        self.specials += [
-            MultiReg(self.enable,      time_gen.discipline_enable,      "time"),
-            MultiReg(self.time_inc,    time_gen.discipline_time_inc,    "time"),
-            MultiReg(self.write_time,  time_gen.discipline_write_time,  "time"),
-            MultiReg(self.adjust_sign, time_gen.discipline_adjust_sign, "time"),
-            MultiReg(self.adjustment,  time_gen.discipline_adjustment,  "time"),
+        # Enable is a single bit; a plain synchronizer is sufficient.
+        self.specials += MultiReg(self.enable, time_gen.discipline_enable, "time")
+
+        # The servo asserts the write/adjust strobes in the same cycle it
+        # updates their values: a strobe through PulseSynchronizer and a value
+        # through per-bit MultiReg take a similar number of destination
+        # clocks, so the time domain could apply a half-settled 64-bit word
+        # (torn coarse write during PTP acquisition). Carry each value with
+        # its strobe through a handshaked crossing instead.
+        self.write_cdc = write_cdc = stream.ClockDomainCrossing(
+            [("ts", 64)], cd_from=cd_from, cd_to="time")
+        self.comb += [
+            write_cdc.sink.valid.eq(self.write),
+            write_cdc.sink.ts.eq(self.write_time),
+            write_cdc.source.ready.eq(1),
+            time_gen.discipline_write.eq(write_cdc.source.valid),
+            time_gen.discipline_write_time.eq(write_cdc.source.ts),
         ]
 
-        self.write_ps  = PulseSynchronizer(cd_from, "time")
-        self.adjust_ps = PulseSynchronizer(cd_from, "time")
-        self.submodules += self.write_ps, self.adjust_ps
+        self.adjust_cdc = adjust_cdc = stream.ClockDomainCrossing(
+            [("sign", 1), ("value", 64)], cd_from=cd_from, cd_to="time")
         self.comb += [
-            self.write_ps.i.eq(self.write),
-            self.adjust_ps.i.eq(self.adjust),
-            time_gen.discipline_write.eq(self.write_ps.o),
-            time_gen.discipline_adjust.eq(self.adjust_ps.o),
+            adjust_cdc.sink.valid.eq(self.adjust),
+            adjust_cdc.sink.sign.eq(self.adjust_sign),
+            adjust_cdc.sink.value.eq(self.adjustment),
+            adjust_cdc.source.ready.eq(1),
+            time_gen.discipline_adjust.eq(adjust_cdc.source.valid),
+            time_gen.discipline_adjust_sign.eq(adjust_cdc.source.sign),
+            time_gen.discipline_adjustment.eq(adjust_cdc.source.value),
         ]
+
+        # The increment is consumed on every time-domain cycle and
+        # accumulates, so register it atomically on change rather than
+        # bit-synchronizing a live value.
+        time_inc_prev = Signal(32)
+        sync_from = getattr(self.sync, cd_from)
+        sync_from += time_inc_prev.eq(self.time_inc)
+        self.inc_cdc = inc_cdc = stream.ClockDomainCrossing(
+            [("inc", 32)], cd_from=cd_from, cd_to="time")
+        self.comb += [
+            inc_cdc.sink.valid.eq(self.time_inc != time_inc_prev),
+            inc_cdc.sink.inc.eq(self.time_inc),
+            inc_cdc.source.ready.eq(1),
+        ]
+        self.sync.time += If(inc_cdc.source.valid,
+            time_gen.discipline_time_inc.eq(inc_cdc.source.inc)
+        )
 
 # PTP Time Discipline ------------------------------------------------------------------------------
 

--- a/litex_m2sdr/gateware/ptp_discipline.py
+++ b/litex_m2sdr/gateware/ptp_discipline.py
@@ -12,6 +12,8 @@ from litex.gen import *
 from litex.soc.interconnect.csr import *
 from litex.soc.interconnect import stream
 
+from litex_m2sdr.gateware.cdc import ValueStrobeCDC
+
 # Time Discipline CDC ------------------------------------------------------------------------------
 
 class TimeDisciplineCDC(LiteXModule):
@@ -36,43 +38,33 @@ class TimeDisciplineCDC(LiteXModule):
         # clocks, so the time domain could apply a half-settled 64-bit word
         # (torn coarse write during PTP acquisition). Carry each value with
         # its strobe through a handshaked crossing instead.
-        self.write_cdc = write_cdc = stream.ClockDomainCrossing(
-            [("ts", 64)], cd_from=cd_from, cd_to="time")
+        self.write_cdc = write_cdc = ValueStrobeCDC(64, cd_from=cd_from, cd_to="time")
         self.comb += [
-            write_cdc.sink.valid.eq(self.write),
-            write_cdc.sink.ts.eq(self.write_time),
-            write_cdc.source.ready.eq(1),
-            time_gen.discipline_write.eq(write_cdc.source.valid),
-            time_gen.discipline_write_time.eq(write_cdc.source.ts),
+            write_cdc.strobe.eq(self.write),
+            write_cdc.value.eq(self.write_time),
+            time_gen.discipline_write.eq(write_cdc.strobe_o),
+            time_gen.discipline_write_time.eq(write_cdc.value_o),
         ]
 
-        self.adjust_cdc = adjust_cdc = stream.ClockDomainCrossing(
+        self.adjust_cdc = adjust_cdc = ValueStrobeCDC(
             [("sign", 1), ("value", 64)], cd_from=cd_from, cd_to="time")
         self.comb += [
-            adjust_cdc.sink.valid.eq(self.adjust),
-            adjust_cdc.sink.sign.eq(self.adjust_sign),
-            adjust_cdc.sink.value.eq(self.adjustment),
-            adjust_cdc.source.ready.eq(1),
-            time_gen.discipline_adjust.eq(adjust_cdc.source.valid),
-            time_gen.discipline_adjust_sign.eq(adjust_cdc.source.sign),
-            time_gen.discipline_adjustment.eq(adjust_cdc.source.value),
+            adjust_cdc.strobe.eq(self.adjust),
+            adjust_cdc.sign.eq(self.adjust_sign),
+            adjust_cdc.value.eq(self.adjustment),
+            time_gen.discipline_adjust.eq(adjust_cdc.strobe_o),
+            time_gen.discipline_adjust_sign.eq(adjust_cdc.sign_o),
+            time_gen.discipline_adjustment.eq(adjust_cdc.value_o),
         ]
 
         # The increment is consumed on every time-domain cycle and
         # accumulates, so register it atomically on change rather than
         # bit-synchronizing a live value.
-        time_inc_prev = Signal(32)
-        sync_from = getattr(self.sync, cd_from)
-        sync_from += time_inc_prev.eq(self.time_inc)
-        self.inc_cdc = inc_cdc = stream.ClockDomainCrossing(
-            [("inc", 32)], cd_from=cd_from, cd_to="time")
-        self.comb += [
-            inc_cdc.sink.valid.eq(self.time_inc != time_inc_prev),
-            inc_cdc.sink.inc.eq(self.time_inc),
-            inc_cdc.source.ready.eq(1),
-        ]
-        self.sync.time += If(inc_cdc.source.valid,
-            time_gen.discipline_time_inc.eq(inc_cdc.source.inc)
+        self.inc_cdc = inc_cdc = ValueStrobeCDC(32, cd_from=cd_from, cd_to="time",
+            on_change=True)
+        self.comb += inc_cdc.value.eq(self.time_inc)
+        self.sync.time += If(inc_cdc.strobe_o,
+            time_gen.discipline_time_inc.eq(inc_cdc.value_o)
         )
 
 # PTP Time Discipline ------------------------------------------------------------------------------

--- a/litex_m2sdr/gateware/si5351.py
+++ b/litex_m2sdr/gateware/si5351.py
@@ -157,10 +157,16 @@ class LiteI2CSequencer(LiteXModule):
         I2C_MASTER_RXTX_ADDR     = i2c_base + 0x10
         I2C_MASTER_STATUS_ADDR   = i2c_base + 0x14
 
+        # Bound the RX flush: a stuck RX-ready status bit would otherwise trap
+        # the sequencer in the CHECK-RX-READY/FLUSH-RX loop forever and hang
+        # the SI5351 configuration.
+        flush_count = Signal(max=64)
+
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         self.fsm.act("IDLE",
             NextValue(mem_port.adr, 0),
+            NextValue(flush_count, 0),
             NextState("CHECK-RX-READY")
         )
         self.fsm.act("CHECK-RX-READY",
@@ -170,7 +176,7 @@ class LiteI2CSequencer(LiteXModule):
             bus.adr.eq(I2C_MASTER_STATUS_ADDR),
             bus.sel.eq(0xf),
             If(bus.ack,
-                If(bus.dat_r & 0b10,
+                If(((bus.dat_r & 0b10) != 0) & (flush_count != 63),
                     NextState("FLUSH-RX")
                 ).Else(
                     NextState("CHECK-TX-READY")
@@ -184,6 +190,7 @@ class LiteI2CSequencer(LiteXModule):
             bus.adr.eq(I2C_MASTER_RXTX_ADDR),
             bus.sel.eq(0xf),
             If(bus.ack,
+                NextValue(flush_count, flush_count + 1),
                 NextState("CHECK-RX-READY")
             )
         )

--- a/litex_m2sdr/gateware/time.py
+++ b/litex_m2sdr/gateware/time.py
@@ -12,6 +12,8 @@ from litex.gen import *
 from litex.soc.interconnect.csr import *
 from litex.soc.interconnect import stream
 
+from litex_m2sdr.gateware.cdc import ValueStrobeCDC
+
 # Time Generator -----------------------------------------------------------------------------------
 
 class TimeGenerator(LiteXModule):
@@ -138,58 +140,49 @@ class TimeGenerator(LiteXModule):
         time_read_ps = PulseSynchronizer("sys", "time")
         self.submodules += time_read_ps
         self.comb += time_read_ps.i.eq(self._control.fields.read)
-        self.time_read_cdc = time_read_cdc = stream.ClockDomainCrossing(
-            [("ts", 64)], cd_from="time", cd_to="sys")
+        self.time_read_cdc = time_read_cdc = ValueStrobeCDC(64, cd_from="time", cd_to="sys")
         self.comb += [
-            time_read_cdc.sink.valid.eq(time_read_ps.o),
-            time_read_cdc.sink.ts.eq(self.time),
-            time_read_cdc.source.ready.eq(1),
+            time_read_cdc.strobe.eq(time_read_ps.o),
+            time_read_cdc.value.eq(self.time),
         ]
-        self.sync += If(time_read_cdc.source.valid,
-            self._read_time.status.eq(time_read_cdc.source.ts)
+        self.sync += If(time_read_cdc.strobe_o,
+            self._read_time.status.eq(time_read_cdc.value_o)
         )
 
-        # Time Write (SW -> FPGA). The value travels with the strobe through
-        # one handshaked crossing so the time domain never applies a
-        # half-settled 64-bit word.
-        self.time_write_cdc = time_write_cdc = stream.ClockDomainCrossing(
-            [("ts", 64)], cd_from="sys", cd_to="time")
+        # Time Write (SW -> FPGA). The value travels with the strobe so the
+        # time domain never applies a half-settled 64-bit word.
+        self.time_write_cdc = time_write_cdc = ValueStrobeCDC(64, cd_from="sys", cd_to="time")
         self.comb += [
-            time_write_cdc.sink.valid.eq(self._control.fields.write),
-            time_write_cdc.sink.ts.eq(self._write_time.storage),
-            time_write_cdc.source.ready.eq(1),
-            self.write.eq(time_write_cdc.source.valid),
-            self.write_time.eq(time_write_cdc.source.ts),
+            time_write_cdc.strobe.eq(self._control.fields.write),
+            time_write_cdc.value.eq(self._write_time.storage),
+            self.write.eq(time_write_cdc.strobe_o),
+            self.write_time.eq(time_write_cdc.value_o),
         ]
 
         # Time Adjust (SW -> FPGA). Registered atomically in the time domain:
         # the adjustment is summed into the live time output on every cycle,
         # so a torn update would glitch the timestamps fed to the DMA headers
         # and VRT packets.
-        self.time_adjust_cdc = time_adjust_cdc = stream.ClockDomainCrossing(
-            [("value", 64)], cd_from="sys", cd_to="time")
+        self.time_adjust_cdc = time_adjust_cdc = ValueStrobeCDC(64, cd_from="sys", cd_to="time")
         self.comb += [
-            time_adjust_cdc.sink.valid.eq(self._time_adjustment.re),
-            time_adjust_cdc.sink.value.eq(self._time_adjustment.storage),
-            time_adjust_cdc.source.ready.eq(1),
-            self._time_adjust_change.eq(time_adjust_cdc.source.valid),
+            time_adjust_cdc.strobe.eq(self._time_adjustment.re),
+            time_adjust_cdc.value.eq(self._time_adjustment.storage),
+            self._time_adjust_change.eq(time_adjust_cdc.strobe_o),
         ]
-        self.sync.time += If(time_adjust_cdc.source.valid,
-            self.time_adjustment.eq(time_adjust_cdc.source.value)
+        self.sync.time += If(time_adjust_cdc.strobe_o,
+            self.time_adjustment.eq(time_adjust_cdc.value_o)
         )
 
         # Time Increment (SW -> FPGA). Registered atomically: the increment is
         # accumulated every cycle, so torn bits would permanently offset the
         # time.
-        self.time_inc_cdc = time_inc_cdc = stream.ClockDomainCrossing(
-            [("inc", 32)], cd_from="sys", cd_to="time")
+        self.time_inc_cdc = time_inc_cdc = ValueStrobeCDC(32, cd_from="sys", cd_to="time")
         self.comb += [
-            time_inc_cdc.sink.valid.eq(self._time_inc.re),
-            time_inc_cdc.sink.inc.eq(self._time_inc.storage),
-            time_inc_cdc.source.ready.eq(1),
+            time_inc_cdc.strobe.eq(self._time_inc.re),
+            time_inc_cdc.value.eq(self._time_inc.storage),
         ]
-        self.sync.time += If(time_inc_cdc.source.valid,
-            self.time_inc.eq(time_inc_cdc.source.inc)
+        self.sync.time += If(time_inc_cdc.strobe_o,
+            self.time_inc.eq(time_inc_cdc.value_o)
         )
 
     def add_cdc(self):

--- a/litex_m2sdr/gateware/time.py
+++ b/litex_m2sdr/gateware/time.py
@@ -131,30 +131,66 @@ class TimeGenerator(LiteXModule):
         # Sync.
         self.specials += MultiReg(self._control.fields.sync_enable, self.sync_enable)
 
-        # Time Read (FPGA -> SW).
-        time_read = Signal(64)
+        # Time Read (FPGA -> SW). The full 64-bit snapshot crosses through one
+        # handshaked crossing: per-bit synchronizers would let software observe
+        # torn values while the snapshot settles (the C library used to need a
+        # multi-attempt stable-read workaround for exactly this).
         time_read_ps = PulseSynchronizer("sys", "time")
         self.submodules += time_read_ps
         self.comb += time_read_ps.i.eq(self._control.fields.read)
-        self.sync.time += If(time_read_ps.o, time_read.eq(self.time))
-        self.specials += MultiReg(time_read, self._read_time.status)
+        self.time_read_cdc = time_read_cdc = stream.ClockDomainCrossing(
+            [("ts", 64)], cd_from="time", cd_to="sys")
+        self.comb += [
+            time_read_cdc.sink.valid.eq(time_read_ps.o),
+            time_read_cdc.sink.ts.eq(self.time),
+            time_read_cdc.source.ready.eq(1),
+        ]
+        self.sync += If(time_read_cdc.source.valid,
+            self._read_time.status.eq(time_read_cdc.source.ts)
+        )
 
-        # Time Write (SW -> FPGA).
-        self.specials += MultiReg(self._write_time.storage, self.write_time, "time")
-        time_write_ps = PulseSynchronizer("sys", "time")
-        self.submodules += time_write_ps
-        self.comb += time_write_ps.i.eq(self._control.fields.write)
-        self.comb += self.write.eq(time_write_ps.o)
+        # Time Write (SW -> FPGA). The value travels with the strobe through
+        # one handshaked crossing so the time domain never applies a
+        # half-settled 64-bit word.
+        self.time_write_cdc = time_write_cdc = stream.ClockDomainCrossing(
+            [("ts", 64)], cd_from="sys", cd_to="time")
+        self.comb += [
+            time_write_cdc.sink.valid.eq(self._control.fields.write),
+            time_write_cdc.sink.ts.eq(self._write_time.storage),
+            time_write_cdc.source.ready.eq(1),
+            self.write.eq(time_write_cdc.source.valid),
+            self.write_time.eq(time_write_cdc.source.ts),
+        ]
 
-        # Time Adjust (SW -> FPGA).
-        self.specials += MultiReg(self._time_adjustment.storage, self.time_adjustment, "time")
-        time_adjust_ps = PulseSynchronizer("sys", "time")
-        self.submodules += time_adjust_ps
-        self.comb += time_adjust_ps.i.eq(self._time_adjustment.re)
-        self.comb += self._time_adjust_change.eq(time_adjust_ps.o)
+        # Time Adjust (SW -> FPGA). Registered atomically in the time domain:
+        # the adjustment is summed into the live time output on every cycle,
+        # so a torn update would glitch the timestamps fed to the DMA headers
+        # and VRT packets.
+        self.time_adjust_cdc = time_adjust_cdc = stream.ClockDomainCrossing(
+            [("value", 64)], cd_from="sys", cd_to="time")
+        self.comb += [
+            time_adjust_cdc.sink.valid.eq(self._time_adjustment.re),
+            time_adjust_cdc.sink.value.eq(self._time_adjustment.storage),
+            time_adjust_cdc.source.ready.eq(1),
+            self._time_adjust_change.eq(time_adjust_cdc.source.valid),
+        ]
+        self.sync.time += If(time_adjust_cdc.source.valid,
+            self.time_adjustment.eq(time_adjust_cdc.source.value)
+        )
 
-        # Time Increment.
-        self.specials += MultiReg(self._time_inc.storage, self.time_inc, "time")
+        # Time Increment (SW -> FPGA). Registered atomically: the increment is
+        # accumulated every cycle, so torn bits would permanently offset the
+        # time.
+        self.time_inc_cdc = time_inc_cdc = stream.ClockDomainCrossing(
+            [("inc", 32)], cd_from="sys", cd_to="time")
+        self.comb += [
+            time_inc_cdc.sink.valid.eq(self._time_inc.re),
+            time_inc_cdc.sink.inc.eq(self._time_inc.storage),
+            time_inc_cdc.source.ready.eq(1),
+        ]
+        self.sync.time += If(time_inc_cdc.source.valid,
+            self.time_inc.eq(time_inc_cdc.source.inc)
+        )
 
     def add_cdc(self):
         time        = Signal(64)

--- a/test/test_cdc.py
+++ b/test/test_cdc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen.sim import run_simulation
+
+from litex_m2sdr.gateware.cdc import ValueStrobeCDC
+
+# ValueStrobeCDC Tests ------------------------------------------------------------------------------
+
+
+def test_value_strobe_cdc_transfer():
+    """A strobed value arrives intact, with strobe_o pulsing once per transfer."""
+    dut = ValueStrobeCDC(64, cd_from="sys", cd_to="dst")
+    received = []
+
+    def gen():
+        for value in [0x0123456789ABCDEF, 0xFFFFFFFFFFFFFFFF, 0]:
+            yield dut.value.eq(value)
+            yield dut.strobe.eq(1)
+            yield
+            yield dut.strobe.eq(0)
+            for _ in range(16):
+                yield
+
+    def mon():
+        for _ in range(80):
+            if (yield dut.strobe_o):
+                received.append((yield dut.value_o))
+            yield
+
+    run_simulation(dut, {"sys": gen(), "dst": mon()}, clocks={"sys": 10, "dst": 7})
+    assert received == [0x0123456789ABCDEF, 0xFFFFFFFFFFFFFFFF, 0]
+
+
+def test_value_strobe_cdc_multi_field():
+    """Multiple fields cross together and stay consistent."""
+    dut = ValueStrobeCDC([("sign", 1), ("value", 64)], cd_from="sys", cd_to="dst")
+    received = []
+
+    def gen():
+        for sign, value in [(1, 1000), (0, 2000)]:
+            yield dut.sign.eq(sign)
+            yield dut.value.eq(value)
+            yield dut.strobe.eq(1)
+            yield
+            yield dut.strobe.eq(0)
+            for _ in range(16):
+                yield
+
+    def mon():
+        for _ in range(60):
+            if (yield dut.strobe_o):
+                received.append(((yield dut.sign_o), (yield dut.value_o)))
+            yield
+
+    run_simulation(dut, {"sys": gen(), "dst": mon()}, clocks={"sys": 10, "dst": 7})
+    assert received == [(1, 1000), (0, 2000)]
+
+
+def test_value_strobe_cdc_on_change():
+    """With on_change=True, a transfer fires per input change, not per cycle."""
+    dut = ValueStrobeCDC(32, cd_from="sys", cd_to="dst", on_change=True)
+    received = []
+
+    def gen():
+        yield dut.value.eq(111)
+        for _ in range(16):
+            yield
+        yield dut.value.eq(222)
+        for _ in range(16):
+            yield
+
+    def mon():
+        for _ in range(48):
+            if (yield dut.strobe_o):
+                received.append((yield dut.value_o))
+            yield
+
+    run_simulation(dut, {"sys": gen(), "dst": mon()}, clocks={"sys": 10, "dst": 7})
+    assert received == [111, 222]


### PR DESCRIPTION
## Summary

This PR fixes the clock-domain crossings around the board time and PTP
discipline paths, plus a few smaller gateware robustness/clarity items found
during a gateware review.

The main issue: all 64-bit values exchanged between the sys and time domains
(time read snapshot, time write, adjustment, increment, clock-measurement
latch, PTP discipline write/trim) crossed through per-bit `MultiReg`
synchronizers with no bus coherence. Consequences:

- software could observe torn 64-bit time snapshots while a read settled
  (the C library carries a multi-attempt stable-read workaround in
  `m2sdr_read_reg_u64()` for exactly this)
- a write/adjust strobe could apply a half-settled 64-bit word; for the PTP
  servo, which asserts strobe and value in the same cycle, this allowed torn
  coarse writes during acquisition (transient time jumps the servo then
  silently re-converges from)
- the time adjustment is summed into the live time output combinationally,
  so a torn update could glitch the timestamps feeding the DMA headers and
  VRT packets for a few cycles
- the increment accumulates on every tick, so torn bits permanently offset
  the time

Changes:
- cross 64-bit time/measurement CSR values through handshaked crossings
  (value travels with its strobe); register adjustment/increment atomically
  in the time domain
- factor the recurring value+strobe crossing idiom into a shared
  `ValueStrobeCDC` helper (`gateware/cdc.py`, with direct unit tests) used
  by the time generator, PTP discipline and clock measurement
- carry PTP discipline write/trim values with their strobes across domains;
  register the continuously-consumed increment atomically on change
- bound the SI5351 I2C RX flush loop so a stuck status bit cannot hang the
  configuration sequencer
- remove the dead `enable_datapath` signal from the AD9361 core
- document that PCIe streaming liveness depends on the time generator
  (headers held in reset until the PPS-fed DMA synchronizer syncs)
- clarify the header inserter reset draining and the RX PHY
  drop-on-backpressure behavior

The CSR map is unchanged, so no software or kernel header regeneration is
needed. The `m2sdr_read_reg_u64()` software workaround is kept for
compatibility with bitstreams built before this change.

## Validation

- full simulation suite passes (144 tests), including the new ValueStrobeCDC
  tests, the time core, PTP
  discipline, SoC Ethernet+PTP, SI5351, header, and measurement tests
- both the `m2` PCIe and baseboard Ethernet+PTP configurations elaborate to
  Verilog cleanly
- generated CSR addresses verified identical to the committed
  `software/kernel/csr.h` superset

Sim-validated only: a bitstream rebuild plus an on-board check of
`test_time.py` and PTP lock is recommended before merging.