### PR TITLE
Feature/wide mode rf tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,20 +228,28 @@ The AD9361's analog baseband filters are normally limited to ~56 MHz. Requesting
 m2sdr_rf --channel-layout 1t1r --sample-rate 122.88e6 ...
 ```
 
-Converter half-band stages are bypassed so the data port runs at 2x rate, and the TX/RX baseband filters are force-widened with tuned register words, opening a true ~100 MHz analog passband at 122.88 MSPS. The interface DATA_CLK follows the channel layout: 245.76 MHz in 1T1R (stock gateware) and 491.52 MHz in 2T2R (gateware built with `--with-rfic-oversampling`). The doubled-rate interface framing can come up misaligned, so the configuration PRBS-verifies the interface and retries the clock programming in place until it is aligned (typically 1-2 attempts).
+Converter half-band stages are bypassed so the data port runs at 2x rate, and the TX/RX baseband filters are re-tuned by the chip's own BBF calibration against a ~54/62 MHz corner target (programming the tune dividers past the driver's bandwidth clamp), opening a true ~100 MHz analog passband at 122.88 MSPS while keeping the calibrated noise behavior. The interface DATA_CLK follows the channel layout: 245.76 MHz in 1T1R (stock gateware) and 491.52 MHz in 2T2R (gateware built with `--with-rfic-oversampling`). The doubled-rate interface framing can come up misaligned, so the configuration PRBS-verifies the interface and retries the clock programming in place until it is aligned (typically 1-2 attempts).
 
-Measured (loopback TX1->RX1 with 40 dB pad + external-receiver cross-check, 3.6 GHz, 100 MHz NR-FR1-TM3.1 64QAM test model):
+Measured at 3.6 GHz on the internal reference (RX side: clean external transmitter -> M2SDR RX, 50 MHz NR-FR1-TM3.1 64QAM, MATLAB 5G Toolbox EVM; in-band SNR: notch/NPR method):
 
-| Metric                          | Wide (overclock)        | Stock ~56 MHz       |
-|---------------------------------|-------------------------|---------------------|
-| Usable analog bandwidth         | ~100 MHz                | ~56 MHz             |
-| EVM, 100 MHz NR TM3.1 (PDSCH)   | ~10% RMS (*)            | n/a (BW > filter)   |
-| EVM, 10 MHz NR TM3.1            | ~3% RMS                 | ~3% RMS             |
-| No-signal RX floor (rx-gain 55) | -31.6 dBFS              | -34 dBFS            |
-| TX image rejection, tx-att 0    | ~30 dB                  | ~42 dB              |
-| TX image rejection, tx-att >=10 | ~44-58 dB               | ~44-58 dB           |
+| Metric (wide mode, 122.88 MSPS)            | Measured                          |
+|--------------------------------------------|-----------------------------------|
+| Usable analog bandwidth                    | ~100 MHz (full quality to +/-40)  |
+| RX EVM, 50 MHz TM3.1 centered              | ~6.0-6.6% RMS                     |
+| RX EVM, 50 MHz TM3.1 shifted +/-25 MHz     | ~8.7-9.2% RMS (touches band edge) |
+| RX in-band SNR (NPR), +/-10..31 MHz        | 26-29.5 dB                        |
+| RX in-band SNR (NPR), +/-41 / +/-45 MHz    | ~21 / ~17 dB                      |
+| RX passband flatness (with EQ FIR)         | +/-1.2 dB to +/-44 MHz            |
+| No-signal RX floor (rx-gain 55)            | -35.6 dBFS integrated             |
+| RX image rejection (quadrature tracking)   | ~40-43 dBc                        |
+| TX EVM, 50 MHz TM3.1 (flat over tx-att 0-18) | ~5.2-6% RMS                     |
+| TX image rejection (tx-att 0)              | ~44 dBc                           |
+| TX passband flatness (chip TX FIR EQ)      | +/-1.3 dB to +/-42 MHz (from -8 dB) |
 
-(*) With TX magnitude pre-emphasis flattening the widened-filter rolloff the per-band effective SNR is uniform (+/-50 MHz); the ~10% ceiling decomposes into ~7% TX (reference/LO phase noise) and ~8.5% RX (widened-BBF noise floor). Best EVM is obtained on the internal clock reference; an external 10 MHz reference costs ~6% EVM through the Si5351's higher multiplication ratio (N=84 vs N=34).
+The RX EVM bottoms out with the ADC filled to ~-12 dBFS RMS at the lowest rx-gain that gets there (the band-edge noise floor is gain-independent). TX EVM is constant-dBc (drive-independent over tx-att 0-18). The remaining limit on both sides is LO phase noise from the reference chain (Si5351 multiplication x94 into the RFPLLs); the RX band-edge limit (beyond ~+/-40 MHz) is the converter's own shaped noise at this oversampling ratio - both are silicon/architecture limits, not configuration. TX passband flatness over the full 100 MHz is achieved in-chip with a 16-tap TX FIR equalizer (`M2SDR_OC_TX_FIR_FILE`; the taps must be designed for the FIR's 245.76 MHz processing rate in this mode), so real-time transmitters need no host-side pre-emphasis; waveform pre-emphasis remains available as an alternative. Best EVM is obtained on the internal clock reference; an external 10 MHz reference costs ~6% EVM through the Si5351's higher multiplication ratio (N=84 vs N=34).
+
+
+Tuning/diagnostic environment variables (defaults are the measured optimum): `M2SDR_OC_BBF_TUNE` (BBF corner target), `M2SDR_OC_BBF_FORCE` (legacy register force-widening), `M2SDR_OC_RX_FIR_FILE` / `M2SDR_OC_TX_FIR_FILE` (passband flatness EQ FIR taps, max 16; TX taps designed for 245.76 MHz), `M2SDR_QEC_KEXP` (RX quadrature tracking loop gain), `M2SDR_RFPLL_CP_PERCENT` (RX RFPLL charge pump scale), `M2SDR_OC_RX_DELAY`/`M2SDR_OC_TX_DELAY` (interface delay overrides).
 
 [> Getting Started
 ------------------

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -810,7 +810,10 @@ class BaseSoC(SoCMini):
             self.comb += [
                 self.pcie_dma0.source.connect(self.crossbar.mux.sink0),
                 If(self.crossbar.mux.sel == 0,
-                    self.header.tx.reset.eq(~self.pcie_dma0.synchronizer.synced)
+                    # The synchronizer is shared between directions and stays synced while the
+                    # other direction runs; gating the FSM reset on the Reader enable re-aligns it
+                    # with the stream on every Reader start, including in Full-Duplex.
+                    self.header.tx.reset.eq(~self.pcie_dma0.synchronizer.synced | ~self.pcie_dma0.reader.enable)
                 )
             ]
         if with_eth:
@@ -833,7 +836,11 @@ class BaseSoC(SoCMini):
             self.comb += [
                 self.crossbar.demux.source0.connect(self.pcie_dma0.sink),
                 If(self.crossbar.demux.sel == 0,
-                    self.header.rx.reset.eq(~self.pcie_dma0.synchronizer.synced)
+                    # Same as the TX Header FSM above: gating on the Writer enable aligns the
+                    # inserted headers with the first DMA buffer on every Writer start (frames are
+                    # exactly one buffer long, so a phase slip at start would persist for the
+                    # whole run).
+                    self.header.rx.reset.eq(~self.pcie_dma0.synchronizer.synced | ~self.pcie_dma0.writer.enable)
                 )
             ]
         if with_eth:

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -498,9 +498,15 @@ static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
 	/* Start DMA Writer */
 	litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_ENABLE_OFFSET, 1);
 
-	/* Start DMA Synchronizer (RX only) */
-	litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b0);
-	litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b10);
+	/* Arm DMA Synchronizer (RX only) only if the Reader is not active:
+	 * re-arming drops `synced` and cuts the running Reader stream mid-frame
+	 * (and stalls both directions until the next PPS edge). */
+	if (!dmachan->reader_enable) {
+		litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b0);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b10);
+	} else {
+		dev_dbg(&s->dev->dev, "DMA Reader is active; skipping synchronizer re-arm in writer_start\n");
+	}
 }
 
 /* Stop DMA writer for a specific channel */
@@ -566,9 +572,15 @@ static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
 	/* Start DMA reader */
 	litepcie_writel(s, dmachan->base + PCIE_DMA_READER_ENABLE_OFFSET, 1);
 
-	/* Start DMA Synchronizer (TX & RX) */
-	litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b0);
-	litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b01);
+	/* Arm DMA Synchronizer (TX & RX) only if the Writer is not active:
+	 * re-arming drops `synced` and cuts the running Writer stream mid-frame
+	 * (and stalls both directions until the next PPS edge). */
+	if (!dmachan->writer_enable) {
+		litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b0);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_SYNCHRONIZER_ENABLE_OFFSET, 0b01);
+	} else {
+		dev_dbg(&s->dev->dev, "DMA Writer is active; skipping synchronizer re-arm in reader_start\n");
+	}
 }
 
 /* Stop DMA reader for a specific channel */

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -391,10 +391,19 @@ static int litepcie_ioctl_sata_dma(struct litepcie_chan *chan,
 /*                               LitePCIe Interrupts                                              */
 /* -----------------------------------------------------------------------------------------------*/
 
-/* Function to enable a specific interrupt on a LitePCIe device */
+/* Function to enable a specific interrupt on a LitePCIe device.
+ *
+ * The MSI enable register is shared by all interrupt sources and the ioctl
+ * paths run concurrently (e.g. one thread starting the DMA writer while
+ * another starts the reader), so the read-modify-write must be locked: a
+ * lost update here leaves that source's hw_count frozen and its consumer
+ * starving while the hardware streams normally. */
 static void litepcie_enable_interrupt(struct litepcie_device *s, int irq_num)
 {
+	unsigned long flags;
 	uint32_t v;
+
+	spin_lock_irqsave(&s->lock, flags);
 
 	/* Read the current interrupt enable register value */
 	v = litepcie_readl(s, CSR_PCIE_MSI_ENABLE_ADDR);
@@ -404,12 +413,17 @@ static void litepcie_enable_interrupt(struct litepcie_device *s, int irq_num)
 
 	/* Write the updated value back to the register */
 	litepcie_writel(s, CSR_PCIE_MSI_ENABLE_ADDR, v);
+
+	spin_unlock_irqrestore(&s->lock, flags);
 }
 
 /* Function to disable a specific interrupt on a LitePCIe device */
 static void litepcie_disable_interrupt(struct litepcie_device *s, int irq_num)
 {
+	unsigned long flags;
 	uint32_t v;
+
+	spin_lock_irqsave(&s->lock, flags);
 
 	/* Read the current interrupt enable register value */
 	v = litepcie_readl(s, CSR_PCIE_MSI_ENABLE_ADDR);
@@ -419,6 +433,8 @@ static void litepcie_disable_interrupt(struct litepcie_device *s, int irq_num)
 
 	/* Write the updated value back to the register */
 	litepcie_writel(s, CSR_PCIE_MSI_ENABLE_ADDR, v);
+
+	spin_unlock_irqrestore(&s->lock, flags);
 }
 
 /* -----------------------------------------------------------------------------------------------*/

--- a/litex_m2sdr/software/user/ad9361/ad9361.c
+++ b/litex_m2sdr/software/user/ad9361/ad9361.c
@@ -7497,6 +7497,106 @@ int32_t ad9361_rssi_gain_step_calib(struct ad9361_rf_phy *phy)
  * "Measured" notes below come from A/B experiments on a 100 MHz NR-FR1-TM3.1
  * loopback (per-band coherence effective SNR + MATLAB 5G Toolbox EVM),
  * cross-checked against an external receiver. */
+/* Chip-native wide BBF tune: re-run the AD9361's own RX/TX BBF tune
+ * calibrations with an out-of-range corner target by programming the tune
+ * dividers directly (the driver clamps BBBW to 28/20 MHz; the tune circuit
+ * itself is just a divided BBPLL clock plus the chip's R/C search, so it can
+ * tune wider). bbbw is half the complex bandwidth: 39 MHz gives an RX corner
+ * of 1.4x = ~54 MHz and a TX corner of 1.6x = ~62 MHz with BBPLL at
+ * 983.04 MHz. Returns true when both calibrations complete. */
+static bool ad9361_wide_bbf_tune(struct ad9361_rf_phy *phy, uint32_t bbbw)
+{
+    uint32_t bbpll = clk_get_rate(phy, phy->ref_clk_scale[BBPLL_CLK]);
+    uint32_t khz   = ((bbbw % 1000000u) * 128u + 500000u) / 1000000u;
+    uint32_t target, divider;
+    bool ok = true;
+    int i;
+
+    ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);
+
+    /* RX: corner = 1.4 x BBBW; divider = ceil(BBPLL / (1.4 BBBW 2pi/ln2)). */
+    target  = 126906u * (bbbw / 10000u);
+    divider = (bbpll + target - 1) / target;
+    if (divider < 1)   divider = 1;
+    if (divider > 511) divider = 511;
+    ad9361_spi_write(phy->spi, REG_RX_BBF_TUNE_DIVIDE, divider & 0xff);
+    ad9361_spi_write(phy->spi, REG_RX_BBF_TUNE_CONFIG,
+        (ad9361_spi_read(phy->spi, REG_RX_BBF_TUNE_CONFIG) & ~1) | (divider >> 8));
+    phy->rxbbf_div = divider; /* keep the driver's view (ADC setup uses it). */
+    ad9361_spi_write(phy->spi, REG_RX_BBBW_MHZ, bbbw / 1000000u);
+    ad9361_spi_write(phy->spi, REG_RX_BBBW_KHZ, khz > 127 ? 127 : khz);
+    ad9361_spi_write(phy->spi, REG_RX_MIX_LO_CM, RX_MIX_LO_CM(0x3F));
+    ad9361_spi_write(phy->spi, REG_RX_MIX_GM_CONFIG, RX_MIX_GM_PLOAD(3));
+    ad9361_spi_write(phy->spi, REG_RX1_TUNE_CTRL, 0x02); /* Tune circuit on.  */
+    ad9361_spi_write(phy->spi, REG_RX2_TUNE_CTRL, 0x02);
+    ad9361_spi_write(phy->spi, REG_CALIBRATION_CTRL, RX_BB_TUNE_CAL);
+    for (i = 0; i < 200; i++) {
+        if (!(ad9361_spi_read(phy->spi, REG_CALIBRATION_CTRL) & RX_BB_TUNE_CAL))
+            break;
+        mdelay(1);
+    }
+    ok &= (i < 200);
+    printf("RFIC overclock: RX BBF tune div=%u %s.\n", divider,
+           (i < 200) ? "done" : "TIMEOUT");
+    ad9361_spi_write(phy->spi, REG_RX1_TUNE_CTRL, 0x03); /* Tune circuit off. */
+    ad9361_spi_write(phy->spi, REG_RX2_TUNE_CTRL, 0x03);
+
+    /* TX: corner = 1.6 x BBBW; divider = ceil(BBPLL / (1.6 BBBW 2pi/ln2)). */
+    target  = 145036u * (bbbw / 10000u);
+    divider = (bbpll + target - 1) / target;
+    if (divider < 1)   divider = 1;
+    if (divider > 511) divider = 511;
+    ad9361_spi_write(phy->spi, REG_TX_BBF_TUNE_DIVIDER, divider & 0xff);
+    ad9361_spi_write(phy->spi, REG_TX_BBF_TUNE_MODE,
+        (ad9361_spi_read(phy->spi, REG_TX_BBF_TUNE_MODE) & ~1) | (divider >> 8));
+    ad9361_spi_write(phy->spi, REG_TX_TUNE_CTRL, TUNER_RESAMPLE | TUNE_CTRL(1));
+    ad9361_spi_write(phy->spi, REG_CALIBRATION_CTRL, TX_BB_TUNE_CAL);
+    for (i = 0; i < 200; i++) {
+        if (!(ad9361_spi_read(phy->spi, REG_CALIBRATION_CTRL) & TX_BB_TUNE_CAL))
+            break;
+        mdelay(1);
+    }
+    ok &= (i < 200);
+    printf("RFIC overclock: TX BBF tune div=%u %s.\n", divider,
+           (i < 200) ? "done" : "TIMEOUT");
+    ad9361_spi_write(phy->spi, REG_TX_TUNE_CTRL,
+                     TUNER_RESAMPLE | TUNE_CTRL(1) | PD_TUNE);
+
+    ad9361_ensm_restore_prev_state(phy);
+    return ok;
+}
+
+/* Load an equalizer FIR (file of integer taps, one per line, multiple of 16)
+ * into the chip FIR engine. The engine corrupts data beyond a 245.76 MHz
+ * processing clock at this overclock (measured), which caps the taps per
+ * direction; the caller passes the cap and configures dec/int = 1. Returns
+ * the FIR-enable low bits for 0x002/0x003 (0x01 loaded, 0x00 off). */
+static uint8_t ad9361_load_eq_fir(struct ad9361_rf_phy *phy, const char *file,
+                                  enum fir_dest dest, int max_taps, const char *what)
+{
+    int16_t coefs[64];
+    FILE *ff = fopen(file, "r");
+    int n = 0;
+
+    if (ff) {
+        int v;
+        while (n < 64 && fscanf(ff, "%d", &v) == 1)
+            coefs[n++] = (int16_t)v;
+        fclose(ff);
+    }
+    if (n <= 0 || (n % 16) != 0 || n > max_taps) {
+        printf("RFIC overclock: bad %s EQ FIR file '%s' (%d taps), FIR off.\n",
+               what, file, n);
+        return 0x00;
+    }
+    if (ad9361_load_fir_filter_coef(phy, dest, 0, n, coefs) != 0) {
+        printf("RFIC overclock: %s EQ FIR load FAILED, FIR off.\n", what);
+        return 0x00;
+    }
+    printf("RFIC overclock: %d-tap %s EQ FIR loaded (%s).\n", n, what, file);
+    return 0x01;
+}
+
 void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
 {
     /* Filter-control registers: halve the decimation/interpolation so the data
@@ -7517,12 +7617,56 @@ void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
         /* 0x003 (Rx Enable & Filter Ctrl) low bits 0x14: RHB3 dec2 ([5:4]=01),
          * RHB2 bypassed ([3]=0), RHB1 dec2 ([2]=1), RX FIR off ([1:0]=00):
          * total decimation 4 from a 4x-rate ADC clock = 2x port rate. */
-        ad9361_spi_write(phy->spi, 0x003, (rx_ctrl & 0xC0) | 0x14);
+        uint8_t rx_fir = 0x00;
+        /* M2SDR_OC_RX_FIR_FILE: decimate-by-1 RX FIR as a passband flatness
+         * equalizer; the composite BBF + half-band response otherwise rolls
+         * off ~7-9.5dB over the outer +/-36-49MHz. Up to 32 taps: the engine
+         * processes at 2x the 122.88MHz output rate here, which 32 taps just
+         * meet. */
+        const char *fir_file = getenv("M2SDR_OC_RX_FIR_FILE");
+        if (fir_file != NULL) {
+            phy->rx_fir_dec = 1;
+            rx_fir = ad9361_load_eq_fir(phy, fir_file,
+                (enum fir_dest)(((rx_ctrl >> 6) & 0x3) | FIR_IS_RX), 32, "RX");
+        }
+        ad9361_spi_write(phy->spi, 0x003, (rx_ctrl & 0xC0) | 0x14 | rx_fir);
+        /* M2SDR_OC_TX_FIR_FILE: interpolate-by-1 TX FIR as a passband
+         * pre-emphasis equalizer (the composite TX BBF + DAC sinc response
+         * droops to ~-8dB over the outer +/-38-49MHz; measured flat to
+         * +/-1.3dB at +/-42 with the inverse design). IMPORTANT: in this
+         * mode the FIR processes in the 245.76MHz domain (each port sample
+         * seen twice with the interpolation stages bypassed), so the taps
+         * must be designed for fs = 245.76MHz, not the 122.88MHz port rate
+         * - a 122.88-designed filter applies frequency-stretched 2x and
+         * degenerates to its DC gain over the signal band - and the engine
+         * ceiling allows only 16 of them. Pre-emphasis costs its peak boost
+         * in maximum output power. */
+        uint8_t tx_fir = 0x00;
+        const char *tx_fir_file = getenv("M2SDR_OC_TX_FIR_FILE");
+        if (tx_fir_file != NULL) {
+            phy->tx_fir_int = 1;
+            tx_fir = ad9361_load_eq_fir(phy, tx_fir_file,
+                (enum fir_dest)((tx_ctrl >> 6) & 0x3), 16, "TX");
+        }
         /* 0x002 (Tx Enable & Filter Ctrl) low bits 0x00: all THB stages and
          * the TX FIR bypassed - the DAC runs directly at the port rate. */
-        ad9361_spi_write(phy->spi, 0x002, (tx_ctrl & 0xC0) | 0x00);
+        ad9361_spi_write(phy->spi, 0x002, (tx_ctrl & 0xC0) | 0x00 | tx_fir);
     }
 
+    /* Baseband filters: the default is the chip-native wide tune (the chip's
+     * own R/C search run against a ~54/62 MHz corner target), which keeps the
+     * calibrated noise behavior. M2SDR_OC_BBF_FORCE selects the register
+     * force-widening fallback below instead; M2SDR_OC_BBF_TUNE overrides the
+     * tune target (BBBW in Hz, half the complex bandwidth). */
+    bool bbf_tuned = false;
+    if (getenv("M2SDR_OC_BBF_FORCE") == NULL) {
+        const char *s = getenv("M2SDR_OC_BBF_TUNE");
+        uint32_t bbbw = s ? (uint32_t)strtoul(s, NULL, 0) : 39000000u;
+
+        bbf_tuned = ad9361_wide_bbf_tune(phy, bbbw);
+    }
+
+    if (!bbf_tuned) {
     /* TX baseband filter (3rd-order Butterworth, corner ~ 1/(2.pi.R.C)):
      * resistor words to 0x9f = override-enable bit (0x80) + maximum code
      * (0x1f), capacitor words to 0x00 = minimum C; both push the corner as
@@ -7542,6 +7686,7 @@ void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
     /* R2B is part of the same override set (0x0c2..0x0cb); maxing it
      * measures ~+1 dB effective SNR at the band edges. */
     ad9361_spi_write(phy->spi, 0x0cb, 0x1f); /* TX BBF R2B (max).     */
+    }
 
     /* TX secondary (post-BBF single-pole) filter capacitor word: the driver's
      * ad9361_tx_bb_second_filter_calib() places this pole at 2.5 x BBBW and
@@ -7556,7 +7701,7 @@ void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
      * R1A is the DENOMINATOR of the bi-quad gain (R4/R1A) and R5 of the pole
      * gain (R6/R5); zeroing them (as a naive copy of the TX recipe does)
      * collapses the RX path - measured as "no signal, ~0 dB IQ image". */
-    {
+    if (!bbf_tuned) {
         ad9361_spi_write(phy->spi, 0x1e0, 0xbf); /* RX BBF R1A: force + 0x3f (max). */
         ad9361_spi_write(phy->spi, 0x1e4, 0xff); /* RX BBF R5 (max).      */
         /* R5 tune (0x1f2) must be ZERO while R5 (0x1e4/0x1e5) is nonzero
@@ -7597,8 +7742,11 @@ void ad9361_enable_oversampling(struct ad9361_rf_phy *phy)
      * (full-scale noise) captures. Values below are the eye midpoints from
      * the PRBS delay scan (`m2sdr_rf --sample-rate 61.44e6 --calibrate-delay`,
      * 61.44 MSPS 2T2R = electrically the same DATA_CLK 245.76 MHz): RX eye
-     * 4 taps -> clk 1/data 2; TX eye 14 taps -> clk 6/data 7. */
-    ad9361_spi_write(phy->spi, REG_RX_CLOCK_DATA_DELAY, 0x12); /* clk 1 / data 2 */
+     * 4 taps -> clk 1/data 2; TX eye 14 taps -> clk 6/data 7. The RX clock
+     * delay also absorbs the ~0.6ns insertion delay of the per-lane RX
+     * IDELAYE2s in the deskew-capable gateware (measured midpoint clk 4 /
+     * data 3 with the IDELAYs at tap 0). */
+    ad9361_spi_write(phy->spi, REG_RX_CLOCK_DATA_DELAY, 0x43); /* clk 4 / data 3 */
     ad9361_spi_write(phy->spi, REG_TX_CLOCK_DATA_DELAY, 0x67); /* clk 6 / data 7 */
 
     /* Per-board override of the interface delays from the environment

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
@@ -1094,6 +1094,47 @@ static int m2sdr_wide_bandwidth_bringup(struct m2sdr_dev *dev,
         rc = m2sdr_wide_bandwidth_verify(dev);
         if (rc == M2SDR_ERR_OK) {
             M2SDR_LOGF("Wide-bandwidth interface verified aligned (try %d).\n", try_);
+            /* RX quadrature tracking loop gain: at the driver default
+             * (K exp 0x15) the loop is effectively inert in this mode and
+             * the image rejection settles at ~23-28dBc - a direct 3.5-7%
+             * EVM floor. K exp 0x0a converges to ~40-43dBc (measured;
+             * stable from 0x02 to 0x0a). M2SDR_QEC_KEXP overrides. */
+            {
+                const char *s = getenv("M2SDR_QEC_KEXP");
+                uint8_t kexp = s ? (uint8_t)strtoul(s, NULL, 0) & 0x1F : 0x0a;
+
+                ad9361_spi_write(phy->spi, REG_CALIBRATION_CONFIG_2,
+                    CALIBRATION_CONFIG2_DFLT | K_EXP_PHASE(kexp));
+                ad9361_spi_write(phy->spi, REG_CALIBRATION_CONFIG_3,
+                    PREVENT_POS_LOOP_GAIN | K_EXP_AMPLITUDE(kexp));
+            }
+            /* RFPLL loop peaking: the LUT charge-pump current leaves a
+             * ~5dB skirt bump at 1-3MHz offsets (measured); reducing it to
+             * ~30% removes the peaking on both synthesizers and the EVM
+             * plateaus there (RX 6.8 -> 6.2%, TX 7.3 -> 5.1% on a 50MHz TM;
+             * lower values measure no further gain and erode loop margin).
+             * M2SDR_RFPLL_CP_PERCENT overrides (100 = LUT value). */
+            {
+                const char *s = getenv("M2SDR_RFPLL_CP_PERCENT");
+                unsigned pct = s ? (unsigned)strtoul(s, NULL, 0) : 30;
+                static const uint16_t cp_regs[2] = {
+                    REG_RX_CP_CURRENT, REG_TX_CP_CURRENT
+                };
+                unsigned i;
+
+                for (i = 0; i < 2; i++) {
+                    uint8_t cp = ad9361_spi_read(phy->spi, cp_regs[i]);
+                    uint8_t icp = cp & CHARGE_PUMP_CURRENT(~0);
+                    uint8_t nicp = (uint8_t)((icp * pct + 50) / 100);
+
+                    if (nicp < 1)
+                        nicp = 1;
+                    if (nicp > CHARGE_PUMP_CURRENT(~0))
+                        nicp = CHARGE_PUMP_CURRENT(~0);
+                    ad9361_spi_write(phy->spi, cp_regs[i],
+                        (cp & ~CHARGE_PUMP_CURRENT(~0)) | nicp);
+                }
+            }
             return M2SDR_ERR_OK;
         }
     }
@@ -1313,7 +1354,14 @@ int m2sdr_apply_config(struct m2sdr_dev *dev, const struct m2sdr_config *cfg)
     init_param->gpio_cal_sw1       = -1;
     init_param->gpio_cal_sw2       = -1;
 
-    rc = m2sdr_apply_channel_layout(dev, init_param, channel_layout, 0, 0);
+    {
+        /* M2SDR_RF_CHANNEL=2 selects the second physical RF port pair
+         * (RX2/TX2) in 1T1R; the default is RX1/TX1. */
+        const char *s = getenv("M2SDR_RF_CHANNEL");
+        unsigned ch = (s != NULL && strtoul(s, NULL, 0) == 2) ? 1 : 0;
+
+        rc = m2sdr_apply_channel_layout(dev, init_param, channel_layout, ch, ch);
+    }
     if (rc != M2SDR_ERR_OK)
         return rc;
 #ifdef USE_LITEETH

--- a/scripts/flash_gateware.sh
+++ b/scripts/flash_gateware.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# No-reboot M2SDR gateware reflash (proven recipe, 2026-06-10):
+# flash-write -> ICAP flash-reload (FPGA reconfigures, PCIe retrains by
+# itself) -> driver unload -> PCIe remove/rescan -> driver reload.
+#
+# Usage: scripts/flash_gateware.sh <image.bin> [offset]
+#   offset: 0x800000 (default) = x4/main image slot; 0x0 = fallback slot
+#           (an x2 fallback image lives at 0x0 on this board).
+#
+# After this, REBUILD the user software if the CSR map changed
+# (make -C litex_m2sdr/software/user) and relink any tools that statically
+# link libm2sdr.a.
+#
+# If the device does not reappear: pulse Secondary Bus Reset on bridge
+# 04:00.0 (setpci -s 04:00.0 BRIDGE_CONTROL bit 0x40) before rescan.
+# If config space is dead (D3cold, "Unsupported device version 255"):
+# only a full power cycle helps.
+set -e
+U="$(dirname "$0")/../litex_m2sdr/software/user"
+BIN=${1:?usage: flash_gateware.sh image.bin [offset]}
+OFF=${2:-0x800000}
+PCIDEV=0000:05:00.0
+
+echo YES | "$U/m2sdr_util" flash-write "$BIN" "$OFF"
+"$U/m2sdr_util" flash-reload || true
+sleep 4
+sudo rmmod m2sdr 2>/dev/null || true
+echo 1 | sudo tee /sys/bus/pci/devices/$PCIDEV/remove >/dev/null
+sleep 1
+echo 1 | sudo tee /sys/bus/pci/rescan >/dev/null
+sleep 2
+sudo modprobe m2sdr
+sleep 1
+lspci -d 10ee:
+sudo lspci -s ${PCIDEV#0000:} -vv | grep LnkSta: || true
+ls -l /dev/m2sdr0

--- a/scripts/loopback_selftest.c
+++ b/scripts/loopback_selftest.c
@@ -1,0 +1,926 @@
+/* M2SDR cable-loopback self-test engine.
+ *
+ * Verifies, for one RF configuration, the properties the DMA/timestamp stack
+ * must hold so that "when we get samples, they are correct":
+ *
+ *  T1  RX DMA headers: every buffer carries the sync word + a hardware
+ *      timestamp with uniform cadence (one frame per 8KiB DMA buffer).
+ *  T2  Transmission correctness over the loopback cable: per-channel tones
+ *      with the expected SNR, channel mapping (no swap), and sample-stream
+ *      continuity proven by tone phase advancing exactly one buffer period
+ *      per buffer (a single dropped/duplicated sample shifts the phase by
+ *      2*pi*f_rel and fails the check).
+ *  T3  Host-drop recovery: the reader thread stalls on purpose; the library
+ *      must report the overflow (zero-copy mode) and the first buffer after
+ *      the gap must carry a timestamp an exact integer number of buffer
+ *      periods after the last one before it.
+ *  T4  TX headers: the FPGA extractor's last-header/last-timestamp CSRs must
+ *      track the sync word and the synthetic timestamps submitted by the
+ *      host (misalignment would show payload bytes here).
+ *  T5  Burst timing determinism: gated bursts on the TX sample timeline must
+ *      arrive with uniform spacing on the RX hardware timeline.
+ *  T6  Stream restart alignment: stopping/restarting one direction while the
+ *      other keeps running must not slip the header framing (this is the
+ *      historical FDX header-FSM bug).
+ *
+ * Build/run via scripts/loopback_selftest.sh, which links against the
+ * in-repo libm2sdr (never the installed copy) and sweeps configurations.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#include "m2sdr.h"
+
+#define MAGIC 0x5aa55aa55aa55aa5ull
+
+/* ------------------------------------------------------------------ */
+/* Options / globals                                                   */
+/* ------------------------------------------------------------------ */
+
+static struct {
+    double      rate;
+    int         layout2;     /* 1 = 2T2R */
+    int         chan;        /* cabled port pair: 1, 2, or 3 = both */
+    double      freq;
+    int         rx_gain;
+    int         tx_att;
+    int         sc8;
+    int         no_tx;
+    int         nbufs;       /* buffers analyzed in the cadence phase */
+    int         stall_ms;
+    int         zero_copy;
+    int         no_restart;
+    int         no_rf;       /* skip apply_config: RF configured externally */
+    const char *dev_id;
+} opt = {
+    .rate = 61.44e6, .layout2 = 0, .chan = 2, .freq = 3.6e9,
+    .rx_gain = 40, .tx_att = 10, .sc8 = 0, .no_tx = 0,
+    .nbufs = 6000, .stall_ms = 50, .zero_copy = 1, .no_restart = 0,
+    .no_rf = 0,
+    .dev_id = "pcie:/dev/m2sdr0",
+};
+
+static struct m2sdr_dev *dev;
+static unsigned sample_sz;       /* bytes per channel-sample (I+Q)       */
+static unsigned nch;             /* stream channels                      */
+static unsigned spb;             /* channel-samples per DMA payload      */
+static unsigned frames;          /* frames (per-channel samples) per buf */
+static double   dt_nom;          /* nominal buffer period in ns          */
+static double   f_rel[2];        /* per-channel tone, cycles per frame   */
+static int      chan_cabled[2];
+
+static int n_pass, n_fail, n_skip;
+
+static void check(const char *name, int pass, const char *fmt, ...)
+{
+    char detail[256];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(detail, sizeof(detail), fmt, ap);
+    va_end(ap);
+    printf("CHECK %-28s %s  %s\n", name, pass ? "PASS" : "FAIL", detail);
+    if (pass) n_pass++; else n_fail++;
+}
+
+static void skip(const char *name, const char *why)
+{
+    printf("CHECK %-28s SKIP  %s\n", name, why);
+    n_skip++;
+}
+
+static void info(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    printf("INFO  ");
+    vprintf(fmt, ap);
+    printf("\n");
+    va_end(ap);
+}
+
+/* ------------------------------------------------------------------ */
+/* TX thread: continuous per-channel tones, optional burst gating      */
+/* ------------------------------------------------------------------ */
+
+enum { TX_TONE, TX_BURST, TX_PAUSE, TX_QUIT };
+
+#define BURST_PERIOD 64 /* buffers */
+#define BURST_ON      8 /* buffers */
+
+static atomic_int    tx_mode    = TX_TONE;
+static atomic_int    tx_paused  = 0;     /* ack that the thread is idle   */
+static atomic_long   tx_bufs    = 0;
+static atomic_long   tx_underflows = 0;
+static pthread_t     tx_thread;
+static int           tx_running = 0;
+
+#define TX_TS_BASE 0x4000000000000000ull /* synthetic, never 0 */
+
+static void tx_fill(void *buf, long bufidx, int gated_off)
+{
+    /* Per-channel rotators persist across buffers so the tone phase is
+     * continuous on the TX sample timeline. */
+    static double cr[2] = {1, 1}, ci[2] = {0, 0};
+    double wr[2], wi[2];
+    int amp_on[2];
+
+    for (int c = 0; c < 2; c++) {
+        wr[c] = cos(2 * M_PI * f_rel[c]);
+        wi[c] = sin(2 * M_PI * f_rel[c]);
+        amp_on[c] = chan_cabled[c] && !gated_off;
+    }
+    (void)bufidx;
+
+    int16_t *s16 = buf;
+    int8_t  *s8  = buf;
+    const int a16 = 1200, a8 = 75;
+
+    for (unsigned n = 0; n < frames; n++) {
+        for (unsigned c = 0; c < nch; c++) {
+            int cc = (nch == 2) ? (int)c : (opt.chan == 2 ? 1 : 0);
+            int i, q;
+            if (amp_on[cc]) {
+                i = (int)lrint(cr[cc] * (opt.sc8 ? a8 : a16));
+                q = (int)lrint(ci[cc] * (opt.sc8 ? a8 : a16));
+            } else {
+                i = q = 0;
+            }
+            if (opt.sc8) { *s8++ = (int8_t)i; *s8++ = (int8_t)q; }
+            else         { *s16++ = (int16_t)i; *s16++ = (int16_t)q; }
+            /* advance the rotator even while gated off: burst edges must
+             * land on the continuous timeline, not restart the phase */
+            double nr = cr[cc] * wr[cc] - ci[cc] * wi[cc];
+            double ni = cr[cc] * wi[cc] + ci[cc] * wr[cc];
+            cr[cc] = nr; ci[cc] = ni;
+        }
+        if ((n & 0xff) == 0xff)
+            for (int c = 0; c < 2; c++) {
+                double m = sqrt(cr[c] * cr[c] + ci[c] * ci[c]);
+                cr[c] /= m; ci[c] /= m;
+            }
+    }
+}
+
+static void *tx_main(void *arg)
+{
+    (void)arg;
+    void *buf = m2sdr_alloc_buffer(opt.sc8 ? M2SDR_FORMAT_SC8_Q7
+                                           : M2SDR_FORMAT_SC16_Q11, spb);
+
+    for (;;) {
+        int mode = atomic_load(&tx_mode);
+        if (mode == TX_QUIT)
+            break;
+        if (mode == TX_PAUSE) {
+            atomic_store(&tx_paused, 1);
+            usleep(2000);
+            continue;
+        }
+        atomic_store(&tx_paused, 0);
+
+        long idx = atomic_load(&tx_bufs);
+        int gated_off = (mode == TX_BURST) &&
+                        ((idx % BURST_PERIOD) >= BURST_ON);
+        tx_fill(buf, idx, gated_off);
+
+        struct m2sdr_metadata meta = {
+            .timestamp = TX_TS_BASE + (uint64_t)idx,
+            .flags     = M2SDR_META_FLAG_HAS_TIME,
+        };
+        int rc = m2sdr_sync_tx(dev, buf, spb, &meta, 1000);
+        if (rc == M2SDR_ERR_UNDERFLOW) {
+            atomic_fetch_add(&tx_underflows, 1);
+        } else if (rc != M2SDR_ERR_OK && rc != M2SDR_ERR_TIMEOUT) {
+            usleep(1000);
+            continue;
+        }
+        atomic_fetch_add(&tx_bufs, 1);
+    }
+    m2sdr_free_buffer(buf);
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* RX analysis                                                         */
+/* ------------------------------------------------------------------ */
+
+/* One RX DMA buffer, analyzed. */
+struct bufstat {
+    uint64_t ts;
+    int      has_ts;
+    int      zero;
+    float    amp[2];     /* tone magnitude per channel, normalized      */
+    float    phase[2];   /* tone phase per channel (local-index ref)    */
+    float    rms[2];
+};
+
+static float *tw_cos[2], *tw_sin[2]; /* per-channel local-index twiddles */
+
+static void analysis_init(void)
+{
+    for (int c = 0; c < 2; c++) {
+        tw_cos[c] = malloc(frames * sizeof(float));
+        tw_sin[c] = malloc(frames * sizeof(float));
+        for (unsigned n = 0; n < frames; n++) {
+            tw_cos[c][n] = (float)cos(2 * M_PI * f_rel[c] * n);
+            tw_sin[c][n] = (float)sin(2 * M_PI * f_rel[c] * n);
+        }
+    }
+}
+
+static void analyze(const void *payload, struct bufstat *st)
+{
+    const int16_t *s16 = payload;
+    const int8_t  *s8  = payload;
+    const float fs = opt.sc8 ? 127.0f : 2047.0f;
+
+    if (opt.no_tx) {
+        /* No signal expected: only the all-zero (DMA start gap) check, on a
+         * sparse stride so the reader keeps up at 983 MB/s. */
+        const uint64_t *w = payload;
+        unsigned nw = spb * sample_sz / 8;
+        st->zero = 1;
+        for (unsigned k = 0; k < nw; k += 16)
+            if (w[k]) {
+                st->zero = 0;
+                break;
+            }
+        memset(st->amp, 0, sizeof(st->amp));
+        memset(st->phase, 0, sizeof(st->phase));
+        memset(st->rms, 0, sizeof(st->rms));
+        return;
+    }
+
+    st->zero = 1;
+    for (unsigned c = 0; c < nch; c++) {
+        int cc = (nch == 2) ? (int)c : (opt.chan == 2 ? 1 : 0);
+        float ar = 0, ai = 0;
+        double p = 0;
+        for (unsigned n = 0; n < frames; n++) {
+            float xi, xq;
+            unsigned k = (n * nch + c) * 2;
+            if (opt.sc8) { xi = s8[k] / fs;  xq = s8[k + 1] / fs; }
+            else         { xi = s16[k] / fs; xq = s16[k + 1] / fs; }
+            if (xi != 0 || xq != 0)
+                st->zero = 0;
+            /* x * e^{-j 2 pi f n} accumulated over the buffer */
+            ar += xi * tw_cos[cc][n] + xq * tw_sin[cc][n];
+            ai += xq * tw_cos[cc][n] - xi * tw_sin[cc][n];
+            p  += xi * xi + xq * xq;
+        }
+        st->amp[cc]   = sqrtf(ar * ar + ai * ai) / frames;
+        st->phase[cc] = atan2f(ai, ar);
+        st->rms[cc]   = (float)sqrt(p / frames);
+    }
+}
+
+static int read_buf(struct bufstat *st, void *payload, int *overflowed,
+                    unsigned timeout_ms)
+{
+    struct m2sdr_metadata meta;
+    int rc = m2sdr_sync_rx(dev, payload, spb, &meta, timeout_ms);
+    if (rc == M2SDR_ERR_OVERFLOW) {
+        if (overflowed)
+            (*overflowed)++;
+        rc = m2sdr_sync_rx(dev, payload, spb, &meta, timeout_ms);
+    }
+    if (rc != M2SDR_ERR_OK)
+        return rc;
+    st->has_ts = !!(meta.flags & M2SDR_META_FLAG_HAS_TIME);
+    st->ts     = meta.timestamp;
+    return 0;
+}
+
+static double wrap_pi(double x)
+{
+    while (x >  M_PI) x -= 2 * M_PI;
+    while (x < -M_PI) x += 2 * M_PI;
+    return x;
+}
+
+static int cmp_dbl(const void *a, const void *b)
+{
+    double d = *(const double *)a - *(const double *)b;
+    return (d > 0) - (d < 0);
+}
+
+static double median(double *v, int n)
+{
+    qsort(v, n, sizeof(double), cmp_dbl);
+    return n & 1 ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
+
+/* ------------------------------------------------------------------ */
+/* CSR helpers                                                         */
+/* ------------------------------------------------------------------ */
+
+static uint64_t csr_read64(uint32_t addr)
+{
+    uint32_t hi = 0, lo = 0;
+    m2sdr_reg_read(dev, addr, &hi);
+    m2sdr_reg_read(dev, addr + 4, &lo);
+    return ((uint64_t)hi << 32) | lo;
+}
+
+/* ------------------------------------------------------------------ */
+/* Phases                                                              */
+/* ------------------------------------------------------------------ */
+
+static struct bufstat *stats;
+static double steady_amp[2];
+
+/* Read and discard until the stream looks live: headers present and, with
+ * TX running, the tone visible. Returns leading all-zero buffer count. */
+static int warmup(void *payload, int want_tone, int max_ms)
+{
+    struct bufstat st;
+    int zeros = 0, got = 0;
+    long deadline = max_ms;
+
+    while (deadline > 0) {
+        int rc = read_buf(&st, payload, NULL, 1000);
+        if (getenv("LBT_DEBUG") && (rc != 0 || got < 3))
+            fprintf(stderr, "warmup: rc=%d got=%d zeros=%d\n", rc, got, zeros);
+        if (rc == M2SDR_ERR_TIMEOUT) {
+            deadline -= 1000;
+            continue;
+        }
+        if (rc != 0)
+            return -1;
+        analyze(payload, &st);
+        if (st.zero && !got) {
+            zeros++;
+            continue;
+        }
+        got++;
+        if (!want_tone && got >= 100)
+            return zeros;
+        if (want_tone) {
+            int ok = 1;
+            for (int c = 0; c < 2; c++)
+                if (chan_cabled[c] && st.amp[c] < 0.01)
+                    ok = 0;
+            if (ok && got >= 100)
+                return zeros;
+        }
+        if (got > 60000) /* ~1-2 s of buffers without the tone */
+            return zeros;
+    }
+    return -1;
+}
+
+static void phase_cadence(void *payload, const char *tag, int nbufs,
+                          int with_tone_checks)
+{
+    char name[64];
+    int hdr_ok = 0, zero_mid = 0, ovf = 0;
+    int n = 0;
+
+    for (n = 0; n < nbufs; n++) {
+        if (read_buf(&stats[n], payload, &ovf, 1000) != 0)
+            break;
+        analyze(payload, &stats[n]);
+        if (stats[n].has_ts)
+            hdr_ok++;
+        if (stats[n].zero && n > 0 && !stats[n - 1].zero)
+            zero_mid++;
+    }
+
+    snprintf(name, sizeof(name), "%s.headers", tag);
+    check(name, n == nbufs && hdr_ok == n,
+          "%d/%d buffers read, %d with valid sync word", n, nbufs, hdr_ok);
+    if (opt.zero_copy) {
+        snprintf(name, sizeof(name), "%s.no-overflow", tag);
+        check(name, ovf == 0, "%d unexpected ring overflows", ovf);
+    }
+    if (n < 2)
+        return;
+
+    /* Cadence: per-buffer timestamp delta uniformity. */
+    double *dts = malloc((n - 1) * sizeof(double));
+    int mono = 1;
+    for (int k = 1; k < n; k++) {
+        dts[k - 1] = (double)(int64_t)(stats[k].ts - stats[k - 1].ts);
+        if (dts[k - 1] <= 0)
+            mono = 0;
+    }
+    /* Mean over the whole span averages out the 10ns timestamp
+     * quantization (per-buffer deltas snap to the 10ns time-clock grid). */
+    double dt_mean = (double)(int64_t)(stats[n - 1].ts - stats[0].ts) / (n - 1);
+    double worst = 0;
+    for (int k = 0; k < n - 1; k++) {
+        double d = fabs(dts[k] - dt_mean);
+        if (d > worst)
+            worst = d;
+    }
+    double ppm = (dt_mean / dt_nom - 1) * 1e6;
+
+    snprintf(name, sizeof(name), "%s.cadence", tag);
+    check(name, mono && worst <= 40.0 && fabs(ppm) < 100.0,
+          "dt=%.1fns (nom %.1f, %+.1fppm), max dev %.1fns, monotonic=%d",
+          dt_mean, dt_nom, ppm, worst, mono);
+    free(dts);
+
+    snprintf(name, sizeof(name), "%s.zeros-midstream", tag);
+    check(name, zero_mid == 0, "%d all-zero buffers after stream start",
+          zero_mid);
+
+    if (!with_tone_checks)
+        return;
+
+    /* Tone level + channel mapping. */
+    for (int c = 0; c < 2; c++) {
+        if (!chan_cabled[c]) {
+            if (nch == 2) {
+                /* Un-driven channel must not show the other channel's tone
+                 * at ITS OWN tone bin beyond crosstalk. */
+                double a = 0;
+                for (int k = 0; k < n; k++)
+                    a += stats[k].amp[c];
+                a /= n;
+                snprintf(name, sizeof(name), "%s.ch%d-quiet", tag, c + 1);
+                check(name, a < 0.02, "undriven channel amp %.4f", a);
+            }
+            continue;
+        }
+        double a = 0, r = 0;
+        for (int k = 0; k < n; k++) {
+            a += stats[k].amp[c];
+            r += stats[k].rms[c];
+        }
+        a /= n; r /= n;
+        steady_amp[c] = a;
+        /* rms^2 = mean(I^2+Q^2) carries the full tone power a^2. */
+        double rest = fmax(r * r - a * a, 1e-12);
+        double snr = 10 * log10(a * a / rest);
+        snprintf(name, sizeof(name), "%s.ch%d-tone", tag, c + 1);
+        check(name, a > 0.01 && snr > 15.0,
+              "amp %.4f (%.1f dBFS rms), tone/rest %.1f dB",
+              a, 20 * log10(fmax(r, 1e-9)), snr);
+
+        /* Sample-stream continuity: tone phase must advance by the same
+         * amount every buffer. A single dropped/repeated frame shifts it
+         * by 2*pi*f_rel (~0.3-0.5 rad), well above the noise. */
+        double exp_adv = 0;
+        double sr = 0, si = 0;
+        for (int k = 1; k < n; k++) {
+            double d = wrap_pi(stats[k].phase[c] - stats[k - 1].phase[c]);
+            sr += cos(d); si += sin(d);
+        }
+        exp_adv = atan2(si, sr); /* circular mean advance */
+        double worst_ph = 0;
+        int bad = 0;
+        for (int k = 1; k < n; k++) {
+            double d = fabs(wrap_pi(stats[k].phase[c]
+                                    - stats[k - 1].phase[c] - exp_adv));
+            if (d > worst_ph)
+                worst_ph = d;
+            if (d > 0.15)
+                bad++;
+        }
+        snprintf(name, sizeof(name), "%s.ch%d-continuity", tag, c + 1);
+        check(name, bad == 0,
+              "phase step %.4f rad/buf, worst dev %.3f rad, %d/%d over 0.15",
+              exp_adv, worst_ph, bad, n - 1);
+    }
+}
+
+static void phase_stall(void *payload)
+{
+    /* Deliberately stop reading, then verify the stream account stays exact:
+     * the discontinuity must land on the buffer grid (lost data = an integer
+     * number of whole DMA buffers, headers still aligned) and its size must
+     * match the stall. In zero-copy mode the loss surfaces at the first read
+     * after the stall; the buffered helper path may serve retained ring
+     * contents first, so the whole post-stall window is scanned. */
+    struct bufstat anchor, st;
+    int overflows = 0;
+
+    if (read_buf(&anchor, payload, &overflows, 1000) != 0 || !anchor.has_ts) {
+        check("stall.anchor", 0, "could not read anchor buffer");
+        return;
+    }
+
+    usleep((useconds_t)opt.stall_ms * 1000);
+
+    overflows = 0;
+    int nscan = 600, ngaps = 0, offgrid = 0, hdr_bad = 0;
+    double missing = 0, worst_frac = 0;
+    uint64_t prev = anchor.ts;
+    int i;
+    for (i = 0; i < nscan; i++) {
+        if (read_buf(&st, payload, &overflows, 2000) != 0)
+            break;
+        if (!st.has_ts) {
+            hdr_bad++;
+            continue;
+        }
+        double dt = (double)(int64_t)(st.ts - prev);
+        prev = st.ts;
+        double bufs = dt / dt_nom;
+        double frac = fabs(bufs - round(bufs)) * dt_nom; /* ns off the grid */
+        if (frac > worst_frac)
+            worst_frac = frac;
+        if (frac > 60.0)
+            offgrid++;
+        if (round(bufs) > 1) {
+            ngaps++;
+            missing += dt - dt_nom;
+        }
+    }
+
+    check("stall.resume", i == nscan && hdr_bad == 0,
+          "%d/%d valid headered buffers after %d ms host stall",
+          i - hdr_bad, nscan, opt.stall_ms);
+
+    if (opt.zero_copy)
+        check("stall.overflow-reported", overflows > 0,
+              "library returned M2SDR_ERR_OVERFLOW %d time(s)", overflows);
+    else
+        skip("stall.overflow-reported", "no explicit signaling without zero-copy");
+
+    check("stall.gap-on-buffer-grid", ngaps >= 1 && offgrid == 0,
+          "%d gap(s), worst %.1fns off the %.1fns buffer grid",
+          ngaps, worst_frac, dt_nom);
+    check("stall.gap-duration",
+          missing > opt.stall_ms * 0.3e6 && missing < opt.stall_ms * 1e6 + 100e6,
+          "%.1fms missing vs %dms stall (ring holds %.1fms)",
+          missing / 1e6, opt.stall_ms, 256 * dt_nom / 1e6);
+
+    /* Post-recovery re-verification. */
+    phase_cadence(payload, "recovery", opt.nbufs / 2, !opt.no_tx);
+}
+
+static void phase_tx_csrs(void)
+{
+    if (opt.no_tx) {
+        skip("txhdr.magic", "TX disabled in this configuration");
+        return;
+    }
+    uint64_t hdr = csr_read64(CSR_HEADER_LAST_TX_HEADER_ADDR);
+    uint64_t ts  = csr_read64(CSR_HEADER_LAST_TX_TIMESTAMP_ADDR);
+    long idx_now = atomic_load(&tx_bufs);
+
+    check("txhdr.magic", hdr == MAGIC,
+          "extractor last header %016llx", (unsigned long long)hdr);
+
+    long idx = (long)(ts - TX_TS_BASE);
+    check("txhdr.timestamp-tracks", ts >= TX_TS_BASE &&
+          idx <= idx_now && idx >= idx_now - 512,
+          "extracted ts -> buffer %ld, host at %ld (lag %ld)",
+          idx, idx_now, idx_now - idx);
+
+    usleep(50 * 1000);
+    uint64_t ts2 = csr_read64(CSR_HEADER_LAST_TX_TIMESTAMP_ADDR);
+    check("txhdr.timestamp-advances", ts2 > ts,
+          "%llu -> %llu over 50ms",
+          (unsigned long long)(ts - TX_TS_BASE),
+          (unsigned long long)(ts2 - TX_TS_BASE));
+
+    uint64_t rxh = csr_read64(CSR_HEADER_LAST_RX_HEADER_ADDR);
+    check("rxhdr.magic-csr", rxh == MAGIC,
+          "inserter last header %016llx", (unsigned long long)rxh);
+}
+
+static void phase_burst(void *payload)
+{
+    if (opt.no_tx) {
+        skip("burst.spacing", "TX disabled in this configuration");
+        return;
+    }
+    int c = chan_cabled[1] ? 1 : 0; /* measure on one cabled channel */
+    double thr_lo = 0.1 * steady_amp[c];
+    if (steady_amp[c] < 0.01) {
+        skip("burst.spacing", "no steady tone amplitude to gate against");
+        return;
+    }
+
+    atomic_store(&tx_mode, TX_BURST);
+
+    struct bufstat st;
+    double arrivals[24];
+    int n_arr = 0, low_run = 0;
+    /* settle two periods, then collect 16 bursts (bounded read budget) */
+    int budget = BURST_PERIOD * (16 + 4);
+    int settled = 0;
+
+    const float fs = opt.sc8 ? 127.0f : 2047.0f;
+    float p_thr = (float)(0.25 * steady_amp[c] * steady_amp[c] * 2);
+
+    while (budget-- > 0 && n_arr < 16) {
+        if (read_buf(&st, payload, NULL, 1000) != 0)
+            break;
+        analyze(payload, &st);
+        if (settled < 2 * BURST_PERIOD) {
+            settled++;
+            low_run = (st.amp[c] < thr_lo) ? low_run + 1 : 0;
+            continue;
+        }
+        if (st.amp[c] < thr_lo) {
+            low_run++;
+            continue;
+        }
+        if (low_run >= 3 && st.amp[c] > thr_lo) {
+            /* burst rising edge inside this buffer: find the first frame
+             * above the power threshold */
+            const int16_t *s16 = payload;
+            const int8_t  *s8  = payload;
+            int edge = -1;
+            for (unsigned nf = 0; nf < frames; nf++) {
+                unsigned k = (nf * nch + (nch == 2 ? (unsigned)c : 0)) * 2;
+                float xi, xq;
+                if (opt.sc8) { xi = s8[k] / fs;  xq = s8[k + 1] / fs; }
+                else         { xi = s16[k] / fs; xq = s16[k + 1] / fs; }
+                if (xi * xi + xq * xq > p_thr) {
+                    edge = (int)nf;
+                    break;
+                }
+            }
+            if (edge >= 0 && st.has_ts)
+                arrivals[n_arr++] = (double)st.ts + edge / opt.rate * 1e9;
+        }
+        low_run = 0;
+    }
+
+    atomic_store(&tx_mode, TX_TONE);
+
+    if (n_arr < 6) {
+        check("burst.spacing", 0, "only %d burst edges detected", n_arr);
+        return;
+    }
+    double sp[23];
+    for (int k = 1; k < n_arr; k++)
+        sp[k - 1] = arrivals[k] - arrivals[k - 1];
+    double *tmp = malloc((n_arr - 1) * sizeof(double));
+    memcpy(tmp, sp, (n_arr - 1) * sizeof(double));
+    double sp_med = median(tmp, n_arr - 1);
+    free(tmp);
+    double worst = 0;
+    for (int k = 0; k < n_arr - 1; k++) {
+        double d = fabs(sp[k] - sp_med);
+        if (d > worst)
+            worst = d;
+    }
+    double sp_nom = BURST_PERIOD * dt_nom;
+    check("burst.spacing", fabs(sp_med - sp_nom) < 1000.0 && worst < 300.0,
+          "%d bursts, spacing %.0fns (nom %.0f), max jitter %.0fns",
+          n_arr, sp_med, sp_nom, worst);
+}
+
+static void phase_restart(void *payload)
+{
+    if (opt.no_restart) {
+        skip("restart.rx", "disabled");
+        return;
+    }
+
+    /* RX restarts while TX keeps running: the historical FDX header-FSM
+     * bug made the inserter free-run mid-frame here, shifting every
+     * header by a constant offset for the whole run. */
+    int ok = 1;
+    for (int it = 0; it < 3 && ok; it++) {
+        if (m2sdr_stream_deactivate(dev, M2SDR_RX) != 0 ||
+            (usleep(20000), m2sdr_stream_activate(dev, M2SDR_RX)) != 0) {
+            ok = 0;
+            break;
+        }
+        if (warmup(payload, !opt.no_tx, 4000) < 0) {
+            ok = 0;
+            break;
+        }
+        struct bufstat st;
+        for (int k = 0; k < 300; k++) {
+            if (read_buf(&st, payload, NULL, 1000) != 0 || !st.has_ts) {
+                ok = 0;
+                break;
+            }
+        }
+    }
+    check("restart.rx", ok,
+          "3x RX stop/start under running TX, 300 headered buffers each");
+
+    if (opt.no_tx) {
+        skip("restart.tx", "TX disabled in this configuration");
+        return;
+    }
+
+    /* TX restarts while RX keeps running. */
+    ok = 1;
+    for (int it = 0; it < 3 && ok; it++) {
+        atomic_store(&tx_mode, TX_PAUSE);
+        for (int w = 0; w < 500 && !atomic_load(&tx_paused); w++)
+            usleep(1000);
+        if (m2sdr_stream_deactivate(dev, M2SDR_TX) != 0 ||
+            (usleep(20000), m2sdr_stream_activate(dev, M2SDR_TX)) != 0) {
+            ok = 0;
+            atomic_store(&tx_mode, TX_TONE);
+            break;
+        }
+        atomic_store(&tx_mode, TX_TONE);
+        /* tone must come back and headers stay aligned */
+        struct bufstat st;
+        int back = 0;
+        for (int k = 0; k < 60000 && !back; k++) {
+            if (read_buf(&st, payload, NULL, 1000) != 0)
+                break;
+            analyze(payload, &st);
+            if (!st.has_ts) {
+                ok = 0;
+                break;
+            }
+            int c = chan_cabled[1] ? 1 : 0;
+            if (st.amp[c] > 0.5 * steady_amp[c])
+                back = 1;
+        }
+        if (!back)
+            ok = 0;
+        if (ok) {
+            uint64_t hdr = csr_read64(CSR_HEADER_LAST_TX_HEADER_ADDR);
+            if (hdr != MAGIC)
+                ok = 0;
+        }
+    }
+    check("restart.tx", ok,
+          "3x TX stop/start under running RX, tone + header magic recover");
+}
+
+/* ------------------------------------------------------------------ */
+/* Main                                                                */
+/* ------------------------------------------------------------------ */
+
+static void usage(const char *argv0)
+{
+    fprintf(stderr,
+        "usage: %s [--rate HZ] [--layout 1t1r|2t2r] [--chan 1|2|both]\n"
+        "          [--freq HZ] [--rx-gain dB] [--tx-att dB] [--sc8]\n"
+        "          [--no-tx] [--nbufs N] [--stall-ms MS] [--no-zerocopy]\n"
+        "          [--no-restart] [--dev ID]\n", argv0);
+    exit(2);
+}
+
+int main(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        const char *a = argv[i];
+        if      (!strcmp(a, "--rate")     && i + 1 < argc) opt.rate = atof(argv[++i]);
+        else if (!strcmp(a, "--layout")   && i + 1 < argc) opt.layout2 = !strcmp(argv[++i], "2t2r");
+        else if (!strcmp(a, "--chan")     && i + 1 < argc) {
+            const char *v = argv[++i];
+            opt.chan = !strcmp(v, "both") ? 3 : atoi(v);
+        }
+        else if (!strcmp(a, "--freq")     && i + 1 < argc) opt.freq = atof(argv[++i]);
+        else if (!strcmp(a, "--rx-gain")  && i + 1 < argc) opt.rx_gain = atoi(argv[++i]);
+        else if (!strcmp(a, "--tx-att")   && i + 1 < argc) opt.tx_att = atoi(argv[++i]);
+        else if (!strcmp(a, "--sc8"))                      opt.sc8 = 1;
+        else if (!strcmp(a, "--no-tx"))                    opt.no_tx = 1;
+        else if (!strcmp(a, "--nbufs")    && i + 1 < argc) opt.nbufs = atoi(argv[++i]);
+        else if (!strcmp(a, "--stall-ms") && i + 1 < argc) opt.stall_ms = atoi(argv[++i]);
+        else if (!strcmp(a, "--no-zerocopy"))              opt.zero_copy = 0;
+        else if (!strcmp(a, "--no-restart"))               opt.no_restart = 1;
+        else if (!strcmp(a, "--no-rf"))                    opt.no_rf = 1;
+        else if (!strcmp(a, "--dev")      && i + 1 < argc) opt.dev_id = argv[++i];
+        else usage(argv[0]);
+    }
+
+    nch       = opt.layout2 ? 2 : 1;
+    sample_sz = opt.sc8 ? 2 : 4;
+    spb       = (M2SDR_BUFFER_BYTES - M2SDR_DMA_HEADER_SIZE) / sample_sz;
+    frames    = spb / nch;
+    dt_nom    = frames / opt.rate * 1e9;
+    f_rel[0]  = 0.0537;
+    f_rel[1]  = 0.0773;
+    chan_cabled[0] = (opt.chan & 1) != 0;
+    chan_cabled[1] = (opt.chan & 2) != 0;
+
+    info("config: %s %.2f MSPS %s chan=%s%s%s, %u frames/buf, dt %.1f ns",
+         opt.layout2 ? "2T2R" : "1T1R", opt.rate / 1e6,
+         opt.sc8 ? "sc8" : "sc16",
+         chan_cabled[0] ? "1" : "", chan_cabled[1] ? "2" : "",
+         opt.no_tx ? " (RX-only)" : "", frames, dt_nom);
+
+    /* In 1T1R the second physical port pair is selected in the RFIC. */
+    if (!opt.layout2 && opt.chan == 2)
+        setenv("M2SDR_RF_CHANNEL", "2", 1);
+
+    if (m2sdr_open(&dev, opt.dev_id) != 0) {
+        fprintf(stderr, "device open failed\n");
+        return 1;
+    }
+
+    if (!opt.no_rf) {
+    struct m2sdr_config cfg;
+    m2sdr_config_init(&cfg);
+    cfg.sample_rate      = (int64_t)opt.rate;
+    cfg.bandwidth        = (int64_t)fmin(opt.rate * 0.8, 56e6);
+    cfg.tx_freq          = (int64_t)opt.freq;
+    cfg.rx_freq          = (int64_t)opt.freq;
+    cfg.tx_att           = opt.tx_att;
+    cfg.rx_gain1         = opt.rx_gain;
+    cfg.rx_gain2         = opt.rx_gain;
+    cfg.program_rx_gains = true;
+    cfg.enable_8bit_mode = opt.sc8;
+    cfg.channel_layout   = opt.layout2 ? M2SDR_CHANNEL_LAYOUT_2T2R
+                                       : M2SDR_CHANNEL_LAYOUT_1T1R;
+    cfg.clock_source     = M2SDR_CLOCK_SOURCE_INTERNAL;
+    if (m2sdr_apply_config(dev, &cfg) != 0) {
+        fprintf(stderr, "apply_config failed\n");
+        return 1;
+    }
+    }
+
+    enum m2sdr_format fmt = opt.sc8 ? M2SDR_FORMAT_SC8_Q7
+                                    : M2SDR_FORMAT_SC16_Q11;
+    struct m2sdr_sync_params sp;
+    if (!opt.no_tx) {
+        m2sdr_sync_params_init(&sp);
+        sp.direction        = M2SDR_TX;
+        sp.format           = fmt;
+        sp.buffer_size      = spb;
+        sp.zero_copy        = opt.zero_copy;
+        sp.tx_header_enable = true;
+        if (m2sdr_sync_config_ex(dev, &sp) != 0) {
+            fprintf(stderr, "TX stream config failed\n");
+            return 1;
+        }
+    }
+    m2sdr_sync_params_init(&sp);
+    sp.direction        = M2SDR_RX;
+    sp.format           = fmt;
+    sp.buffer_size      = spb;
+    sp.zero_copy        = opt.zero_copy;
+    sp.rx_header_enable = true;
+    sp.rx_strip_header  = true;
+    if (m2sdr_sync_config_ex(dev, &sp) != 0) {
+        fprintf(stderr, "RX stream config failed\n");
+        return 1;
+    }
+
+    /* Route TX DMA -> RFIC and RFIC -> RX DMA through the FPGA crossbar. */
+    m2sdr_reg_write(dev, CSR_CROSSBAR_MUX_SEL_ADDR, 0);
+    m2sdr_reg_write(dev, CSR_CROSSBAR_DEMUX_SEL_ADDR, 0);
+
+    analysis_init();
+    stats = malloc((size_t)opt.nbufs * sizeof(*stats));
+    void *payload = m2sdr_alloc_buffer(fmt, spb);
+
+    if (!opt.no_tx) {
+        pthread_create(&tx_thread, NULL, tx_main, NULL);
+        tx_running = 1;
+        /* Let the TX side prefill the kernel ring before RX starts so the
+         * free-running FPGA reader never outruns the host writes. */
+        for (int w = 0; w < 300 && atomic_load(&tx_bufs) < 128; w++)
+            usleep(10000);
+    }
+
+    int zeros = warmup(payload, !opt.no_tx, 6000);
+    check("stream.starts", zeros >= 0, "first samples within timeout");
+    if (zeros < 0)
+        goto out;
+    info("leading all-zero buffers at start: %d (%.2f ms)",
+         zeros, zeros * dt_nom / 1e6);
+
+    /* Board time vs first header timestamp. */
+    {
+        struct bufstat st;
+        uint64_t t_board = 0;
+        if (read_buf(&st, payload, NULL, 1000) == 0 && st.has_ts &&
+            m2sdr_get_time(dev, &t_board) == 0) {
+            double d = ((double)t_board - (double)st.ts) / 1e6;
+            check("timestamp.absolute", fabs(d) < 200.0,
+                  "header vs board time: %.2f ms apart", d);
+        } else {
+            check("timestamp.absolute", 0, "could not read time/header");
+        }
+    }
+
+    phase_cadence(payload, "run", opt.nbufs, !opt.no_tx);
+    phase_stall(payload);
+    phase_tx_csrs();
+    phase_burst(payload);
+
+    if (!opt.no_tx) {
+        long uf = atomic_load(&tx_underflows);
+        check("tx.no-underflows", uf == 0, "%ld TX ring underflows", uf);
+    }
+
+    phase_restart(payload);
+
+out:
+    if (tx_running) {
+        atomic_store(&tx_mode, TX_QUIT);
+        pthread_join(tx_thread, NULL);
+    }
+    m2sdr_close(dev);
+
+    printf("RESULT %s pass=%d fail=%d skip=%d\n",
+           n_fail == 0 ? "PASS" : "FAIL", n_pass, n_fail, n_skip);
+    return n_fail == 0 ? 0 : 1;
+}

--- a/scripts/loopback_selftest.sh
+++ b/scripts/loopback_selftest.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# M2SDR cable-loopback regression sweep.
+#
+# Builds scripts/loopback_selftest.c against the IN-REPO libm2sdr (never the
+# installed copy) and runs it across the supported configuration matrix,
+# verifying transmission correctness, DMA-header timestamps (including
+# host-drop recovery) and stream restart alignment for each.
+#
+# Requires loopback cable(s) between the TX/RX port pair(s) given by --chan
+# (default: port pair 2, i.e. TX2 -> RX2).
+#
+# Usage: scripts/loopback_selftest.sh [--chan 1|2|both] [--quick] [--config NAME]
+#        extra engine flags can be passed after --
+
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LIBDIR="$REPO/litex_m2sdr/software/user/libm2sdr"
+KERNDIR="$REPO/litex_m2sdr/software/kernel"
+ENGINE=/tmp/loopback_selftest
+
+CHAN=2
+QUICK=0
+ONLY=""
+EXTRA=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --chan)   CHAN="$2"; shift 2 ;;
+        --quick)  QUICK=1; shift ;;
+        --config) ONLY="$2"; shift 2 ;;
+        --)       shift; EXTRA=("$@"); break ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ ! -f "$LIBDIR/libm2sdr.a" ]; then
+    echo "libm2sdr.a not built - build the user software first" >&2
+    exit 1
+fi
+
+cc -O3 -Wall -Wextra -o "$ENGINE" "$REPO/scripts/loopback_selftest.c" \
+   -I"$LIBDIR" -I"$KERNDIR" "$LIBDIR/libm2sdr.a" -lm -lpthread || exit 1
+
+# name | engine args
+# 2T2R @ 122.88 is RX-only: the AD9361 TX datapath scrambles in the
+# 2R2T-oversampled mode (chip-internal limitation, see RESULTS_overclock.md).
+CONFIGS=(
+    "1t1r-30.72-sc16  | --layout 1t1r --rate 30720000  "
+    "1t1r-61.44-sc16  | --layout 1t1r --rate 61440000  "
+    "2t2r-61.44-sc16  | --layout 2t2r --rate 61440000  "
+    "1t1r-122.88-sc16 | --layout 1t1r --rate 122880000 "
+    "1t1r-122.88-sc8  | --layout 1t1r --rate 122880000 --sc8"
+)
+# KNOWN LIMITATION (run on demand with --config 2t2r-122.88-rx): 2T2R @
+# 122.88 MSPS RX-to-host drops ~17% of samples regardless of format (sc16
+# and sc8 both measure ~1.208x the nominal buffer period): the sys-domain
+# RX datapath tops out at ~101.7M frames/s. The FPGA<->AD9361 interface is
+# clean at this rate (PRBS/deskew verified); the ceiling is internal, and
+# only the DMA-header timestamps make the loss visible. TX is additionally
+# blocked chip-internally (see RESULTS_overclock.md), hence --no-tx.
+EXTRA_CONFIGS=(
+    "2t2r-122.88-rx   | --layout 2t2r --rate 122880000 --no-tx --sc8"
+)
+if [ "$QUICK" = 1 ]; then
+    CONFIGS=(
+        "1t1r-61.44-sc16  | --layout 1t1r --rate 61440000  "
+        "1t1r-122.88-sc16 | --layout 1t1r --rate 122880000 "
+    )
+fi
+
+declare -A RESULT
+FAILED=0
+for entry in "${CONFIGS[@]}" "${EXTRA_CONFIGS[@]}"; do
+    name="${entry%%|*}"; name="${name// /}"
+    args="${entry#*|}"
+    if [ -n "$ONLY" ]; then
+        [ "$name" != "$ONLY" ] && continue
+    else
+        # EXTRA_CONFIGS run only when explicitly selected.
+        skip_extra=0
+        for x in "${EXTRA_CONFIGS[@]}"; do
+            xn="${x%%|*}"; xn="${xn// /}"
+            [ "$name" = "$xn" ] && skip_extra=1
+        done
+        [ "$skip_extra" = 1 ] && continue
+    fi
+    echo
+    echo "===== $name ====="
+    # shellcheck disable=SC2086
+    if "$ENGINE" $args --chan "$CHAN" "${EXTRA[@]+"${EXTRA[@]}"}"; then
+        RESULT[$name]=PASS
+    else
+        RESULT[$name]=FAIL
+        FAILED=1
+    fi
+done
+
+echo
+echo "===== summary ====="
+for entry in "${CONFIGS[@]}" "${EXTRA_CONFIGS[@]}"; do
+    name="${entry%%|*}"; name="${name// /}"
+    [ -z "${RESULT[$name]:-}" ] && continue
+    printf "%-20s %s\n" "$name" "${RESULT[$name]}"
+done
+exit $FAILED


### PR DESCRIPTION
Stacked on #127  — review the last commit. RF-quality follow-up to the wide-bandwidth (122.88 MSPS) mode from #123; all chip-side, applies to the stock gateware.

1. Baseband filters: the register force-widening default is replaced by the chip's own RX/TX BBF tune calibrations run against a ~54/62 MHz corner target (tune dividers programmed past the driver's bandwidth clamp). This keeps the calibrated noise behavior: +17 dB mid-band RX floor vs. the forced registers. The forced recipe remains available as M2SDR_OC_BBF_FORCE.
2. Passband flatness EQ FIRs (optional, M2SDR_OC_RX_FIR_FILE / M2SDR_OC_TX_FIR_FILE): the composite responses otherwise roll off 7–9.5 dB (RX) / droop to −8 dB (TX) over the outer ±36–49 MHz; with the inverse designs the band is flat to ±1.2–1.3 dB out to ±42–44 MHz. Note the TX FIR processes in the 245.76 MHz domain in this mode, so real-time transmitters need no host-side pre-emphasis.
3. RX quadrature tracking loop gain: the driver-default K exponent leaves the tracking loop effectively inert here — image rejection settles at 23–28 dBc, a direct 3.5–7 % EVM floor. 0x0a converges to 40–43 dBc (M2SDR_QEC_KEXP overrides).
4. RFPLL charge pump: the LUT current leaves ~5 dB of loop peaking at 1–3 MHz offsets; scaling to ~30 % removes it on both synthesizers — RX EVM 6.8 → 6.2 %, TX 7.3 → 5.1 % on a 50 MHz NR TM3.1 (M2SDR_RFPLL_CP_PERCENT overrides).
4. (Minor) M2SDR_RF_CHANNEL=2 selects the second physical RF port pair in 1T1R.

Measured results (3.6 GHz, MATLAB 5G Toolbox EVM + notch/NPR method, cross-checked against an external receiver) are in the updated README table: RX EVM ~6.0–6.6 % on a centered 50 MHz TM3.1, in-band SNR 26–29.5 dB over ±10–31 MHz, TX EVM ~5.2–6 % flat over tx-att 0–18. The remaining limits (reference-chain LO phase noise of the Si5351C variant mid-band, converter shaped noise beyond ±40 MHz) are likely due to hard limits of the AD9361 & the SDR architecture.