### PR TITLE
tools: add host-buffered play and record

### DIFF
--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -242,8 +242,8 @@ m2sdr_rf: $(LIBM2SDR_STATIC) $(CLI_OBJS) m2sdr_rf.o
 m2sdr_play: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) m2sdr_play.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) m2sdr_play.o $(M2SDR_LINK_LIBS)
 
-m2sdr_record: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) m2sdr_record.o
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) m2sdr_record.o $(M2SDR_LINK_LIBS)
+m2sdr_record: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_record.o
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_record.o $(M2SDR_LINK_LIBS) $(PTHREAD_LIBS)
 
 m2sdr_sigmf: $(LIBM2SDR_STATIC) m2sdr_sigmf.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ m2sdr_sigmf.o $(M2SDR_LINK_LIBS)

--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -47,7 +47,7 @@ CXX     = $(CROSS_COMPILE)g++
 AR      = ar
 .DEFAULT_GOAL := all
 FORCE:
-.PHONY: FORCE all core-tools core-tests examples test-libm2sdr test-sigmf test-sigmf-smoke test-sigmf-cli test-sata-cli clean install install_dev check analyze-libm2sdr
+.PHONY: FORCE all core-tools core-tests examples test-libm2sdr test-sigmf test-sigmf-smoke test-sigmf-cli test-sata-cli test-sata-hostio test-host-queue clean install install_dev check analyze-libm2sdr
 
 ALL_BINARIES := m2sdr_util m2sdr_rf m2sdr_gpio m2sdr_play m2sdr_record m2sdr_sigmf m2sdr_sata \
                 m2sdr_gen m2sdr_fm_tx m2sdr_fm_rx m2sdr_check m2sdr_scan
@@ -96,7 +96,8 @@ EXAMPLES = ../../doc/libm2sdr/example_sync_rx ../../doc/libm2sdr/example_sync_tx
            ../../doc/libm2sdr/example_tone_tx ../../doc/libm2sdr/example_rx_n
 CLI_OBJS = m2sdr_cli.o
 TOOL_OBJS = m2sdr_tool.o
-TEST_PROGS = tests/test_libm2sdr tests/test_m2sdr_sigmf tests/test_sigmf_capture_smoke tests/test_sigmf_cli tests/test_m2sdr_sata_cli tests/test_m2sdr_sata_hostio
+HOST_QUEUE_OBJS = m2sdr_host_queue.o
+TEST_PROGS = tests/test_libm2sdr tests/test_m2sdr_sigmf tests/test_sigmf_capture_smoke tests/test_sigmf_cli tests/test_m2sdr_sata_cli tests/test_m2sdr_sata_hostio tests/test_m2sdr_host_queue
 
 LIBM2SDR_OBJS = \
 	libm2sdr/m2sdr_si5351_i2c.o \
@@ -134,7 +135,7 @@ M2SDR_IMGUI_OBJS := $(M2SDR_IMGUI_SRCS:.cpp=.o)
 
 all: $(PROGS)
 core-tools: $(CORE_BINARIES) $(LIBM2SDR_STATIC) $(LIBM2SDR_SHARED)
-core-tests: core-tools test-libm2sdr test-sigmf test-sigmf-smoke test-sigmf-cli test-sata-cli test-sata-hostio
+core-tests: core-tools test-libm2sdr test-sigmf test-sigmf-smoke test-sigmf-cli test-sata-cli test-sata-hostio test-host-queue
 
 examples: $(LIBM2SDR_STATIC) $(EXAMPLES)
 test-libm2sdr: $(TEST_PROGS)
@@ -155,6 +156,9 @@ test-sata-cli: tests/test_m2sdr_sata_cli m2sdr_sata
 test-sata-hostio: tests/test_m2sdr_sata_hostio
 	./tests/test_m2sdr_sata_hostio
 
+test-host-queue: tests/test_m2sdr_host_queue
+	./tests/test_m2sdr_host_queue
+
 tests/test_libm2sdr: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) tests/test_libm2sdr.o | $(BUILD_FLAGS_FILE)
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) tests/test_libm2sdr.o $(LIBM2SDR_STATIC) -lm
 
@@ -172,6 +176,9 @@ tests/test_m2sdr_sata_cli: tests/test_m2sdr_sata_cli.o | $(BUILD_FLAGS_FILE)
 
 tests/test_m2sdr_sata_hostio: tests/test_m2sdr_sata_hostio.o m2sdr_sata_hostio.o | $(BUILD_FLAGS_FILE)
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ tests/test_m2sdr_sata_hostio.o m2sdr_sata_hostio.o -lm
+
+tests/test_m2sdr_host_queue: tests/test_m2sdr_host_queue.o $(HOST_QUEUE_OBJS) | $(BUILD_FLAGS_FILE)
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ tests/test_m2sdr_host_queue.o $(HOST_QUEUE_OBJS) $(PTHREAD_LIBS)
 
 analyze-libm2sdr:
 	cppcheck --enable=warning,style,performance,portability --error-exitcode=1 \
@@ -224,6 +231,7 @@ ad9361/libad9361_m2sdr.a: $(BUILD_FLAGS_FILE) ad9361/ad9361_api.o ad9361/ad9361_
 # --- Binaries ---
 
 M2SDR_LINK_LIBS := $(LIBM2SDR_STATIC) -lm
+PTHREAD_LIBS := -pthread
 
 m2sdr_util: $(LIBM2SDR_STATIC) $(CLI_OBJS) m2sdr_util.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) m2sdr_util.o $(M2SDR_LINK_LIBS)
@@ -279,7 +287,7 @@ clean:
 	rm -f .build-flags .build-flags-*
 	rm -f liblitepcie/*.a liblitepcie/*.o liblitepcie/*.d
 	rm -f libm2sdr/*.a libm2sdr/*.o libm2sdr/*.d
-	rm -f tests/*.o tests/*.d tests/test_libm2sdr tests/test_m2sdr_sigmf tests/test_sigmf_capture_smoke tests/test_sigmf_cli
+	rm -f tests/*.o tests/*.d $(TEST_PROGS)
 	rm -f libliteeth/*.a libliteeth/*.o libliteeth/*.d
 	rm -f ad9361/*.o ad9361/*.d ad9361/*~
 	rm -f kissfft/*.o kissfft/*.d
@@ -297,7 +305,7 @@ $(BUILD_FLAGS_FILE): FORCE
 		rm -f *.o *.a *.d; \
 		rm -f liblitepcie/*.a liblitepcie/*.o liblitepcie/*.d; \
 		rm -f libm2sdr/*.a libm2sdr/*.o libm2sdr/*.d; \
-		rm -f tests/*.o tests/*.d tests/test_libm2sdr tests/test_m2sdr_sigmf tests/test_sigmf_capture_smoke tests/test_sigmf_cli; \
+		rm -f tests/*.o tests/*.d $(TEST_PROGS); \
 		rm -f libliteeth/*.a libliteeth/*.o libliteeth/*.d; \
 		rm -f ad9361/*.o ad9361/*.d; \
 		rm -f kissfft/*.o kissfft/*.d; \

--- a/litex_m2sdr/software/user/Makefile
+++ b/litex_m2sdr/software/user/Makefile
@@ -239,8 +239,8 @@ m2sdr_util: $(LIBM2SDR_STATIC) $(CLI_OBJS) m2sdr_util.o
 m2sdr_rf: $(LIBM2SDR_STATIC) $(CLI_OBJS) m2sdr_rf.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) m2sdr_rf.o $(M2SDR_LINK_LIBS)
 
-m2sdr_play: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) m2sdr_play.o
-	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) m2sdr_play.o $(M2SDR_LINK_LIBS)
+m2sdr_play: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_play.o
+	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_play.o $(M2SDR_LINK_LIBS) $(PTHREAD_LIBS)
 
 m2sdr_record: $(LIBM2SDR_STATIC) $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_record.o
 	$(CC) $(LINK_CFLAGS) $(LDFLAGS) -o $@ $(CLI_OBJS) $(TOOL_OBJS) $(HOST_QUEUE_OBJS) m2sdr_record.o $(M2SDR_LINK_LIBS) $(PTHREAD_LIBS)

--- a/litex_m2sdr/software/user/README.md
+++ b/litex_m2sdr/software/user/README.md
@@ -359,6 +359,8 @@ m2sdr_play [options] filename [loops]
 Common playback options:
 - `--format sc16|sc8`
 - `--timed-start`
+- `--host-buffers N`
+- `--prefill N`
 
 SigMF input:
 - `--capture-index`
@@ -366,10 +368,16 @@ SigMF input:
 `filename` can be a raw sample file, a `.sigmf-data` file, a `.sigmf-meta` file, or a SigMF basename when adjacent SigMF files exist.
 For SigMF inputs, `core:dataset` is honored and resolved relative to the metadata file when needed.
 M2SDR-specific SigMF datasets with `core:header_bytes=16` are also accepted and replayed with timestamps restored into TX metadata.
+Use `--host-buffers` to decouple input file/pipe reads from the TX loop.
+`--prefill` waits for a number of queued DMA buffers before playback starts,
+which can be useful when the input source has bursty latency. This is mainly
+useful for playback from stdin, slower/shared storage, or another process that
+can briefly stall; it does not increase sustained throughput.
 
 Example usage:
 ~~~~
 ./m2sdr_play --format sc16 tx_file.bin 10
+./m2sdr_play --host-buffers 64 --prefill 16 tx_file.bin 1
 ./m2sdr_play capture.sigmf-meta 10
 ./m2sdr_play --capture-index 1 capture.sigmf-meta 1
 ./m2sdr_play --capture-index 2 framed_capture.sigmf-meta 0
@@ -386,12 +394,13 @@ This is the matching `libm2sdr` RX example, including optional timestamp/header 
 m2sdr_record [options] filename size
 ~~~~
 - **filename**: Destination file for captured I/Q samples (or `-` for stdout).
-- **size**: Number of samples to capture.
+- **size**: Optional byte limit to capture.
 
 Common capture options:
 - `--format sc16|sc8`
 - `--enable-header`
 - `--strip-header`
+- `--host-buffers N`
 
 SigMF output:
 - `--sigmf`
@@ -413,9 +422,16 @@ SigMF annotations:
 - `--annotate-ts-jumps`
 - `--ts-jump-threshold-pct`
 
+Use `--host-buffers` to decouple RX DMA draining from host file/stdout writes.
+The default queue policy blocks when the queue is full and preserves output
+ordering. This is mainly useful when writing to a pipe, stdout consumer, or
+storage target that can briefly stall; it does not compensate for a sink that
+is continuously slower than the RX stream.
+
 Example usage:
 ~~~~
 ./m2sdr_record --enable-header --strip-header rx_file.bin 2000000
+./m2sdr_record --host-buffers 64 rx_file.bin 2000000
 ./m2sdr_record --sigmf --sample-rate 30720000 --center-freq 2400000000 --enable-header --strip-header capture 2000000
 ./m2sdr_record --sigmf --sample-rate 30720000 --annotation-label burst --annotation-comment "loopback capture" capture 2000000
 ./m2sdr_record --sigmf --sample-rate 30720000 --annotation-label burst-a --annotation-start 0 --annotation-count 8192 --annotation-add --annotation-label burst-b --annotation-start 16384 --annotation-count 8192 capture 2000000

--- a/litex_m2sdr/software/user/m2sdr_host_queue.c
+++ b/litex_m2sdr/software/user/m2sdr_host_queue.c
@@ -1,0 +1,222 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "m2sdr_host_queue.h"
+
+struct m2sdr_host_queue_sync {
+    pthread_mutex_t mutex;
+    pthread_cond_t not_empty;
+    pthread_cond_t not_full;
+};
+
+static struct m2sdr_host_queue_sync *m2sdr_host_queue_sync(struct m2sdr_host_queue *queue)
+{
+    return (struct m2sdr_host_queue_sync *)queue->sync;
+}
+
+int m2sdr_host_queue_init(struct m2sdr_host_queue *queue,
+                          unsigned capacity,
+                          size_t slot_size)
+{
+    struct m2sdr_host_queue_sync *sync;
+    int mutex_ready = 0;
+    int not_empty_ready = 0;
+    int not_full_ready = 0;
+
+    if (!queue || capacity == 0 || slot_size == 0)
+        return M2SDR_HOST_QUEUE_ERROR;
+
+    memset(queue, 0, sizeof(*queue));
+    queue->storage = calloc(capacity, slot_size);
+    queue->lengths = calloc(capacity, sizeof(*queue->lengths));
+    queue->tags = calloc(capacity, sizeof(*queue->tags));
+    sync = calloc(1, sizeof(*sync));
+    if (!queue->storage || !queue->lengths || !queue->tags || !sync) {
+        free(queue->storage);
+        free(queue->lengths);
+        free(queue->tags);
+        free(sync);
+        memset(queue, 0, sizeof(*queue));
+        return M2SDR_HOST_QUEUE_ERROR;
+    }
+
+    if (pthread_mutex_init(&sync->mutex, NULL) != 0)
+        goto fail;
+    mutex_ready = 1;
+    if (pthread_cond_init(&sync->not_empty, NULL) != 0)
+        goto fail;
+    not_empty_ready = 1;
+    if (pthread_cond_init(&sync->not_full, NULL) != 0)
+        goto fail;
+    not_full_ready = 1;
+
+    queue->slot_size = slot_size;
+    queue->capacity = capacity;
+    queue->sync = sync;
+    return M2SDR_HOST_QUEUE_OK;
+
+fail:
+    if (not_full_ready)
+        pthread_cond_destroy(&sync->not_full);
+    if (not_empty_ready)
+        pthread_cond_destroy(&sync->not_empty);
+    if (mutex_ready)
+        pthread_mutex_destroy(&sync->mutex);
+    free(queue->storage);
+    free(queue->lengths);
+    free(queue->tags);
+    free(sync);
+    memset(queue, 0, sizeof(*queue));
+    return M2SDR_HOST_QUEUE_ERROR;
+}
+
+void m2sdr_host_queue_destroy(struct m2sdr_host_queue *queue)
+{
+    struct m2sdr_host_queue_sync *sync;
+
+    if (!queue || !queue->sync)
+        return;
+
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_destroy(&sync->mutex);
+    pthread_cond_destroy(&sync->not_empty);
+    pthread_cond_destroy(&sync->not_full);
+    free(sync);
+    free(queue->storage);
+    free(queue->lengths);
+    free(queue->tags);
+    memset(queue, 0, sizeof(*queue));
+}
+
+void m2sdr_host_queue_close_writer(struct m2sdr_host_queue *queue)
+{
+    struct m2sdr_host_queue_sync *sync;
+
+    if (!queue || !queue->sync)
+        return;
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_lock(&sync->mutex);
+    queue->writer_closed = 1;
+    pthread_cond_broadcast(&sync->not_empty);
+    pthread_mutex_unlock(&sync->mutex);
+}
+
+void m2sdr_host_queue_stop(struct m2sdr_host_queue *queue)
+{
+    struct m2sdr_host_queue_sync *sync;
+
+    if (!queue || !queue->sync)
+        return;
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_lock(&sync->mutex);
+    queue->stopped = 1;
+    pthread_cond_broadcast(&sync->not_empty);
+    pthread_cond_broadcast(&sync->not_full);
+    pthread_mutex_unlock(&sync->mutex);
+}
+
+int m2sdr_host_queue_push(struct m2sdr_host_queue *queue,
+                          const void *data,
+                          size_t len,
+                          uint64_t tag)
+{
+    struct m2sdr_host_queue_sync *sync;
+    unsigned idx;
+
+    if (!queue || !queue->sync || len > queue->slot_size || (!data && len != 0))
+        return M2SDR_HOST_QUEUE_ERROR;
+
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_lock(&sync->mutex);
+
+    while (!queue->stopped && queue->count == queue->capacity)
+        pthread_cond_wait(&sync->not_full, &sync->mutex);
+
+    if (queue->stopped) {
+        pthread_mutex_unlock(&sync->mutex);
+        return M2SDR_HOST_QUEUE_STOPPED;
+    }
+
+    idx = queue->head;
+    if (len != 0)
+        memcpy(queue->storage + ((size_t)idx * queue->slot_size), data, len);
+    queue->lengths[idx] = len;
+    queue->tags[idx] = tag;
+    queue->head = (queue->head + 1) % queue->capacity;
+    queue->count++;
+
+    pthread_cond_signal(&sync->not_empty);
+    pthread_mutex_unlock(&sync->mutex);
+    return M2SDR_HOST_QUEUE_OK;
+}
+
+int m2sdr_host_queue_pop(struct m2sdr_host_queue *queue,
+                         void *dst,
+                         size_t dst_len,
+                         size_t *len,
+                         uint64_t *tag)
+{
+    struct m2sdr_host_queue_sync *sync;
+    unsigned idx;
+    size_t slot_len;
+
+    if (!queue || !queue->sync || !dst || !len)
+        return M2SDR_HOST_QUEUE_ERROR;
+
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_lock(&sync->mutex);
+
+    while (!queue->stopped && queue->count == 0 && !queue->writer_closed)
+        pthread_cond_wait(&sync->not_empty, &sync->mutex);
+
+    if (queue->stopped) {
+        pthread_mutex_unlock(&sync->mutex);
+        return M2SDR_HOST_QUEUE_STOPPED;
+    }
+    if (queue->count == 0 && queue->writer_closed) {
+        pthread_mutex_unlock(&sync->mutex);
+        return M2SDR_HOST_QUEUE_CLOSED;
+    }
+
+    idx = queue->tail;
+    slot_len = queue->lengths[idx];
+    if (slot_len > dst_len) {
+        pthread_mutex_unlock(&sync->mutex);
+        return M2SDR_HOST_QUEUE_ERROR;
+    }
+    if (slot_len != 0)
+        memcpy(dst, queue->storage + ((size_t)idx * queue->slot_size), slot_len);
+    *len = slot_len;
+    if (tag)
+        *tag = queue->tags[idx];
+    queue->tail = (queue->tail + 1) % queue->capacity;
+    queue->count--;
+
+    pthread_cond_signal(&sync->not_full);
+    pthread_mutex_unlock(&sync->mutex);
+    return M2SDR_HOST_QUEUE_OK;
+}
+
+int m2sdr_host_queue_wait_count(struct m2sdr_host_queue *queue,
+                                unsigned min_count)
+{
+    struct m2sdr_host_queue_sync *sync;
+
+    if (!queue || !queue->sync)
+        return M2SDR_HOST_QUEUE_ERROR;
+
+    sync = m2sdr_host_queue_sync(queue);
+    pthread_mutex_lock(&sync->mutex);
+    while (!queue->stopped && queue->count < min_count && !queue->writer_closed)
+        pthread_cond_wait(&sync->not_empty, &sync->mutex);
+
+    if (queue->stopped) {
+        pthread_mutex_unlock(&sync->mutex);
+        return M2SDR_HOST_QUEUE_STOPPED;
+    }
+    pthread_mutex_unlock(&sync->mutex);
+    return M2SDR_HOST_QUEUE_OK;
+}

--- a/litex_m2sdr/software/user/m2sdr_host_queue.h
+++ b/litex_m2sdr/software/user/m2sdr_host_queue.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifndef M2SDR_HOST_QUEUE_H
+#define M2SDR_HOST_QUEUE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum m2sdr_host_queue_result {
+    M2SDR_HOST_QUEUE_OK = 0,
+    M2SDR_HOST_QUEUE_CLOSED = 1,
+    M2SDR_HOST_QUEUE_STOPPED = -1,
+    M2SDR_HOST_QUEUE_ERROR = -2,
+};
+
+struct m2sdr_host_queue {
+    uint8_t *storage;
+    size_t *lengths;
+    uint64_t *tags;
+    size_t slot_size;
+    unsigned capacity;
+    unsigned head;
+    unsigned tail;
+    unsigned count;
+    int writer_closed;
+    int stopped;
+    void *sync;
+};
+
+int m2sdr_host_queue_init(struct m2sdr_host_queue *queue,
+                          unsigned capacity,
+                          size_t slot_size);
+void m2sdr_host_queue_destroy(struct m2sdr_host_queue *queue);
+void m2sdr_host_queue_close_writer(struct m2sdr_host_queue *queue);
+void m2sdr_host_queue_stop(struct m2sdr_host_queue *queue);
+
+int m2sdr_host_queue_push(struct m2sdr_host_queue *queue,
+                          const void *data,
+                          size_t len,
+                          uint64_t tag);
+int m2sdr_host_queue_pop(struct m2sdr_host_queue *queue,
+                         void *dst,
+                         size_t dst_len,
+                         size_t *len,
+                         uint64_t *tag);
+int m2sdr_host_queue_wait_count(struct m2sdr_host_queue *queue,
+                                unsigned min_count);
+
+#endif /* M2SDR_HOST_QUEUE_H */

--- a/litex_m2sdr/software/user/m2sdr_play.c
+++ b/litex_m2sdr/software/user/m2sdr_play.c
@@ -17,9 +17,11 @@
 #include <time.h>
 #include <getopt.h>
 #include <stdbool.h>
+#include <pthread.h>
 
 #include "m2sdr.h"
 #include "m2sdr_cli.h"
+#include "m2sdr_host_queue.h"
 #include "m2sdr_sigmf.h"
 #include "m2sdr_tool.h"
 #include "config.h"
@@ -27,6 +29,21 @@
 #include "liblitepcie.h"
 
 sig_atomic_t keep_running = 1;
+
+struct m2sdr_play_source {
+    struct m2sdr_host_queue queue;
+    FILE *fi;
+    pthread_t thread;
+    uint32_t current_loop;
+    uint32_t loops;
+    uint64_t start_offset_bytes;
+    uint64_t end_offset_bytes;
+    size_t frame_bytes;
+    int close_fi;
+    int enabled;
+    int started;
+    int error;
+};
 
 void intHandler(int dummy) {
     (void)dummy;
@@ -98,6 +115,108 @@ static int read_next_play_frame(FILE *fi, int close_fi, uint32_t *current_loop, 
     return 0;
 }
 
+static void *m2sdr_play_source_worker(void *arg)
+{
+    struct m2sdr_play_source *source = arg;
+    uint8_t raw_buf[DMA_BUFFER_SIZE];
+
+    while (1) {
+        int rc = read_next_play_frame(source->fi, source->close_fi, &source->current_loop,
+                                      source->loops, source->start_offset_bytes,
+                                      source->end_offset_bytes, raw_buf, source->frame_bytes);
+
+        if (rc > 0)
+            break;
+        if (rc < 0) {
+            source->error = 1;
+            m2sdr_host_queue_stop(&source->queue);
+            break;
+        }
+
+        rc = m2sdr_host_queue_push(&source->queue, raw_buf, source->frame_bytes,
+                                   source->current_loop);
+        if (rc != M2SDR_HOST_QUEUE_OK) {
+            if (rc != M2SDR_HOST_QUEUE_STOPPED)
+                source->error = 1;
+            break;
+        }
+    }
+
+    m2sdr_host_queue_close_writer(&source->queue);
+    return NULL;
+}
+
+static int m2sdr_play_source_start(struct m2sdr_play_source *source, FILE *fi, int close_fi,
+                                   uint32_t loops, uint64_t start_offset_bytes,
+                                   uint64_t end_offset_bytes, size_t frame_bytes,
+                                   unsigned host_buffers)
+{
+    memset(source, 0, sizeof(*source));
+    if (host_buffers == 0)
+        return 0;
+
+    if (m2sdr_host_queue_init(&source->queue, host_buffers, DMA_BUFFER_SIZE) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    source->fi = fi;
+    source->close_fi = close_fi;
+    source->loops = loops;
+    source->start_offset_bytes = start_offset_bytes;
+    source->end_offset_bytes = end_offset_bytes;
+    source->frame_bytes = frame_bytes;
+    source->enabled = 1;
+    if (pthread_create(&source->thread, NULL, m2sdr_play_source_worker, source) != 0) {
+        m2sdr_host_queue_destroy(&source->queue);
+        memset(source, 0, sizeof(*source));
+        return -1;
+    }
+    source->started = 1;
+    return 0;
+}
+
+static int m2sdr_play_source_finish(struct m2sdr_play_source *source)
+{
+    int error;
+
+    if (!source->enabled)
+        return 0;
+
+    if (source->started) {
+        m2sdr_host_queue_stop(&source->queue);
+        if (pthread_join(source->thread, NULL) != 0)
+            source->error = 1;
+        source->started = 0;
+    }
+
+    error = source->error;
+    m2sdr_host_queue_destroy(&source->queue);
+    source->enabled = 0;
+    return error ? -1 : 0;
+}
+
+static int m2sdr_play_next_frame(FILE *fi, struct m2sdr_play_source *source, int close_fi,
+                                 uint32_t *current_loop, uint32_t loops,
+                                 uint64_t start_offset_bytes, uint64_t end_offset_bytes,
+                                 uint8_t *raw_buf, size_t frame_bytes)
+{
+    if (source->enabled) {
+        size_t len = 0;
+        uint64_t tag = 0;
+        int rc = m2sdr_host_queue_pop(&source->queue, raw_buf, DMA_BUFFER_SIZE, &len, &tag);
+
+        if (rc == M2SDR_HOST_QUEUE_CLOSED)
+            return 1;
+        if (rc != M2SDR_HOST_QUEUE_OK)
+            return -1;
+        if (len < frame_bytes)
+            memset(raw_buf + len, 0, frame_bytes - len);
+        *current_loop = (uint32_t)tag;
+        return 0;
+    }
+
+    return read_next_play_frame(fi, close_fi, current_loop, loops, start_offset_bytes,
+                                end_offset_bytes, raw_buf, frame_bytes);
+}
+
 static void prepare_play_metadata(const uint8_t *raw_buf, unsigned header_bytes,
                                   struct m2sdr_metadata *meta)
 {
@@ -152,6 +271,8 @@ static void help(void)
     puts("  -q, --quiet           Quiet mode.");
     puts("  -t, --timed-start     Timed start (align to the next second).");
     puts("      --format FMT      Sample format: sc16, sc8 or encoded bfp8 (default: sc16).");
+    puts("      --host-buffers N  Queue N DMA buffers read from input.");
+    puts("      --prefill N       Wait for N queued buffers before starting playback.");
     puts("");
     puts("SigMF input:");
     puts("      --capture-index N Select capture index from SigMF metadata (default: 0).");
@@ -164,7 +285,8 @@ static void help(void)
 
 static void m2sdr_play(const char *device_id, const char *filename, uint32_t loops, uint8_t quiet,
                        uint8_t timed_start, enum m2sdr_format format, unsigned header_bytes,
-                       uint64_t start_offset_bytes, uint64_t end_offset_bytes)
+                       uint64_t start_offset_bytes, uint64_t end_offset_bytes,
+                       unsigned host_buffers, unsigned prefill_buffers)
 {
     struct m2sdr_dev *dev = NULL;
     enum m2sdr_transport_kind transport = M2SDR_TRANSPORT_KIND_UNKNOWN;
@@ -187,6 +309,7 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
     int exit_status = 1;
     uint8_t raw_buf[DMA_BUFFER_SIZE];
     uint8_t payload_buf[DMA_BUFFER_SIZE];
+    struct m2sdr_play_source source = {0};
 
     if (m2sdr_open(&dev, device_id) != 0) {
         fprintf(stderr, "Could not open device: %s\n", device_id);
@@ -275,6 +398,20 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
         close_fi = 1;
     }
 
+    if (m2sdr_play_source_start(&source, fi, close_fi, loops, start_offset_bytes,
+                                end_offset_bytes, frame_bytes, host_buffers) != 0) {
+        fprintf(stderr, "Could not start host input queue\n");
+        goto cleanup;
+    }
+    if (source.enabled && prefill_buffers > 0) {
+        int rc = m2sdr_host_queue_wait_count(&source.queue, prefill_buffers);
+
+        if (rc == M2SDR_HOST_QUEUE_ERROR || rc == M2SDR_HOST_QUEUE_STOPPED) {
+            fprintf(stderr, "Host input queue prefill failed\n");
+            goto cleanup;
+        }
+    }
+
     last_time = get_time_ms();
     while (1) {
 #ifdef USE_LITEPCIE
@@ -296,9 +433,9 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
                 if (dma.reader_sw_count - dma.reader_hw_count < 0)
                     sw_underflows += (uint64_t)(dma.reader_hw_count - dma.reader_sw_count);
 
-                rc = read_next_play_frame(fi, close_fi, &current_loop, loops,
-                                          start_offset_bytes, end_offset_bytes,
-                                          raw_buf, frame_bytes);
+                rc = m2sdr_play_next_frame(fi, &source, close_fi, &current_loop, loops,
+                                           start_offset_bytes, end_offset_bytes,
+                                           raw_buf, frame_bytes);
                 if (rc < 0)
                     goto cleanup;
                 if (rc > 0) {
@@ -320,9 +457,9 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
             if (!keep_running)
                 break;
 
-            rc = read_next_play_frame(fi, close_fi, &current_loop, loops,
-                                      start_offset_bytes, end_offset_bytes,
-                                      raw_buf, frame_bytes);
+            rc = m2sdr_play_next_frame(fi, &source, close_fi, &current_loop, loops,
+                                       start_offset_bytes, end_offset_bytes,
+                                       raw_buf, frame_bytes);
             if (rc < 0)
                 goto cleanup;
             if (rc > 0)
@@ -371,6 +508,8 @@ static void m2sdr_play(const char *device_id, const char *filename, uint32_t loo
     exit_status = 0;
 
 cleanup:
+    if (source.enabled && m2sdr_play_source_finish(&source) != 0)
+        exit_status = 1;
 #ifdef USE_LITEPCIE
     if (use_pcie_dma)
         litepcie_dma_cleanup(&dma);
@@ -390,6 +529,8 @@ int main(int argc, char **argv)
     static uint8_t quiet = 0;
     static uint8_t timed_start = 0;
     static enum m2sdr_format format = M2SDR_FORMAT_SC16_Q11;
+    static unsigned host_buffers = 0;
+    static unsigned prefill_buffers = 0;
     unsigned capture_index = 0;
     unsigned sigmf_header_bytes = 0;
     uint64_t start_offset_bytes = 0;
@@ -407,6 +548,8 @@ int main(int argc, char **argv)
         { "timed-start", no_argument, NULL, 't' },
         { "zero-copy", no_argument, NULL, 'z' },
         { "capture-index", required_argument, NULL, 3 },
+        { "host-buffers", required_argument, NULL, 4 },
+        { "prefill", required_argument, NULL, 5 },
         { "format", required_argument, NULL, 1 },
         { "8bit", no_argument, NULL, 2 },
         { NULL, 0, NULL, 0 }
@@ -448,6 +591,18 @@ int main(int argc, char **argv)
                 return 1;
             }
             break;
+        case 4:
+            if (m2sdr_cli_parse_uint_range(optarg, 1, UINT32_MAX, &host_buffers) != 0) {
+                m2sdr_cli_error("invalid host buffer count '%s'", optarg);
+                return 1;
+            }
+            break;
+        case 5:
+            if (m2sdr_cli_parse_uint_range(optarg, 1, UINT32_MAX, &prefill_buffers) != 0) {
+                m2sdr_cli_error("invalid prefill count '%s'", optarg);
+                return 1;
+            }
+            break;
         case 'q':
             quiet = 1;
             break;
@@ -484,6 +639,15 @@ int main(int argc, char **argv)
 
     if (optind < argc) {
         m2sdr_cli_error("unexpected extra argument: %s", argv[optind]);
+        return 1;
+    }
+
+    if (prefill_buffers > 0 && host_buffers == 0) {
+        fprintf(stderr, "--prefill requires --host-buffers\n");
+        return 1;
+    }
+    if (prefill_buffers > host_buffers) {
+        fprintf(stderr, "--prefill cannot exceed --host-buffers\n");
         return 1;
     }
 
@@ -547,6 +711,7 @@ int main(int argc, char **argv)
     }
 
     m2sdr_play(m2sdr_cli_device_id(&cli_dev), filename, loops, quiet, timed_start, format,
-               sigmf_header_bytes, start_offset_bytes, end_offset_bytes);
+               sigmf_header_bytes, start_offset_bytes, end_offset_bytes,
+               host_buffers, prefill_buffers);
     return 0;
 }

--- a/litex_m2sdr/software/user/m2sdr_record.c
+++ b/litex_m2sdr/software/user/m2sdr_record.c
@@ -18,9 +18,11 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <math.h>
+#include <pthread.h>
 
 #include "m2sdr.h"
 #include "m2sdr_cli.h"
+#include "m2sdr_host_queue.h"
 #include "m2sdr_sigmf.h"
 #include "m2sdr_tool.h"
 #include "config.h"
@@ -28,6 +30,16 @@
 #include "liblitepcie.h"
 
 sig_atomic_t keep_running = 1;
+
+struct m2sdr_record_sink {
+    struct m2sdr_host_queue queue;
+    FILE *fo;
+    pthread_t thread;
+    int enabled;
+    int started;
+    int error;
+    size_t bytes_written;
+};
 
 void intHandler(int dummy) {
     (void)dummy;
@@ -51,6 +63,7 @@ static void help(void)
     puts("      --format FMT      Sample format: sc16, sc8 or encoded bfp8 (default: sc16).");
     puts("      --enable-header   Enable DMA header.");
     puts("      --strip-header    Strip DMA header from output.");
+    puts("      --host-buffers N  Queue N DMA buffers before writing output.");
     puts("");
     puts("SigMF output:");
     puts("      --sigmf           Write a SigMF dataset + metadata pair.");
@@ -278,13 +291,104 @@ static void record_note_timestamp(uint64_t timestamp, size_t total_len, unsigned
     *prev_timestamp = timestamp;
 }
 
-static bool record_write_payload(FILE *fo, const void *data, size_t payload_bytes_per_buf,
-                                 size_t size, size_t *total_len)
+static size_t record_payload_len(size_t payload_bytes_per_buf, size_t size, size_t total_len)
 {
     size_t to_write = payload_bytes_per_buf;
 
-    if (size > 0 && to_write > size - *total_len)
-        to_write = size - *total_len;
+    if (size > 0 && to_write > size - total_len)
+        to_write = size - total_len;
+    return to_write;
+}
+
+static void *m2sdr_record_sink_worker(void *arg)
+{
+    struct m2sdr_record_sink *sink = arg;
+    uint8_t buf[DMA_BUFFER_SIZE];
+
+    while (1) {
+        size_t len = 0;
+        int rc = m2sdr_host_queue_pop(&sink->queue, buf, sizeof(buf), &len, NULL);
+
+        if (rc == M2SDR_HOST_QUEUE_CLOSED)
+            break;
+        if (rc != M2SDR_HOST_QUEUE_OK) {
+            if (rc != M2SDR_HOST_QUEUE_STOPPED)
+                sink->error = 1;
+            break;
+        }
+
+        if (sink->fo && fwrite(buf, 1, len, sink->fo) != len) {
+            perror("fwrite");
+            sink->error = 1;
+            m2sdr_host_queue_stop(&sink->queue);
+            break;
+        }
+        sink->bytes_written += len;
+    }
+
+    return NULL;
+}
+
+static int m2sdr_record_sink_start(struct m2sdr_record_sink *sink, FILE *fo, unsigned host_buffers)
+{
+    memset(sink, 0, sizeof(*sink));
+    if (!fo || host_buffers == 0)
+        return 0;
+
+    if (m2sdr_host_queue_init(&sink->queue, host_buffers, DMA_BUFFER_SIZE) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    sink->fo = fo;
+    sink->enabled = 1;
+    if (pthread_create(&sink->thread, NULL, m2sdr_record_sink_worker, sink) != 0) {
+        m2sdr_host_queue_destroy(&sink->queue);
+        memset(sink, 0, sizeof(*sink));
+        return -1;
+    }
+    sink->started = 1;
+    return 0;
+}
+
+static int m2sdr_record_sink_finish(struct m2sdr_record_sink *sink, bool drain)
+{
+    int error;
+
+    if (!sink->enabled)
+        return 0;
+
+    if (sink->started) {
+        if (drain)
+            m2sdr_host_queue_close_writer(&sink->queue);
+        else
+            m2sdr_host_queue_stop(&sink->queue);
+        if (pthread_join(sink->thread, NULL) != 0)
+            sink->error = 1;
+        sink->started = 0;
+    }
+
+    error = sink->error;
+    m2sdr_host_queue_destroy(&sink->queue);
+    sink->enabled = 0;
+    return error ? -1 : 0;
+}
+
+static bool record_submit_payload(FILE *fo, struct m2sdr_record_sink *sink, const void *data,
+                                  size_t payload_bytes_per_buf, size_t size, size_t *total_len)
+{
+    size_t to_write = record_payload_len(payload_bytes_per_buf, size, *total_len);
+
+    if (sink->enabled) {
+        int rc = m2sdr_host_queue_push(&sink->queue, data, to_write, 0);
+
+        if (rc == M2SDR_HOST_QUEUE_ERROR) {
+            sink->error = 1;
+            return false;
+        }
+        if (rc == M2SDR_HOST_QUEUE_STOPPED)
+            return false;
+        *total_len += to_write;
+        return true;
+    }
+
     if (fo && fwrite(data, 1, to_write, fo) != to_write) {
         perror("fwrite");
         return false;
@@ -296,7 +400,7 @@ static bool record_write_payload(FILE *fo, const void *data, size_t payload_byte
 static void m2sdr_record(const char *device_id, const char *filename, size_t size, uint8_t quiet,
                          uint8_t header, uint8_t strip_header, enum m2sdr_format format,
                          bool sigmf_enable, bool annotate_ts_jumps, double ts_jump_threshold_pct,
-                         struct m2sdr_sigmf_meta *sigmf_meta)
+                         struct m2sdr_sigmf_meta *sigmf_meta, unsigned host_buffers)
 {
     struct m2sdr_dev *dev = NULL;
     enum m2sdr_transport_kind transport = M2SDR_TRANSPORT_KIND_UNKNOWN;
@@ -322,6 +426,7 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
     bool stop = false;
     int exit_status = 1;
     uint8_t buf[DMA_BUFFER_SIZE];
+    struct m2sdr_record_sink sink = {0};
 
     if (m2sdr_open(&dev, device_id) != 0) {
         fprintf(stderr, "Could not open device: %s\n", device_id);
@@ -361,6 +466,11 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
                 goto cleanup;
             }
         }
+    }
+
+    if (m2sdr_record_sink_start(&sink, fo, host_buffers) != 0) {
+        fprintf(stderr, "Could not start host output queue\n");
+        goto cleanup;
     }
 
 #ifdef USE_LITEPCIE
@@ -427,7 +537,8 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
                         rx_data += 16;
                 }
 
-                if (!record_write_payload(fo, rx_data, payload_bytes_per_buf, size, &total_len)) {
+                if (!record_submit_payload(fo, &sink, rx_data, payload_bytes_per_buf,
+                                           size, &total_len)) {
                     stop = true;
                     break;
                 }
@@ -461,7 +572,8 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
                                       &prev_timestamp, &nominal_dt);
             }
 
-            if (!record_write_payload(fo, rx_data, payload_bytes_per_buf, size, &total_len))
+            if (!record_submit_payload(fo, &sink, rx_data, payload_bytes_per_buf,
+                                       size, &total_len))
                 break;
 
             total_buffers++;
@@ -474,7 +586,8 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
 
             if (i % 10 == 0) {
                 if (header) {
-                    fprintf(stderr, "\e[1m%10s %10s %8s %23s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "TIME");
+                    fprintf(stderr, "\e[1m%10s %10s %8s %23s\e[0m\n",
+                            "SPEED(Gbps)", "BUFFERS", "SIZE(MB)", "TIME");
                 } else {
                     fprintf(stderr, "\e[1m%10s %10s %9s\e[0m\n", "SPEED(Gbps)", "BUFFERS", "SIZE(MB)");
                 }
@@ -494,12 +607,21 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
                 fprintf(stderr, "%11.2f %10" PRIu64 " %8" PRIu64 " %19s.%03u\n",
                         speed, total_buffers, size_mb, time_str, ms);
             } else {
-                fprintf(stderr, "%11.2f %10" PRIu64 " %9" PRIu64 "\n", speed, total_buffers, size_mb);
+                fprintf(stderr, "%11.2f %10" PRIu64 " %9" PRIu64 "\n",
+                        speed, total_buffers, size_mb);
             }
 
             last_time = get_time_ms();
             last_buffers = total_buffers;
         }
+    }
+
+    if (sink.enabled) {
+        if (m2sdr_record_sink_finish(&sink, true) != 0) {
+            fprintf(stderr, "Host output queue failed\n");
+            goto cleanup;
+        }
+        total_len = sink.bytes_written;
     }
 
     if (sigmf_enable) {
@@ -524,6 +646,8 @@ static void m2sdr_record(const char *device_id, const char *filename, size_t siz
     exit_status = 0;
 
 cleanup:
+    if (sink.enabled)
+        m2sdr_record_sink_finish(&sink, false);
     print_stream_summary(dev, quiet);
 #ifdef USE_LITEPCIE
     if (use_pcie_dma)
@@ -547,6 +671,7 @@ int main(int argc, char **argv)
     static uint8_t strip_header = 0;
     static uint8_t annotate_ts_jumps = 0;
     static enum m2sdr_format format = M2SDR_FORMAT_SC16_Q11;
+    static unsigned host_buffers = 0;
     double ts_jump_threshold_pct = 5.0;
     struct m2sdr_sigmf_meta sigmf_meta;
     struct m2sdr_sigmf_annotation pending_annotation;
@@ -577,6 +702,7 @@ int main(int argc, char **argv)
         { "annotation-add", no_argument, NULL, 15 },
         { "annotate-ts-jumps", no_argument, NULL, 16 },
         { "ts-jump-threshold-pct", required_argument, NULL, 17 },
+        { "host-buffers", required_argument, NULL, 18 },
         { "format", required_argument, NULL, 1 },
         { "8bit", no_argument, NULL, 2 },
         { NULL, 0, NULL, 0 }
@@ -704,6 +830,12 @@ int main(int argc, char **argv)
                 return 1;
             }
             break;
+        case 18:
+            if (m2sdr_cli_parse_uint_range(optarg, 1, UINT32_MAX, &host_buffers) != 0) {
+                m2sdr_cli_error("invalid host buffer count '%s'", optarg);
+                return 1;
+            }
+            break;
         default:
             exit(1);
         }
@@ -775,6 +907,7 @@ int main(int argc, char **argv)
     }
 
     m2sdr_record(m2sdr_cli_device_id(&cli_dev), filename, size, quiet, header, strip_header, format,
-                 sigmf_enable ? true : false, annotate_ts_jumps ? true : false, ts_jump_threshold_pct, &sigmf_meta);
+                 sigmf_enable ? true : false, annotate_ts_jumps ? true : false, ts_jump_threshold_pct,
+                 &sigmf_meta, host_buffers);
     return 0;
 }

--- a/litex_m2sdr/software/user/tests/test_m2sdr_host_queue.c
+++ b/litex_m2sdr/software/user/tests/test_m2sdr_host_queue.c
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../m2sdr_host_queue.h"
+
+static int expect_pop(struct m2sdr_host_queue *queue,
+                      const char *expected,
+                      uint64_t expected_tag)
+{
+    char buf[8] = {0};
+    size_t len = 0;
+    uint64_t tag = 0;
+
+    if (m2sdr_host_queue_pop(queue, buf, sizeof(buf), &len, &tag) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    if (len != strlen(expected) || memcmp(buf, expected, len) != 0)
+        return -1;
+    if (tag != expected_tag)
+        return -1;
+    return 0;
+}
+
+static int test_fifo_and_close(void)
+{
+    struct m2sdr_host_queue queue;
+    char buf[8];
+    size_t len = 0;
+
+    if (m2sdr_host_queue_init(&queue, 2, sizeof(buf)) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    if (m2sdr_host_queue_push(&queue, "aa", 2, 10) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    if (m2sdr_host_queue_push(&queue, "bbb", 3, 11) != M2SDR_HOST_QUEUE_OK)
+        return -1;
+    if (expect_pop(&queue, "aa", 10) != 0)
+        return -1;
+    if (expect_pop(&queue, "bbb", 11) != 0)
+        return -1;
+    m2sdr_host_queue_close_writer(&queue);
+    if (m2sdr_host_queue_pop(&queue, buf, sizeof(buf), &len, NULL) != M2SDR_HOST_QUEUE_CLOSED)
+        return -1;
+    m2sdr_host_queue_destroy(&queue);
+    return 0;
+}
+
+int main(void)
+{
+    if (test_fifo_and_close() != 0) {
+        fprintf(stderr, "test_fifo_and_close failed\n");
+        return 1;
+    }
+    printf("test_m2sdr_host_queue: ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add a small pthread-backed host queue helper for user-space streaming tools.
- Add optional blocking host-side output buffering to `m2sdr_record`.
- Add optional host-side input buffering/prefill to `m2sdr_play`.
- Document the new generic play/record options in the user tools README.

## Notes

This keeps the useful idea from PR #108 but reapplies it on current `main` instead of merging the stale draft branch directly. The implementation is split into small commits and uses the existing direct LitePCIe paths, sync fallbacks, SigMF handling, and progress output.

The exposed API is intentionally small: `m2sdr_record --host-buffers`, plus `m2sdr_play --host-buffers` / `--prefill`. The default tool behavior remains unbuffered.

## Testing

```
make -C litex_m2sdr/software/user m2sdr_play m2sdr_record tests/test_m2sdr_host_queue
./tests/test_m2sdr_host_queue
make -C litex_m2sdr/software/user core-tests
```
