### PR TITLE
soapysdr: serialize cleanup with stream setup

### DIFF
--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -1009,6 +1009,14 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
 
 SoapyLiteXM2SDR::~SoapyLiteXM2SDR(void) {
     SoapySDR::log(SOAPY_SDR_INFO, "Power down and cleanup");
+
+    _rx_stream.stop_requested.store(true);
+    _tx_stream.stop_requested.store(true);
+
+    std::lock_guard<std::recursive_mutex> rx_stream_lock(_rx_stream_mutex);
+    std::lock_guard<std::recursive_mutex> tx_stream_lock(_tx_stream_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
+
     spi_unregister_fd(_spi_id);
     if (_rx_stream.opened) {
         stopRxStreamUnlocked();

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
@@ -374,6 +374,11 @@ SoapySDR::Stream *SoapyLiteXM2SDR::setupStream(
     const std::string &format,
     const std::vector<size_t> &channels,
     const SoapySDR::Kwargs &args) {
+    if (direction != SOAPY_SDR_RX && direction != SOAPY_SDR_TX)
+        throw std::runtime_error("Invalid direction.");
+
+    std::lock_guard<std::recursive_mutex> stream_lock(
+        direction == SOAPY_SDR_RX ? _rx_stream_mutex : _tx_stream_mutex);
     std::unique_lock<std::mutex> lock(_mutex);
 
     SoapySDR::Kwargs searchArgs = args;


### PR DESCRIPTION
## Summary
- take the per-direction stream mutex during setupStream()
- make the Soapy destructor request stream stop and wait for both stream mutexes before closing the device
- keep cleanup ordered behind in-flight setup/activation/RF configuration calls

## Root cause
Issue #75 shows the destructor logging "Power down and cleanup" before activateStream() finishes channel_configure()/setSampleRate(), then the RF path hits EBADF on a LitePCIe ioctl. The existing stream teardown locks protected closeStream()/deactivateStream(), but the destructor could still close the fd while setupStream()/activateStream() was running.

## Tests
- make -C litex_m2sdr/software/user libm2sdr/libm2sdr.a
- cmake -S litex_m2sdr/software/soapysdr -B /tmp/litex_m2sdr-issue75-soapy-build
- cmake --build /tmp/litex_m2sdr-issue75-soapy-build

Closes https://github.com/enjoy-digital/litex_m2sdr/issues/75