### PR TITLE
soapysdr: name channels after the board RF connectors

### DIFF
--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -1151,6 +1151,21 @@ size_t SoapyLiteXM2SDR::getNumChannels(const int) const {
     return 2;
 }
 
+SoapySDR::Kwargs SoapyLiteXM2SDR::getChannelInfo(
+    const int direction,
+    const size_t channel) const {
+    SoapySDR::Kwargs info;
+
+    /* Name channels after the board RF connectors so applications can
+     * present a meaningful per-channel selection. */
+    if (direction == SOAPY_SDR_RX)
+        info["label"] = (channel == 0) ? "RX1" : "RX2";
+    else
+        info["label"] = (channel == 0) ? "TX1" : "TX2";
+
+    return info;
+}
+
 bool SoapyLiteXM2SDR::getFullDuplex(const int, const size_t) const {
     return true;
 }

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
@@ -89,6 +89,7 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
     *                                 Channels API
     ***********************************************************************************************/
     size_t getNumChannels(const int) const override;
+    SoapySDR::Kwargs getChannelInfo(const int direction, const size_t channel) const override;
     bool getFullDuplex(const int, const size_t) const override;
 
     /***********************************************************************************************


### PR DESCRIPTION
## Summary
- implement SoapySDR `getChannelInfo()` with per-channel labels matching the board RF connectors: RX channels report `RX1`/`RX2`, TX channels `TX1`/`TX2`
- both channels previously looked byte-for-byte identical to applications (no channel info, same antenna name), so programs such as SDRangel could not present a meaningful per-channel selection

## Tests
- `SoapyLiteXM2SDR` build on main
- `SoapySDRUtil --probe` against the fake LiteEth target now reports `label=RX1/RX2/TX1/TX2` in the per-channel blocks (probed with the module applied on top of #120's branch, since bypass probing on main needs the `Fix Soapy bypass probe setup` fix from that PR)

Note: single-channel stream selection (`setupStream` with `{0}`, `{1}` or `{0,1}`) already landed since the issue was filed, so with this change SDRangel should now both list and stream the channels distinctly — feedback from the reporter with SDRangel would be welcome before closing.

Refs: #78