### PR TITLE
soapysdr: add optional auto bandwidth mode

### DIFF
--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -131,6 +131,11 @@ bool parse_bool_arg(const std::string &value)
     throw std::runtime_error("Invalid boolean argument: " + value);
 }
 
+double auto_bandwidth_from_sample_rate(double sample_rate)
+{
+    return std::min(std::max(sample_rate, 0.2e6), 56.0e6);
+}
+
 bool antenna_allowed(const std::vector<std::string> &ants, const std::string &name)
 {
     if (ants.empty())
@@ -774,6 +779,8 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
         rx_agc_pin_requested = true;
         rx_agc_pin = parse_bool_arg(args.at("rx_agc_pin"));
     }
+    if (args.count("auto_bandwidth") > 0)
+        _autoBandwidth = parse_bool_arg(args.at("auto_bandwidth"));
 
     if (args.count("ad9361_fir_profile") > 0) {
         _ad9361_fir_profile = args.at("ad9361_fir_profile");
@@ -1812,6 +1819,8 @@ void SoapyLiteXM2SDR::setSampleRate(
         _sampleRateHwBitMode == _bitMode &&
         _sampleRateHwFirProfile == _ad9361_fir_profile) {
         setSampleMode();
+        if (_autoBandwidth)
+            setBandwidthUnlocked(direction, auto_bandwidth_from_sample_rate(rate));
         if (direction == SOAPY_SDR_RX && _rx_stream.opened) {
             _rx_stream.time0_ns = this->getHardwareTime("");
             _rx_stream.time0_count = _rx_stream.user_count;
@@ -1877,6 +1886,7 @@ void SoapyLiteXM2SDR::setSampleRate(
     timeout.throw_if_timed_out();
 #endif
 
+    bool sample_rate_applied = false;
     {
         int rc = m2sdr_set_sample_rate(_dev, hw_sample_rate);
         if (rc != 0) {
@@ -1886,12 +1896,15 @@ void SoapyLiteXM2SDR::setSampleRate(
             _sampleRateHw = hw_sample_rate;
             _sampleRateHwBitMode = _bitMode;
             _sampleRateHwFirProfile = _ad9361_fir_profile;
+            sample_rate_applied = true;
         }
     }
 #if USE_LITEETH
     timeout.throw_if_timed_out();
 #endif
 
+    if (_autoBandwidth && sample_rate_applied)
+        setBandwidthUnlocked(direction, auto_bandwidth_from_sample_rate(rate));
 
     /* Finally, update the sample mode (bit depth) based on the new configuration. */
     setSampleMode();
@@ -1985,13 +1998,12 @@ std::vector<std::string> SoapyLiteXM2SDR::getStreamFormats(
  *                                      Bandwidth API
  **************************************************************************************************/
 
-void SoapyLiteXM2SDR::setBandwidth(
+void SoapyLiteXM2SDR::setBandwidthUnlocked(
     const int direction,
-    const size_t channel,
-    const double bw) {
+    const double bw)
+{
     if (bw == 0.0)
         return;
-    std::lock_guard<std::mutex> lock(_mutex);
 
     uint32_t bwi = static_cast<uint32_t>(bw);
 
@@ -2016,6 +2028,16 @@ void SoapyLiteXM2SDR::setBandwidth(
 #if USE_LITEETH
     timeout.throw_if_timed_out();
 #endif
+}
+
+void SoapyLiteXM2SDR::setBandwidth(
+    const int direction,
+    const size_t /*channel*/,
+    const double bw)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    setBandwidthUnlocked(direction, bw);
 }
 
 double SoapyLiteXM2SDR::getBandwidth(

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
@@ -483,6 +483,7 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
         M2SDR_RX_GAIN_MODE_SLOW_ATTACK_AGC,
     };
     std::string _ad9361_fir_profile = "legacy"; /* legacy | bypass | match | wide */
+    bool _autoBandwidth = false;
     bool _sampleRateHwApplied = false;
     int64_t _sampleRateHw = 0;
     uint32_t _sampleRateHwBitMode = 0;
@@ -529,6 +530,9 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
         bool holdLast,
         const long timeoutUs);
     void markTxRemainderTime(const long long payloadTimeNs);
+    void setBandwidthUnlocked(
+        const int direction,
+        const double bw);
     bool isLitePCIe() const {
         return _transport == M2SDR_TRANSPORT_KIND_LITEPCIE;
     }

--- a/litex_m2sdr/software/soapysdr/README.md
+++ b/litex_m2sdr/software/soapysdr/README.md
@@ -66,6 +66,8 @@ You can pass device arguments to configure the driver. These are most useful whe
 - **RX AGC mode**: `rx_agc_mode=slow|fast|hybrid|mgc`
   Use `rx_agc_mode0`/`rx_agc_mode1` or `rx0_agc_mode`/`rx1_agc_mode` for per-channel defaults.
 - **RX AGC pin**: `rx_agc_pin=on|off` drives the FPGA-connected AD9361 `RF_EN_AGC` pin for pin-controlled gain flows.
+- **Auto bandwidth**: `auto_bandwidth=on|off` updates the AD9361 analog bandwidth when the sample rate changes.
+  The derived bandwidth follows the requested sample rate and is clamped to the AD9361 `200 kHz` to `56 MHz` range. The default is `off`.
 - **Device selection**: `path=/dev/m2sdr0` for PCIe, `eth_ip=192.168.1.50` for Ethernet, or `dev_id=pcie:/dev/m2sdr0` / `dev_id=eth:192.168.1.50:1234` for an explicit libm2sdr identifier.
 - **Ethernet discovery**: default discovery probes `192.168.1.50:1234` after PCIe. Use `eth_ips=ip[;ip[:port]...]` or `LITEXM2SDR_ETH_IPS` to override the discovery list, and `eth_discovery=0` to disable Ethernet discovery.
 - **Antenna selection**: RX uses `A_BALANCED`, TX uses `A`


### PR DESCRIPTION
## Summary
- add an opt-in `auto_bandwidth` Soapy device argument
- when enabled, sample-rate changes also update the AD9361 analog bandwidth
- derive bandwidth from the requested sample rate and clamp it to the AD9361 200 kHz to 56 MHz range
- keep the default behavior explicit/manual for compatibility

## Testing
- make -C litex_m2sdr/software/user libm2sdr/libm2sdr.a
- cmake -S litex_m2sdr/software/soapysdr -B /tmp/litex_m2sdr-auto-bandwidth-soapy-build
- cmake --build /tmp/litex_m2sdr-auto-bandwidth-soapy-build

Refs https://github.com/enjoy-digital/litex_m2sdr/issues/87