### PR TITLE
libm2sdr: re-apply RX QEC K_exp loop gain after RX LO retune

### DIFF
--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
@@ -1553,6 +1553,8 @@ int m2sdr_apply_config_if_needed(struct m2sdr_dev *dev,
 }
 
 /* Program one LO frequency on the already-initialized AD9361 instance. */
+static void m2sdr_apply_rx_qec_kexp(struct ad9361_rf_phy *phy);
+
 int m2sdr_set_frequency(struct m2sdr_dev *dev, enum m2sdr_direction direction, uint64_t freq)
 {
     struct ad9361_rf_phy *phy;
@@ -1573,9 +1575,26 @@ int m2sdr_set_frequency(struct m2sdr_dev *dev, enum m2sdr_direction direction, u
     } else {
         if (m2sdr_from_ad9361_rc(ad9361_set_rx_lo_freq(phy, freq)) != M2SDR_ERR_OK)
             return M2SDR_ERR_IO;
+        /* The RX LO retune re-runs the AD9361 quad cal, which reverts the QEC
+         * loop gain to the inert default; re-apply the fix so it sticks. */
+        m2sdr_apply_rx_qec_kexp(phy);
     }
 
     return M2SDR_ERR_OK;
+}
+
+/* Apply the RX quadrature-tracking loop gain (K_exp). The AD9361 driver default
+ * (0x15) leaves the loop inert -> ~25 dBc image rejection = a 3.5-7% EVM floor
+ * that corrupts wideband PDSCH LDPC (coherent image, HARQ-combining cannot help);
+ * 0x0a converges to ~40-43 dBc. M2SDR_QEC_KEXP overrides. */
+static void m2sdr_apply_rx_qec_kexp(struct ad9361_rf_phy *phy)
+{
+    const char *s = getenv("M2SDR_QEC_KEXP");
+    uint8_t kexp = s ? (uint8_t)(strtoul(s, NULL, 0) & 0x1F) : 0x0a;
+    ad9361_spi_write(phy->spi, REG_CALIBRATION_CONFIG_2,
+        CALIBRATION_CONFIG2_DFLT | K_EXP_PHASE(kexp));
+    ad9361_spi_write(phy->spi, REG_CALIBRATION_CONFIG_3,
+        PREVENT_POS_LOOP_GAIN | K_EXP_AMPLITUDE(kexp));
 }
 
 /* Program a common sample rate on both RX and TX paths. */


### PR DESCRIPTION
### Problem
The AD9361 driver default RX quadrature-tracking loop gain (`K_exp = 0x15`) leaves
the loop effectively inert: ~25 dBc image rejection, a 3.5–7 % EVM floor. On
wideband receive this corrupts PDSCH/LDPC — the image is coherent, so HARQ
combining can't recover it. `0x0a` converges to ~40–43 dBc.

Each RX LO retune re-runs the AD9361 quad cal, which reverts `K_exp` to the inert
default, so the fix has to be re-applied after every retune, not just at init.

### Change
After `ad9361_set_rx_lo_freq()` in `m2sdr_set_frequency()`, call a small helper
that writes `CALIBRATION_CONFIG_2/3` with `K_EXP_PHASE`/`K_EXP_AMPLITUDE`.
`M2SDR_QEC_KEXP` overrides the value (default `0x0a`; stable across `0x02`–`0x0a`).

### Testing
`test-libm2sdr`, `analyze-libm2sdr` (cppcheck clean), ASan/UBSan, Soapy build — all
pass. Measured ~25 → ~40–43 dBc image rejection on hardware, removing the wideband
EVM floor.