### PR TITLE
kernel: hold off bus mastering until DMA buffers are (re)mapped

### DIFF
--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -1906,6 +1906,12 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 		goto fail1;
 	}
 
+	/* Keep the device from bus-mastering until the core is reset and its DMA
+	 * buffers are (re)mapped: a device left bus-mastering by an unclean teardown
+	 * would otherwise DMA to stale addresses and fault the IOMMU before we are
+	 * ready. Bus mastering is enabled below, after litepcie_dma_init(). */
+	pci_clear_master(dev);
+
 	ret = -EIO;
 
 	/* Check the device version */
@@ -1944,7 +1950,6 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 		fpga_identifier[i] = litepcie_readl(litepcie_dev, CSR_IDENTIFIER_MEM_BASE + i * 4);
 	dev_info(&dev->dev, "Version %s\n", fpga_identifier);
 
-	pci_set_master(dev);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
 	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(DMA_ADDR_WIDTH));
 #else
@@ -2046,6 +2051,10 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 		goto fail3;
 	}
 
+	/* Core was reset and DMA buffers are now mapped: it is safe to let the
+	 * device bus-master (held off since pcim_enable_device above). */
+	pci_set_master(dev);
+
 #ifdef LITEPCIE_HAS_SATA_DMA
 	if (litepcie_soc_has_sata(litepcie_dev))
 		litepcie_sata_dma_alloc(litepcie_dev);
@@ -2141,6 +2150,14 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 	litepcie_dev = pci_get_drvdata(dev);
 
 	dev_info(&dev->dev, "\e[1m[Removing device]\e[0m\n");
+
+	/* Stop DMA at the PCIe level FIRST: clearing Bus Master Enable in config
+	 * space stops the device issuing any new DMA immediately, even if the MMIO
+	 * stop below cannot reach a wedged core. Otherwise a still-bus-mastering
+	 * FPGA writes into the buffers we are about to free -> IOMMU IO_PAGE_FAULT,
+	 * which can escalate (probe soft-lockup, D3cold) to a power-cycle-only wedge.
+	 * In-flight transactions complete cleanly; only new ones are blocked. */
+	pci_clear_master(dev);
 
 	/* Stop the DMAs */
 	litepcie_stop_dma(litepcie_dev);


### PR DESCRIPTION
### Problem
A device left bus-mastering by an unclean teardown keeps issuing DMA into
stale/freed addresses and faults the IOMMU (`IO_PAGE_FAULT`) before the driver is
ready. On our setup this escalated to a probe soft-lockup / D3cold wedge that only
a power cycle cleared.

### Change
- **Probe:** keep `pci_clear_master()` asserted until after `litepcie_dma_init()`
  has (re)mapped the DMA buffers and the core is reset; enable bus mastering only
  then, instead of right after reading the version.
- **Remove:** `pci_clear_master()` **first**, before `litepcie_stop_dma()`, so the
  device stops issuing new DMA immediately even if the MMIO stop can't reach a
  wedged core. In-flight transactions complete cleanly; only new ones are blocked.

### Impact
Eliminates the IOMMU-fault-on-teardown class of wedge (`IO_PAGE_FAULT` storm +
probe hang). Independent robustness fix, not tied to any streaming feature.

### Testing
`make -C litex_m2sdr/software/kernel clean all`. Verified on hardware across
`rmmod`/`insmod` cycles: teardown no longer leaves the device bus-mastering, probe
recovers and re-creates `/dev/m2sdr0`.