### PR TITLE
sata: support concurrent GQRX capture and replay

### DIFF
--- a/doc/sata-bandwidth-investigation.md
+++ b/doc/sata-bandwidth-investigation.md
@@ -1,0 +1,216 @@
+# SATA Bandwidth Investigation And Plan
+
+Date: 2026-07-13. Branch: `feature/sata-gqrx-shared-streaming`.
+Bitstream: `build/litex_m2sdr_baseboard_eth_sata` (Ethernet + SATA baseboard,
+Gen2, 125 MHz sys_clk). Transport: Etherbone at `192.168.1.50`, JTAG via
+FT4232H for recovery. Drive: WDC WDS120G1G0A-00SS50 (WD Green 120 GB,
+DRAM-less SM2258XT, TLC), firmware Z3311000.
+
+## Question
+
+`capture-current` cannot sustain 10 MS/s SC16 1T1R (38.15 MiB/s) without
+backpressuring the shared GQRX RX path. Is the ~18-20 MiB/s sustained rate a
+drive limit, a gateware limit, or a host-path limit?
+
+## Answer
+
+The sustained-write bottleneck is the SSD itself, in its current state. The
+gateware and host paths are exonerated for the ~20 MiB/s cap. Two additional
+independent problems were found and root-caused on hardware: a hard deadlock
+of the whole Ethernet endpoint when replaying to an unconfigured UDP
+destination, and a deliberate-but-costly Etherbone read regression.
+
+## Measurements (2026-07-13 hardware run)
+
+Link and drive state from raw ATA IDENTIFY (drained via
+`sata_identify_source_*` CSRs): negotiated speed Gen2, write cache enabled,
+look-ahead enabled, NCQ supported (unused by LiteSATA), LBA48, 234441648
+sectors.
+
+| Path | Test | Result |
+| ---- | ---- | ------ |
+| Etherbone burst write (staging RAM only) | `diag etherbone-bench`, 128 words | 139.5 MiB/s |
+| Etherbone burst read (staging RAM only) | `diag etherbone-bench`, 128 words | 7.0 MiB/s |
+| Host->SATA (Mem2Sector, 128 KiB cmds) | 16 MiB `diag write` after ~5 min idle | 55.0 MiB/s (path ceiling) |
+| Host->SATA (Mem2Sector) | same, immediately again | 8.6 then 20.2 MiB/s |
+| Host->SATA (Mem2Sector) | 1 GiB `diag write` | 15.1 MiB/s average |
+| Host->SATA (Mem2Sector) | 16 x 64 MiB chunks, per-chunk timing | 10.7-24.6 MiB/s, flat |
+| Host->SATA (Mem2Sector) | 16 x 16 MiB chunks after ~20 min idle | 7.5-51.4 MiB/s, avg ~13 |
+| RF->SATA (Stream2Sectors, 32 MiB cmds) | `capture` 234 MiB @ 30.72 MS/s SC16 (117 MiB/s demand) | 22.8 MiB/s average, flat from first command |
+| SATA->host (Sector2Mem + Etherbone read) | 256 MiB `diag read` | 6.4 MiB/s (host path limit, see below) |
+
+Key observations:
+
+- Both write paths (128 KiB commands via the staging buffer, 32 MiB
+  streaming commands via `Stream2Sectors`) converge on the same 10-25 MiB/s
+  sustained rate. Per-command overhead is therefore not the limiter.
+- The same drive absorbs 51-55 MiB/s (the Etherbone-fed path ceiling) for the
+  first ~16-32 MiB after idle time, then collapses. This is SLC-cache
+  behavior: the effective cache is currently only a few tens of MiB and
+  post-cache/GC writes run at ~10-25 MiB/s.
+- Reads from never-written LBAs (FTL returns zeros, no NAND access) are as
+  slow as reads of written data, proving the 6.4 MiB/s read number is the
+  host Etherbone path, not the drive.
+
+## Findings
+
+### 1. Drive sustained write commit rate (primary capture bottleneck)
+
+The WDS120G1G0A is a DRAM-less TLC drive. Field reports for healthy units
+show 60-120 MB/s post-SLC-cache sequential writes; this unit sustains only
+~10-25 MiB/s with a much smaller-than-expected SLC window. Likely causes:
+the volume has never been TRIMmed (LiteSATA has no DATA SET MANAGEMENT
+support, so from the FTL's perspective every LBA ever written stays valid),
+possible wear (2017-era unit, 40 TBW rating), and bottom-tier sustained
+behavior of this model.
+
+Practical envelope with this drive today: sustained captures must stay below
+~12-15 MiB/s to keep GQRX smooth. 4 MS/s SC16 1T1R (15.26 MiB/s) is
+borderline; 10 MS/s SC16 (38.15 MiB/s) is far above it, matching the
+observed 2x-slow backpressured captures.
+
+The `sata-workflows.md` claim that 18-20 MiB/s is "a sustained-drive limit,
+not an Ethernet or FIFO-capacity limit" is confirmed, with the refinement
+that the limit is drive-state-dependent (8-25 MiB/s observed) and that the
+burst ceiling through the same gateware is at least 55 MiB/s.
+
+### 2. Replay to an unconfigured UDP destination wedges the whole board
+
+Reproduced twice, root-caused, and verified on hardware:
+
+- `LiteEthStream2UDPTX` resets `ip_address` to 0.0.0.0
+  (`liteeth/frontend/stream.py`); only a SoapySDR/GQRX session programs it
+  (`libm2sdr/m2sdr_stream.c`). `m2sdr_sata serve NAME` / `diag replay ... eth`
+  do not.
+- After a bitstream (re)load with no GQRX session, `serve`/`replay` push a
+  UDP stream toward 0.0.0.0. ARP never resolves, the stalled packetizer
+  holds LiteEth's shared TX path, and ICMP + Etherbone die with it. The
+  board needs a JTAG bitstream reload (`openFPGALoader --cable ft4232 ...`).
+- Verification: after reload, `eth_rx_streamer_ip_address` (0x7804) read 0.
+  Writing the host IP (0xC0A80164) and re-running the identical
+  `serve eth_roundtrip_1m` completed in 0.141 s with the board healthy.
+
+This is a first-class robustness bug for the shared-streaming feature: any
+user running `serve` before a GQRX session hard-bricks the Ethernet endpoint
+until JTAG/power recovery.
+
+### 3. Etherbone read window regression (deliberate, this branch)
+
+`M2SDR_SATA_ETHERBONE_READ_WINDOW` was reduced 8 -> 1 to keep catalog reads
+cooperative with a live GQRX client, and
+`eb_read32_bulk_pipeline_checked()` degenerates to stop-and-wait for
+window <= 1. Export/read throughput dropped from ~34 MiB/s to ~6.4 MiB/s.
+Write bursts are unaffected (139.5 MiB/s raw). This does not affect capture
+bandwidth, only `export`/`diag read`.
+
+## Re-Test With A Samsung 850 EVO 250GB (2026-07-13)
+
+Swapping the drive confirmed the diagnosis. Same gateware, same host paths:
+
+| Path | Test | WDS120G1G0A | 850 EVO |
+| ---- | ---- | ----------- | ------- |
+| Host -> SATA | 1 GiB `diag write` | 15.1 MiB/s | 43.9 MiB/s (path limit) |
+| RF -> SATA | 10 MS/s SC16 1T1R, 10 s | ~19 MiB/s, 2x slow | 38.13 MiB/s, real-time |
+| RF -> SATA | 30.72 MS/s SC16 1T1R | ~23 MiB/s | 117.15 MiB/s, real-time |
+| RF -> SATA | 30.72 MS/s SC16 2T2R, 15 s (3.43 GiB) | - | 232.94 MiB/s, real-time |
+
+The 2T2R run wrote 3.43 GiB, past the EVO's TurboWrite cache, with no fade:
+the `Stream2Sectors` path sustains at least 233 MiB/s, close to the practical
+Gen2 payload ceiling. The RFIC rate, not SATA, is now the capture limit.
+
+After a drive hot-plug the PHY needs a re-init (`sata_phy_enable` 0 -> 1) and
+IDENTIFY can briefly return partial data while the link trains; the identify
+hardening below came out of that observation.
+
+## Fixes Implemented (this branch)
+
+- `libm2sdr`: partially drained IDENTIFY data is no longer decoded (it
+  reported a bogus LBA28-sized 128 GiB drive during link training).
+- `m2sdr_sata`: Ethernet replays program a resolvable UDP destination before
+  the RX path is routed to the LiteEth streamer, closing the
+  wedge described in finding 2. Verified on hardware: `serve` on a
+  freshly-loaded bitstream now completes with the board healthy.
+- `m2sdr_sata`: Etherbone catalog reads use the full 8-deep pipeline window
+  again when no live client is streaming (6.4 -> 26-30 MiB/s measured,
+  readback `cmp`-verified) and keep the cooperative single-burst window
+  during a concurrent GQRX session. A 16-deep window measured slower
+  (19 MiB/s): in-flight records overrun the gateware's 160-word record
+  buffering, so 8 is the sweet spot for the current gateware.
+
+## Remaining Plan
+
+Ordered by leverage:
+
+1. Drive maintenance support (optional, in-tree): add ATA DATA SET
+   MANAGEMENT (TRIM) and SMART READ DATA support to LiteSATA +
+   `m2sdr_sata trim|health`, so a capture volume can be maintained and
+   monitored in place. The degraded WDS120G1G0A showed what an
+   unmaintained drive does to sustained rates; a health command would have
+   pointed at the drive immediately.
+
+2. LiteEth robustness (upstream): a UDP stream toward an unresolved ARP
+   target should time out and drop rather than hold the shared TX arbiter
+   forever; the host-side destination fix closes the common path, but the
+   gateware can still be wedged by any misprogrammed destination.
+   Reproduce with `--with-eth-tx-probe` + LiteScope; fix belongs in LiteEth
+   with a test there.
+
+3. Etherbone read concurrency (gateware): pipelined reads scale to
+   window=8 (26-30 MiB/s) but regress at window=16 because the shared
+   Etherbone record path buffers only one 128-word record
+   (`ETH_ETHERBONE_BUFFER_DEPTH = 160`). Deeper record buffering or a
+   second in-flight record would raise the export ceiling toward the
+   ~56 MiB/s the round-trip time allows.
+
+4. Identify robustness: RESOLVED 2026-07-13. Two combined causes: LiteSATA
+   ended IDENTIFY at the first DATA FIS `last` although a drive may split
+   the PIO block into several DRQ blocks (fixed in LiteSATA, branch
+   `fix-multi-fis-identify`: count the 128-dword block in the command layer
+   and identify frontend, accept intermediate PIO Setup FISes), and the
+   host fired identify starts into a still-busy engine while draining only
+   half the block (fixed in `libm2sdr`: wait for idle, drain the full
+   block, retry while a slow transfer is still arriving). The 850 EVO
+   stalls identify for hundreds of milliseconds while garbage-collecting,
+   which is what exposed both. Back-to-back `info` went from ~60% failures
+   to 0/60 on hardware.
+
+5. Observability for future SATA work (per the debugging guide and the
+   ai-era-fpga workflow: prefer small CSRs, then narrow probes).
+   - CSR counters on the LiteSATA user port: commands issued, data words
+     transferred, stall (valid & !ready) cycles, per streamer. Lets
+     `m2sdr_sata info` print live throughput and separates drive stalls
+     from FIFO starvation in the field without a bench.
+   - A drive-independent write benchmark: feed `Stream2Sectors` from a
+     gateware counter/PRBS source (crossbar diag route) so the true
+     gateware SATA ceiling can be measured; today it can only be bounded
+     from below (>= 55 MiB/s) because the drive saturates first.
+   - Report negotiated SATA gen and write-cache state in
+     `m2sdr_sata info` (already available in IDENTIFY words 77/85).
+
+## Repro Commands
+
+```sh
+# Sustained write profile (per-chunk timing, safe raw region):
+for i in $(seq 0 15); do
+  S=$(printf "0x%x" $((0x2000000 + i*32768)))
+  time ./m2sdr_sata -i 192.168.1.50 diag write /tmp/rand_1g.bin $S 32768
+done
+
+# Streamer-path write rate (progress lines print cumulative MiB/s):
+./m2sdr_sata -i 192.168.1.50 --timeout-ms 90000 capture bench \
+    --seconds 2 --sample-rate 30720000 --format sc16 --channel-layout 1t1r \
+    --rx-freq 100M --rx-gain 20 --bandwidth 20M
+./m2sdr_sata -i 192.168.1.50 delete bench
+
+# LiteEth-endpoint wedge recovery (fixed host-side; the gateware can still
+# be wedged by a misprogrammed streamer destination, see Remaining Plan 2):
+openFPGALoader --cable ft4232 \
+    build/litex_m2sdr_baseboard_eth_sata/gateware/litex_m2sdr_baseboard_eth_sata.bit
+```
+
+Note: the installed OpenOCD 0.11 cannot run LiteX's JTAGBone stream script
+(`invalid command name "binary"`; needs OpenOCD >= 0.12) and its `ftdi`
+command syntax predates the configs in `litex/prog/`. openFPGALoader works
+for recovery. Upgrading OpenOCD would restore JTAGBone as an
+Ethernet-independent debug path, which this investigation would have used
+to inspect the wedged state instead of destroying it with a reload.

--- a/doc/sata-validation.md
+++ b/doc/sata-validation.md
@@ -37,7 +37,24 @@ for host-buffer workflows and avoids the RAMB cascade DRC issue observed with a
 
 ## Current Hardware Numbers
 
-These are the latest validated numbers from the 2026-05-24 hardware run.
+RF streamer-path numbers from the 2026-07-13 hardware run with a Samsung
+850 EVO 250GB on the Ethernet + SATA baseboard build (Gen2, write cache
+enabled). All captures completed in real time through `Stream2Sectors`
+while the recorded data demand stayed below the drive's sustained rate:
+
+| Path | Test | Result | Validation |
+| ---- | ---- | ------ | ---------- |
+| RF -> SATA | 10 MS/s SC16 1T1R, 10 s (381.5 MiB) | 38.13 MiB/s, elapsed 10.005 s | real-time, no backpressure |
+| RF -> SATA | 30.72 MS/s SC16 1T1R, 4 s (468.8 MiB) | 117.15 MiB/s, elapsed 4.001 s | real-time, no backpressure |
+| RF -> SATA | 30.72 MS/s SC16 2T2R, 15 s (3.43 GiB) | 232.94 MiB/s, elapsed 15.092 s | real-time, past the drive's TurboWrite cache |
+| Host -> SATA | 1 GiB `diag write` | 43.9 MiB/s | Etherbone staging path limit, not the drive |
+| SATA -> host | 64 MiB `diag read`, idle endpoint | 26-30 MiB/s | readback matched with `cmp` |
+
+The same gateware with a degraded, never-TRIMmed WDC WDS120G1G0A sustained
+only 10-25 MiB/s on long writes; see `sata-bandwidth-investigation.md` for
+that investigation and the drive benchmarking recipe.
+
+The host-buffer numbers below are from the 2026-05-24 hardware run.
 
 | Transport | User-visible path | Host to SATA | SATA to host | Validation |
 | --------- | ----------------- | ------------ | ------------ | ---------- |

--- a/doc/sata-workflows.md
+++ b/doc/sata-workflows.md
@@ -33,6 +33,82 @@ make m2sdr_sata
 
 ## Capture And Retrieve
 
+### Record and replay what GQRX is receiving
+
+Build and load the Ethernet + SATA image, then rebuild the user software and
+SoapySDR module so gateware and software use the same CSR map:
+
+```sh
+./litex_m2sdr.py --variant=baseboard --with-eth --with-sata --build --flash
+make -C litex_m2sdr/software/user clean
+make -C litex_m2sdr/software/user
+cmake -S litex_m2sdr/software/soapysdr -B /tmp/litex_m2sdr_soapy \
+    -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build /tmp/litex_m2sdr_soapy
+sudo cmake --install /tmp/litex_m2sdr_soapy
+```
+
+The clean user build is important after changing gateware because generated CSR
+offsets are compiled into `libm2sdr` and the SoapySDR module.  Installing with
+the `/usr` prefix replaces the module in Debian/Ubuntu's multiarch SoapySDR
+directory; a default `/usr/local` install can otherwise be shadowed by an older
+module under `/usr`.
+
+Start GQRX normally with the Ethernet device
+`driver=LiteXM2SDR,eth_ip=192.168.1.50`, tune it, and enable DSP. The SATA
+utility can then record the exact RX stream that continues to feed GQRX:
+
+```sh
+cd litex_m2sdr/software/user
+./m2sdr_sata -i 192.168.1.50 capture-current my_capture --seconds 10
+```
+
+`capture-current` reads the active sample rate, format, channel layout,
+frequency, and bandwidth published by the SoapySDR driver. It does not retune
+the RFIC or disconnect GQRX. An explicit `--size` can be used instead of
+`--seconds`.
+
+The required sustained write rate is:
+
+```text
+sample rate x bytes per complex sample x channel count
+```
+
+For example, 1T1R SC16 needs 15.26 MiB/s at 4 MS/s and 38.15 MiB/s at
+10 MS/s. The WDC WDS120G1G0A used during Ethernet validation sustained about
+18--20 MiB/s on long LiteSATA writes: 4 MS/s SC16 captured in 10.009 seconds
+and replayed in 9.990 seconds, while 10 MS/s backpressured the shared RX path
+and took about 20 seconds. This is a sustained-drive limit, not an Ethernet or
+FIFO-capacity limit; short writes can be much faster because they are cached.
+Use a rate below the measured sustained write speed when GQRX must remain
+smooth. If the utility reports that elapsed capture time differs from the
+requested time, treat that capture as backpressured and lower the rate, bit
+depth, or channel count.
+
+Replay the named capture into the same Ethernet RX path:
+
+```sh
+./m2sdr_sata -i 192.168.1.50 serve my_capture
+```
+
+GQRX remains open and DSP-active: during `serve` it displays the samples read
+from SATA, and when replay finishes the normal live RF stream is restored.
+Etherbone control is shared by routing replies to each process's UDP source
+port; no second control port or dashboard is required.
+
+To reset an idle or cleanly stopped streamer frontend:
+
+```sh
+./m2sdr_sata -i 192.168.1.50 stop both
+```
+
+The frontend reset cannot abort an ATA command that was already accepted by
+the SATA core. After a timeout, run `info`. If it reports `Drive: Not present`
+while the PHY is still ready, reload the FPGA bitstream before issuing another
+SATA command.
+
+### Standalone RF capture
+
 Record RF samples directly to SATA:
 
 ```sh

--- a/doc/sata-workflows.md
+++ b/doc/sata-workflows.md
@@ -75,15 +75,18 @@ sample rate x bytes per complex sample x channel count
 ```
 
 For example, 1T1R SC16 needs 15.26 MiB/s at 4 MS/s and 38.15 MiB/s at
-10 MS/s. The WDC WDS120G1G0A used during Ethernet validation sustained about
-18--20 MiB/s on long LiteSATA writes: 4 MS/s SC16 captured in 10.009 seconds
-and replayed in 9.990 seconds, while 10 MS/s backpressured the shared RX path
-and took about 20 seconds. This is a sustained-drive limit, not an Ethernet or
-FIFO-capacity limit; short writes can be much faster because they are cached.
-Use a rate below the measured sustained write speed when GQRX must remain
-smooth. If the utility reports that elapsed capture time differs from the
-requested time, treat that capture as backpressured and lower the rate, bit
-depth, or channel count.
+10 MS/s. The sustained rate is a drive property, not an Ethernet or
+FIFO-capacity limit, and varies enormously between drives and with drive
+state. A degraded DRAM-less WDC WDS120G1G0A sustained only 10--25 MiB/s on
+long LiteSATA writes (4 MS/s SC16 was real-time, 10 MS/s backpressured the
+shared RX path and took about twice the requested duration), while a Samsung
+850 EVO 250GB on the same gateware sustained 30.72 MS/s SC16 2T2R
+(233 MiB/s) in real time. Short writes can be much faster than a drive's
+sustained rate because they are absorbed by its SLC/DRAM cache. Use a rate
+below the measured sustained write speed when GQRX must remain smooth; see
+`sata-bandwidth-investigation.md` for the measurement recipe. If the utility
+reports that elapsed capture time differs from the requested time, treat that
+capture as backpressured and lower the rate, bit depth, or channel count.
 
 Replay the named capture into the same Ethernet RX path:
 
@@ -103,9 +106,17 @@ To reset an idle or cleanly stopped streamer frontend:
 ```
 
 The frontend reset cannot abort an ATA command that was already accepted by
-the SATA core. After a timeout, run `info`. If it reports `Drive: Not present`
-while the PHY is still ready, reload the FPGA bitstream before issuing another
-SATA command.
+the SATA core. Interrupting a capture, play, or serve with Ctrl-C therefore
+stops at the current command boundary (at most one 32 MiB command finishes,
+typically well under a second) and the utility exits with the SATA core
+usable; a stopped capture is not registered in the catalog. The `stop`
+command applies the same boundary stop to a busy streamer before resetting
+it. On gateware without the streamer stop CSRs the interrupt falls back to
+finishing the whole programmed transfer (a replay is unpaced so it drains as
+fast as the destination accepts). A second Ctrl-C abandons the transfer:
+after that, or after a timeout, run `info`. If it reports
+`Drive: Not present` while the PHY is still ready, reload the FPGA bitstream
+before issuing another SATA command.
 
 ### Standalone RF capture
 

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -36,6 +36,7 @@ from litex.build.generic_platform import IOStandard
 from litepcie.common            import *
 from litepcie.phy.s7pciephy     import S7PCIEPHY
 from liteeth.phy.a7_1000basex import A7_1000BASEX, A7_2500BASEX
+from liteeth.core             import LiteEthUDPIPCore
 from liteeth.frontend.stream  import LiteEthStream2UDPTX, LiteEthUDP2StreamRX
 from liteeth.core.ptp         import LiteEthPTP
 
@@ -62,6 +63,7 @@ from litex_m2sdr.gateware.pcie        import (
     add_s7_pcie_timing_constraints,
 )
 from litex_m2sdr.gateware.header      import TXRXHeader
+from litex_m2sdr.gateware.etherbone   import SharedLiteEthEtherbone
 from litex_m2sdr.gateware.led         import StatusLed
 from litex_m2sdr.gateware.measurement import MultiClkMeasurement
 from litex_m2sdr.gateware.gpio        import GPIO
@@ -72,7 +74,7 @@ from litex_m2sdr.gateware.sata        import (
     SATA_HOST_BUFFER_BASE, SATA_HOST_BUFFER_SIZE, SATAHostBuffer,
     SATADMAMemoryRouter,
     M2SDRLiteSATASector2MemDMA, M2SDRLiteSATAMem2SectorDMA,
-    M2SDRLiteSATAStream2Sectors, M2SDRLiteSATASectors2Stream)
+    M2SDRLiteSATAStream2Sectors, M2SDRLiteSATASectors2Stream, SATAStreamTap)
 
 from litex_m2sdr.software import generate_litepcie_software
 
@@ -613,7 +615,7 @@ class BaseSoC(SoCMini):
                     igmp_groups   = ptp_igmp_groups,
                     igmp_interval = eth_ptp_igmp_interval,
                 )
-            self.add_etherbone(**eth_etherbone_kwargs)
+            self.add_shared_etherbone(**eth_etherbone_kwargs)
 
             if with_eth_ptp:
                 nominal_time_inc = int(round((1e9/100e6) * (1 << 24)))
@@ -803,6 +805,9 @@ class BaseSoC(SoCMini):
 
         # Crossbar.
         # ---------
+        # Port indices match the host-side TXSRC_*/RXDST_* enums in
+        # litex_m2sdr/software/user/m2sdr_sata_lowlevel.h: 0=PCIe, 1=Eth, 2=SATA.
+        crossbar_sata_port = 2
         self.crossbar = stream.Crossbar(layout=dma_layout(64), n=3, with_csr=True)
 
         # TX: Comms -> Crossbar -> Header.
@@ -836,7 +841,28 @@ class BaseSoC(SoCMini):
 
         # RX: Header -> Crossbar -> Comms.
         # --------------------------------
-        self.comb += self.header.rx.source.connect(self.crossbar.demux.sink)
+        if with_sata:
+            # Keep the normal host RX path active while optionally duplicating
+            # each accepted word into the SATA recorder.  The small mux also
+            # preserves the original exclusive RX->SATA routing mode.
+            self.sata_rx_tap = SATAStreamTap(dma_layout(64))
+            self.sata_rx_mux = stream.Multiplexer(dma_layout(64), n=2)
+            sata_tap_active = Signal()
+            self.comb += [
+                sata_tap_active.eq(
+                    self.sata_rx_streamer.tap.storage &
+                    (self.crossbar.demux.sel != crossbar_sata_port)
+                ),
+                self.header.rx.source.connect(self.sata_rx_tap.sink),
+                self.sata_rx_tap.source.connect(self.crossbar.demux.sink),
+                self.crossbar.demux.source2.connect(self.sata_rx_mux.sink0),
+                self.sata_rx_tap.tap.connect(self.sata_rx_mux.sink1),
+                self.sata_rx_mux.sel.eq(sata_tap_active),
+                self.sata_rx_mux.source.connect(self.sata_rx_streamer.sink, omit={"error"}),
+                self.sata_rx_tap.enable.eq(sata_tap_active),
+            ]
+        else:
+            self.comb += self.header.rx.source.connect(self.crossbar.demux.sink)
         if with_pcie:
             self.comb += [
                 self.crossbar.demux.source0.connect(self.pcie_dma0.sink),
@@ -856,9 +882,6 @@ class BaseSoC(SoCMini):
                 ]
             else:
                 self.comb += self.crossbar.demux.source1.connect(self.eth_rx_streamer.sink)
-        if with_sata:
-            self.comb += self.crossbar.demux.source2.connect(self.sata_rx_streamer.sink, omit={"error"})
-
         # Leds -------------------------------------------------------------------------------------
 
         led_pad = platform.request("user_led")
@@ -1145,6 +1168,53 @@ class BaseSoC(SoCMini):
             mode       = mode,
         )
 
+    def add_shared_etherbone(self, phy, ip_address, data_width=32,
+        arp_entries=4, buffer_depth=16, with_igmp=False,
+        igmp_groups=None, igmp_interval=10):
+        """Add Etherbone with replies routed to each UDP client's source port.
+
+        Mirrors LiteXSoC.add_etherbone with the frontend swapped for
+        SharedLiteEthEtherbone; re-diff against upstream on LiteX bumps.
+        """
+        if data_width != 32:
+            raise ValueError("Shared Etherbone currently requires a 32-bit datapath.")
+
+        ethcore = LiteEthUDPIPCore(
+            phy                  = phy,
+            mac_address          = 0x10e2d5000000,
+            ip_address           = ip_address,
+            clk_freq             = self.clk_freq,
+            arp_entries          = arp_entries,
+            dw                   = data_width,
+            with_ip_broadcast    = True,
+            with_sys_datapath    = True,
+            with_igmp            = with_igmp,
+            igmp_groups          = igmp_groups,
+            igmp_interval        = igmp_interval,
+            interface            = "crossbar",
+            endianness           = "big",
+        )
+        self.add_module(name="ethcore_etherbone", module=ethcore)
+
+        etherbone = SharedLiteEthEtherbone(
+            ethcore.udp,
+            udp_port    = 1234,
+            buffer_depth= buffer_depth,
+            cd          = "sys",
+        )
+        self.add_module(name="etherbone", module=etherbone)
+        self.bus.add_master(name="etherbone", master=etherbone.wishbone.bus)
+
+        eth_rx_clk = getattr(phy, "crg", phy).cd_eth_rx.clk
+        eth_tx_clk = getattr(phy, "crg", phy).cd_eth_tx.clk
+        self.platform.add_period_constraint(eth_rx_clk, 1e9/phy.rx_clk_freq)
+        if eth_rx_clk is not eth_tx_clk:
+            self.platform.add_period_constraint(eth_tx_clk, 1e9/phy.tx_clk_freq)
+            self.platform.add_false_path_constraints(
+                self.crg.cd_sys.clk, eth_rx_clk, eth_tx_clk)
+        else:
+            self.platform.add_false_path_constraints(self.crg.cd_sys.clk, eth_rx_clk)
+
     def add_sata(self, platform, sys_clk_freq, sata_gen=2, with_pcie=False, pcie_msis=None):
         if with_pcie and pcie_msis is None:
             raise ValueError("PCIe MSI map is required when SATA and PCIe are enabled.")
@@ -1237,7 +1307,10 @@ class BaseSoC(SoCMini):
         # Streamers.
         # ----------
         self.sata_rx_streamer = ResetInserter()(M2SDRLiteSATAStream2Sectors(port=self.sata_crossbar.get_port()))
-        self.sata_tx_streamer = ResetInserter()(M2SDRLiteSATASectors2Stream(port=self.sata_crossbar.get_port()))
+        self.sata_tx_streamer = ResetInserter()(M2SDRLiteSATASectors2Stream(
+            port         = self.sata_crossbar.get_port(),
+            sys_clk_freq = sys_clk_freq,
+        ))
         self.sata_streamer_control = CSRStorage(fields=[
             CSRField("rx_reset", size=1, offset=0, pulse=True,
                 description="Pulse reset on the SATA Stream2Sectors streamer."),

--- a/litex_m2sdr/gateware/ad9361/core.py
+++ b/litex_m2sdr/gateware/ad9361/core.py
@@ -142,6 +142,15 @@ class AD9361RFIC(LiteXModule):
                 ("``0b10``", "BFP8 block-floating transport mode."),
             ], description="Sample format.")
         ])
+        # Last stream settings programmed by host software.  These scratch
+        # CSRs let an independent SATA control process describe and size the
+        # stream already configured by GQRX without touching the RFIC.
+        self._active_sample_rate = CSRStorage(32,
+            description="Active host stream sample rate in samples/s.")
+        self._active_rx_frequency_khz = CSRStorage(32,
+            description="Active RX center frequency in kHz.")
+        self._active_bandwidth = CSRStorage(32,
+            description="Active RX bandwidth in Hz.")
 
         # # #
 

--- a/litex_m2sdr/gateware/etherbone.py
+++ b/litex_m2sdr/gateware/etherbone.py
@@ -1,0 +1,168 @@
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Etherbone frontend with per-request UDP reply routing.
+
+The standard LiteEth Etherbone frontend sends every reply to its fixed service
+port.  That requires all host clients to bind the same UDP port and makes two
+independent processes race for replies.  This variant preserves the request's
+source IP/port and returns each read/probe reply to that endpoint.
+"""
+
+from litex.gen import *
+
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.packet import Arbiter, Dispatcher
+
+from liteeth.common import (
+    etherbone_magic,
+    etherbone_packet_header,
+    etherbone_record_header,
+    etherbone_version,
+    eth_etherbone_packet_user_description,
+    eth_udp_user_description,
+    reverse_bytes,
+)
+from liteeth.frontend.etherbone import (
+    LiteEthEtherbonePacketPacketizer,
+    LiteEthEtherbonePacketRX,
+    LiteEthEtherboneProbe,
+    LiteEthEtherboneRecordDepacketizer,
+    LiteEthEtherboneRecordPacketizer,
+    LiteEthEtherboneRecordReceiver,
+    LiteEthEtherboneRecordSender,
+    LiteEthEtherboneWishboneMaster,
+)
+
+
+class SharedLiteEthEtherbonePacketTX(LiteXModule):
+    """Etherbone packet TX returning replies to the request source port."""
+
+    def __init__(self, udp_port):
+        self.sink   = sink   = stream.Endpoint(eth_etherbone_packet_user_description(32))
+        self.source = source = stream.Endpoint(eth_udp_user_description(32))
+
+        self.packetizer = packetizer = LiteEthEtherbonePacketPacketizer()
+        self.comb += [
+            sink.connect(packetizer.sink, keep={"valid", "last", "last_be", "ready", "data"}),
+            sink.connect(packetizer.sink, keep={"pf", "pr", "nr"}),
+            packetizer.sink.version.eq(etherbone_version),
+            packetizer.sink.magic.eq(etherbone_magic),
+            packetizer.sink.port_size.eq(32//8),
+            packetizer.sink.addr_size.eq(32//8),
+        ]
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(packetizer.source.valid,
+                NextState("SEND")
+            )
+        )
+        fsm.act("SEND",
+            packetizer.source.connect(source),
+            source.src_port.eq(udp_port),
+            # Delta vs LiteEth's LiteEthEtherbonePacketTX: reply to the
+            # requester's source port instead of the fixed service port.
+            source.dst_port.eq(sink.src_port),
+            source.ip_address.eq(sink.ip_address),
+            source.length.eq(sink.length + etherbone_packet_header.length),
+            If(source.valid & source.last & source.ready,
+                NextState("IDLE")
+            )
+        )
+
+
+class SharedLiteEthEtherbonePacket(LiteXModule):
+    def __init__(self, udp, udp_port, cd="sys"):
+        self.tx = tx = SharedLiteEthEtherbonePacketTX(udp_port)
+        self.rx = rx = LiteEthEtherbonePacketRX(
+            with_last_handler=(udp.crossbar.dw == 64)
+        )
+        port = udp.crossbar.get_port(udp_port, dw=32, cd=cd)
+        self.comb += [
+            tx.source.connect(port.sink),
+            port.source.connect(rx.sink),
+        ]
+        self.sink, self.source = self.tx.sink, self.rx.source
+
+
+class SharedLiteEthEtherboneRecord(LiteXModule):
+    """Etherbone record path with ordered reply endpoint metadata."""
+
+    def __init__(self, endianness="big", buffer_depth=4):
+        self.sink   = sink   = stream.Endpoint(eth_etherbone_packet_user_description(32))
+        self.source = source = stream.Endpoint(eth_etherbone_packet_user_description(32))
+
+        self.depacketizer = depacketizer = LiteEthEtherboneRecordDepacketizer()
+        self.receiver     = receiver     = LiteEthEtherboneRecordReceiver(buffer_depth)
+        self.comb += sink.connect(depacketizer.sink)
+
+        # A read response can be delayed by Wishbone arbitration. Queue the
+        # requesting endpoint with the read record instead of keeping only a
+        # single global "last client" value.
+        metadata_layout = [
+            ("ip_address", 32),
+            ("src_port",   16),
+        ]
+        self.metadata_fifo = metadata_fifo = stream.SyncFIFO(
+            metadata_layout, buffer_depth, buffered=True
+        )
+        first = Signal(reset=1)
+        needs_metadata = Signal()
+        can_accept = Signal()
+        self.comb += [
+            needs_metadata.eq(first & (depacketizer.source.rcount != 0)),
+            can_accept.eq(~needs_metadata | metadata_fifo.sink.ready),
+            depacketizer.source.connect(receiver.sink, omit={"valid", "ready"}),
+            receiver.sink.valid.eq(depacketizer.source.valid & can_accept),
+            depacketizer.source.ready.eq(receiver.sink.ready & can_accept),
+            metadata_fifo.sink.valid.eq(
+                depacketizer.source.valid & receiver.sink.ready & needs_metadata
+            ),
+            metadata_fifo.sink.ip_address.eq(sink.ip_address),
+            metadata_fifo.sink.src_port.eq(sink.src_port),
+        ]
+        self.sync += If(depacketizer.source.valid & depacketizer.source.ready,
+            first.eq(depacketizer.source.last)
+        )
+        if endianness == "big":
+            self.comb += receiver.sink.data.eq(reverse_bytes(depacketizer.source.data))
+
+        self.sender     = sender     = LiteEthEtherboneRecordSender(buffer_depth)
+        self.packetizer = packetizer = LiteEthEtherboneRecordPacketizer()
+        self.comb += [
+            sender.source.connect(packetizer.sink),
+            packetizer.source.connect(source),
+            source.valid.eq(packetizer.source.valid & metadata_fifo.source.valid),
+            packetizer.source.ready.eq(source.ready & metadata_fifo.source.valid),
+            source.length.eq(etherbone_record_header.length +
+                (sender.source.wcount != 0)*4 + sender.source.wcount*4 +
+                (sender.source.rcount != 0)*4 + sender.source.rcount*4),
+            source.ip_address.eq(metadata_fifo.source.ip_address),
+            source.src_port.eq(metadata_fifo.source.src_port),
+            metadata_fifo.source.ready.eq(source.valid & source.ready & source.last),
+        ]
+        if endianness == "big":
+            self.comb += packetizer.sink.data.eq(reverse_bytes(sender.source.data))
+
+
+class SharedLiteEthEtherbone(LiteXModule):
+    """Wishbone-master Etherbone frontend safe for multiple UDP clients."""
+
+    def __init__(self, udp, udp_port, buffer_depth=4, cd="sys"):
+        self.packet = packet = SharedLiteEthEtherbonePacket(udp, udp_port, cd)
+        self.probe  = probe  = LiteEthEtherboneProbe()
+        self.record = record = SharedLiteEthEtherboneRecord(buffer_depth=buffer_depth)
+
+        dispatcher = Dispatcher(packet.source, [probe.sink, record.sink])
+        arbiter = Arbiter([probe.source, record.source], packet.sink)
+        self.comb += dispatcher.sel.eq(~packet.source.pf)
+        self.submodules += dispatcher, arbiter
+
+        self.wishbone = LiteEthEtherboneWishboneMaster()
+        self.comb += [
+            record.receiver.source.connect(self.wishbone.sink),
+            self.wishbone.source.connect(record.sender.sink),
+        ]

--- a/litex_m2sdr/gateware/sata.py
+++ b/litex_m2sdr/gateware/sata.py
@@ -23,10 +23,19 @@ SATA_HOST_BUFFER_BASE = 0x00020000
 # inferred RAM topology simple. 256KiB was tested and caused RAMB cascade DRC
 # issues on the current Artix-7 target.
 SATA_HOST_BUFFER_SIZE = 128 * 1024
-# Keep RF stream captures in multi-sector SATA commands. This avoids the
-# command/ACK overhead of issuing one write per 512-byte sector while keeping
-# progress and interrupt latency bounded.
-SATA_STREAM_BURST_SECTORS = 4096
+# Use long SATA commands while buffering enough RF data to present the drive in
+# contiguous bursts. A 384-sector preload / 512-sector FIFO is 192KiB / 256KiB
+# respectively. The FIFO naturally alternates between refill and drain while a
+# command remains active, avoiding both sparse word-by-word writes and the
+# command/activate/ack overhead of issuing one command per small buffer.
+#
+# 0xffff is the largest non-zero ATA DMA EXT sector count represented directly
+# by LiteSATA's 16-bit user port. Keeping the FIFO depth at a power of two avoids
+# inefficient Artix-7 BRAM cascading.
+SATA_STREAM_COMMAND_SECTORS = 0xffff
+SATA_STREAM_PRELOAD_SECTORS = 384
+SATA_STREAM_LOW_WATERMARK_SECTORS = 64
+SATA_STREAM_FIFO_SECTORS    = 512
 
 
 # Helpers ------------------------------------------------------------------------------------------
@@ -61,6 +70,43 @@ def _sata_word(data):
     # LiteSATA presents drive words in the opposite byte order from the local
     # little-endian host/radio streams.
     return reverse_bytes(data)
+
+
+class SATAStreamTap(LiteXModule):
+    """Losslessly duplicate a primary stream while the tap is enabled.
+
+    A word is presented to each output only when the other output can accept
+    it, so neither consumer can advance independently and observe duplicates.
+    With the tap disabled, the primary path is a normal transparent link.
+    """
+    def __init__(self, layout):
+        self.sink    = stream.Endpoint(layout)
+        self.source  = stream.Endpoint(layout)
+        self.tap     = stream.Endpoint(layout)
+        self.enable  = Signal()
+
+        # # #
+
+        self.primary_fifo = primary_fifo = stream.SyncFIFO(layout, depth=4, buffered=True)
+        self.tap_fifo = tap_fifo = ResetInserter()(stream.SyncFIFO(layout, depth=4, buffered=True))
+
+        self.comb += [
+            self.sink.connect(primary_fifo.sink, omit={"valid", "ready"}),
+            self.sink.connect(tap_fifo.sink,     omit={"valid", "ready"}),
+            primary_fifo.source.connect(self.source),
+            tap_fifo.source.connect(self.tap),
+
+            # Both queues accept a tapped word in the same cycle.  Their
+            # registered occupancy breaks the ready/valid path between the
+            # PCIe and SATA consumers while sustaining one word per cycle.
+            primary_fifo.sink.valid.eq(
+                self.sink.valid & (~self.enable | tap_fifo.sink.ready)),
+            tap_fifo.sink.valid.eq(
+                self.sink.valid & self.enable & primary_fifo.sink.ready),
+            self.sink.ready.eq(
+                primary_fifo.sink.ready & (~self.enable | tap_fifo.sink.ready)),
+            tap_fifo.reset.eq(~self.enable),
+        ]
 
 
 # SATA Host Buffer ---------------------------------------------------------------------------------
@@ -429,7 +475,11 @@ class M2SDRLiteSATAMem2SectorDMA(LiteXModule):
 
 class M2SDRLiteSATAStream2Sectors(LiteXModule):
     """LiteSATA Stream2Sectors with contiguous multi-sector SATA writes."""
-    def __init__(self, port, data_width=64):
+    def __init__(self, port, data_width=64,
+        burst_sectors=SATA_STREAM_COMMAND_SECTORS,
+        preload_sectors=SATA_STREAM_PRELOAD_SECTORS,
+        low_watermark_sectors=SATA_STREAM_LOW_WATERMARK_SECTORS,
+        fifo_sectors=SATA_STREAM_FIFO_SECTORS):
         self.port     = port
         self.sector   = CSRStorage(48, description="First SATA sector.")
         self.nsectors = CSRStorage(32, description="Number of SATA sectors to record.")
@@ -437,6 +487,8 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         self.done     = CSRStatus(reset=1, description="Asserted when recording has completed.")
         self.error    = CSRStatus(description="Asserted when recording has failed.")
         self.progress = CSRStatus(32, description="Number of SATA sectors written in the current recording.")
+        self.tap      = CSRStorage(description=
+            "Duplicate the selected host RX stream into this recorder while preserving the host path.")
         self.irq      = Signal()
 
         self.sink     = stream.Endpoint([("data", data_width)])
@@ -448,21 +500,49 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         # Full-sector writes: require exact 512B chunks.
         assert (logical_sector_size % stream_bytes) == 0
 
-        words_per_sector = _words_per_sector(port.dw)
-        max_burst_sectors = min(SATA_STREAM_BURST_SECTORS, 0xffff)
+        words_per_sector        = _words_per_sector(port.dw)
+        stream_words_per_sector = logical_sector_size//stream_bytes
+        max_command_sectors     = min(burst_sectors, 0xffff)
+        max_preload_sectors     = min(preload_sectors, fifo_sectors - 1,
+                                      max_command_sectors)
+        low_watermark_sectors   = min(low_watermark_sectors,
+                                      max_preload_sectors - 1)
+        fifo_depth              = fifo_sectors * stream_words_per_sector
+        low_stream_words        = low_watermark_sectors * stream_words_per_sector
+        low_port_words          = low_watermark_sectors * words_per_sector
+
+        assert max_command_sectors > 0
+        assert max_preload_sectors > 0
+        assert low_watermark_sectors > 0
+        assert fifo_sectors > max_preload_sectors
+
+        # Accumulate a useful reservoir before presenting a long command to
+        # LiteSATA. The FIFO continues accepting RF words throughout the
+        # command. When SATA drains it faster than RF can refill it, valid is
+        # temporarily deasserted. High/low-watermark hysteresis prevents the
+        # FIFO from draining completely and degenerating back into sparse
+        # word-by-word SATA traffic. The same command resumes after the FIFO
+        # refills, avoiding command overhead for every reservoir-sized chunk.
+        self.input_fifo = input_fifo = stream.SyncFIFO(
+            [("data", data_width)], depth=fifo_depth, buffered=True)
 
         send_count        = Signal(32)
-        burst_words       = Signal(32)
-        burst_sectors     = Signal(16)
+        command_words       = Signal(32)
+        preload_stream_words = Signal(32)
+        command_sectors     = Signal(16)
         remaining_sectors = Signal(32)
         crt_sec           = Signal(48)
         progress          = Signal(32)
+        drain_enabled     = Signal()
 
         # Converter.
         self.conv = conv = stream.Converter(nbits_from=data_width, nbits_to=port.dw)
 
-        # Connect Stream to Converter.
-        self.comb += self.sink.connect(conv.sink, keep={"valid", "ready", "data", "last"})
+        # Connect Stream through the burst reservoir to the converter.
+        self.comb += [
+            self.sink.connect(input_fifo.sink, keep={"valid", "ready", "data", "last"}),
+            input_fifo.source.connect(conv.sink, keep={"valid", "ready", "data", "last"}),
+        ]
         self.comb += self.progress.status.eq(progress)
 
         # Control FSM.
@@ -470,11 +550,13 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         fsm.act("IDLE",
             If(self.start.re,
                 NextValue(send_count,        0),
-                NextValue(burst_words,       0),
-                NextValue(burst_sectors,     0),
+                NextValue(command_words,       0),
+                NextValue(preload_stream_words, 0),
+                NextValue(command_sectors,     0),
                 NextValue(remaining_sectors, self.nsectors.storage),
                 NextValue(crt_sec,           self.sector.storage),
                 NextValue(progress,          0),
+                NextValue(drain_enabled,     0),
                 *_clear_transfer_status(self.done, self.error),
                 NextState("LOAD-BURST")
             ),
@@ -482,26 +564,53 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         )
         fsm.act("LOAD-BURST",
             NextValue(send_count, 0),
-            If(remaining_sectors > max_burst_sectors,
-                NextValue(burst_sectors, max_burst_sectors),
-                NextValue(burst_words,   max_burst_sectors * words_per_sector),
+            If(remaining_sectors > max_command_sectors,
+                NextValue(command_sectors, max_command_sectors),
+                NextValue(command_words,   max_command_sectors * words_per_sector),
+                NextValue(preload_stream_words,
+                    max_preload_sectors * stream_words_per_sector),
             ).Else(
-                NextValue(burst_sectors, remaining_sectors[:16]),
-                NextValue(burst_words,   remaining_sectors * words_per_sector),
+                NextValue(command_sectors, remaining_sectors[:16]),
+                NextValue(command_words,   remaining_sectors * words_per_sector),
+                If(remaining_sectors > max_preload_sectors,
+                    NextValue(preload_stream_words,
+                        max_preload_sectors * stream_words_per_sector),
+                ).Else(
+                    NextValue(preload_stream_words,
+                        remaining_sectors * stream_words_per_sector),
+                )
             ),
-            NextState("SEND-CMD-AND-DATA")
+            NextState("WAIT-BURST-DATA")
+        )
+        fsm.act("WAIT-BURST-DATA",
+            If(input_fifo.level >= preload_stream_words,
+                NextValue(drain_enabled, 1),
+                NextState("SEND-CMD-AND-DATA")
+            )
         )
         fsm.act("SEND-CMD-AND-DATA",
             # Send one write command/data stream for the current burst. Gate
             # valid with converter output so the first SATA beat cannot use
             # stale data.
-            port.sink.valid.eq(conv.source.valid),
-            port.sink.last.eq(send_count == (burst_words - 1)),
+            port.sink.valid.eq(conv.source.valid & drain_enabled),
+            port.sink.last.eq(send_count == (command_words - 1)),
             port.sink.write.eq(1),
             port.sink.sector.eq(crt_sec),
-            port.sink.count.eq(burst_sectors),
+            port.sink.count.eq(command_sectors),
             port.sink.data.eq(_sata_word(conv.source.data)),
-            conv.source.ready.eq(port.sink.ready),
+            conv.source.ready.eq(port.sink.ready & drain_enabled),
+            # Send only contiguous reservoir bursts. Keep draining the last
+            # low-watermark portion of a command so a short final command
+            # cannot wait for data that belongs to the next command.
+            If(drain_enabled,
+                If((input_fifo.level <= low_stream_words) &
+                   (command_sectors > low_watermark_sectors) &
+                   (send_count < (command_words - low_port_words)),
+                    NextValue(drain_enabled, 0)
+                )
+            ).Elif(input_fifo.level >= preload_stream_words,
+                NextValue(drain_enabled, 1)
+            ),
             If(port.sink.valid & port.sink.ready,
                 NextValue(send_count, send_count + 1),
                 If(port.sink.last,
@@ -523,13 +632,13 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
                     *_fail_transfer(self.done, self.error, self.irq),
                     NextState("IDLE")
                 ).Else(
-                    NextValue(progress, progress + burst_sectors),
-                    If(remaining_sectors <= burst_sectors,
+                    NextValue(progress, progress + command_sectors),
+                    If(remaining_sectors <= command_sectors,
                         *_finish_transfer(self.done, self.irq),
                         NextState("IDLE")
                     ).Else(
-                        NextValue(remaining_sectors, remaining_sectors - burst_sectors),
-                        NextValue(crt_sec, crt_sec + burst_sectors),
+                        NextValue(remaining_sectors, remaining_sectors - command_sectors),
+                        NextValue(crt_sec, crt_sec + command_sectors),
                         NextState("LOAD-BURST")
                     )
                 )
@@ -540,19 +649,29 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
 # SATA Sectors2Stream ------------------------------------------------------------------------------
 
 class M2SDRLiteSATASectors2Stream(LiteXModule):
-    """LiteSATA Sectors2Stream with port-width byte ordering.
+    """Buffered, paced LiteSATA Sectors2Stream.
 
     LiteSATA exposes a 32-bit port on the M2SDR design while the radio/PCIe
     stream is 64-bit. Reverse bytes at the SATA-port word width before
     up-conversion so the Stream2Sectors path is the exact inverse.
+
+    Reads are issued as long multi-sector commands through a bounded FIFO.
+    Ready/valid backpressure pauses the drive whenever that FIFO fills, while
+    the optional pacer releases 64-bit words at the recorded RF byte rate.
     """
-    def __init__(self, port, data_width=64):
+    def __init__(self, port, data_width=64, sys_clk_freq=int(100e6),
+        burst_sectors=SATA_STREAM_COMMAND_SECTORS,
+        fifo_sectors=SATA_STREAM_FIFO_SECTORS):
         self.port     = port
         self.sector   = CSRStorage(48, description="First SATA sector.")
         self.nsectors = CSRStorage(32, description="Number of SATA sectors to play.")
+        self.pace     = CSRStorage(32, description=
+            "Replay rate in 64-bit stream words/s. Zero disables pacing.")
         self.start    = CSR()
         self.done     = CSRStatus(reset=1, description="Asserted when playback has completed.")
         self.error    = CSRStatus(description="Asserted when playback has failed.")
+        self.progress = CSRStatus(32, description=
+            "Number of SATA sectors read in the current playback.")
         self.irq      = Signal()
 
         self.source   = stream.Endpoint([("data", data_width)])
@@ -564,75 +683,189 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
         # Whole-sector streaming.
         assert (logical_sector_size % stream_bytes) == 0
 
-        crt_sec  = Signal(48)
-        last_sec = Signal(48)
+        stream_words_per_sector = logical_sector_size//stream_bytes
+        port_words_per_sector   = _words_per_sector(port.dw)
+        max_command_sectors     = min(burst_sectors, 0xffff)
+        fifo_depth              = fifo_sectors * stream_words_per_sector
 
-        # Sector buffer.
-        self.buf = buf = stream.SyncFIFO([("data", port.dw)], _words_per_sector(port.dw))
+        assert data_width == 64
+        assert max_command_sectors > 0
+        assert fifo_sectors > 0
+
+        crt_sec            = Signal(48)
+        remaining_sectors  = Signal(32)
+        command_sectors    = Signal(16)
+        command_port_words = Signal(32)
+        receive_count      = Signal(32)
+        progress           = Signal(32)
+        final_output_seen  = Signal()
+
+        # FIFO after width conversion lets SATA fetch the next burst while the
+        # current one is being released at the RF stream rate.
+        self.output_fifo = output_fifo = stream.SyncFIFO(
+            [("data", data_width)], depth=fifo_depth, buffered=True)
 
         # Converter.
         self.conv = conv = stream.Converter(nbits_from=port.dw, nbits_to=data_width)
 
-        # Connect Port to Sector Buffer. Reverse per SATA word, not per output
-        # stream beat, so the down-conversion path writes the same words back.
+        # Connect the read response to the converter only while a command is
+        # active. Reverse per SATA word, not per output stream beat, so the
+        # down-conversion path writes the same words back.
         self.comb += [
-            buf.sink.valid.eq(port.source.valid),
-            buf.sink.last.eq(port.source.last),
-            buf.sink.data.eq(_sata_word(port.source.data)),
-            port.source.ready.eq(buf.sink.ready),
+            conv.sink.valid.eq(0),
+            conv.sink.last.eq(0),
+            conv.sink.data.eq(_sata_word(port.source.data)),
+            port.source.ready.eq(0),
+
+            output_fifo.sink.valid.eq(conv.source.valid),
+            output_fifo.sink.last.eq(
+                conv.source.last & (remaining_sectors <= command_sectors)),
+            output_fifo.sink.data.eq(conv.source.data),
+            conv.source.ready.eq(output_fifo.sink.ready),
         ]
 
-        # Connect Sector Buffer to Converter.
-        self.comb += buf.source.connect(conv.sink)
+        self.comb += self.progress.status.eq(progress)
+
+        # Fractional word-rate pacer. A single pending credit is retained when
+        # the downstream host is backpressured; credits are deliberately not
+        # accumulated into a burst.
+        pace_accumulator = Signal(max=max(2, int(sys_clk_freq)))
+        pace_sum         = Signal(33)
+        pace_credit      = Signal()
+        pace_full_rate   = Signal()
+        pace_tick        = Signal()
+        pace_allow       = Signal()
+        output_fire      = Signal()
+
+        self.comb += [
+            pace_sum.eq(pace_accumulator + self.pace.storage),
+            pace_full_rate.eq(
+                (self.pace.storage == 0) | (self.pace.storage >= int(sys_clk_freq))),
+            pace_tick.eq(pace_sum >= int(sys_clk_freq)),
+            pace_allow.eq(pace_full_rate | pace_credit | pace_tick),
+
+            self.source.valid.eq(output_fifo.source.valid & pace_allow),
+            self.source.last.eq(output_fifo.source.last),
+            self.source.data.eq(output_fifo.source.data),
+            output_fifo.source.ready.eq(self.source.ready & pace_allow),
+            output_fire.eq(self.source.valid & self.source.ready),
+        ]
+
+        self.sync += [
+            If(self.start.re,
+                pace_accumulator.eq(0),
+                pace_credit.eq(0),
+                final_output_seen.eq(0),
+            ).Elif(pace_full_rate,
+                pace_accumulator.eq(0),
+                pace_credit.eq(0),
+            ).Elif(pace_credit,
+                If(output_fire,
+                    pace_credit.eq(0),
+                )
+            ).Else(
+                If(pace_tick,
+                    pace_accumulator.eq(pace_sum - int(sys_clk_freq)),
+                    If(~output_fire,
+                        pace_credit.eq(1),
+                    )
+                ).Else(
+                    pace_accumulator.eq(pace_sum),
+                )
+            ),
+            If(output_fire & self.source.last,
+                final_output_seen.eq(1),
+            )
+        ]
 
         # Control FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             If(self.start.re,
-                NextValue(crt_sec,  self.sector.storage),
-                NextValue(last_sec, self.sector.storage + self.nsectors.storage - 1),
+                NextValue(crt_sec,           self.sector.storage),
+                NextValue(remaining_sectors, self.nsectors.storage),
+                NextValue(command_sectors,   0),
+                NextValue(command_port_words, 0),
+                NextValue(receive_count,    0),
+                NextValue(progress,          0),
                 *_clear_transfer_status(self.done, self.error),
-                NextState("SEND-CMD")
+                NextState("LOAD-BURST")
+            )
+        )
+        fsm.act("LOAD-BURST",
+            If(remaining_sectors > max_command_sectors,
+                NextValue(command_sectors, max_command_sectors),
+                NextValue(command_port_words,
+                    max_command_sectors * port_words_per_sector),
+            ).Else(
+                NextValue(command_sectors, remaining_sectors[:16]),
+                NextValue(command_port_words,
+                    remaining_sectors * port_words_per_sector),
             ),
-            conv.source.ready.eq(1)
+            NextState("WAIT-FIFO-SPACE")
+        )
+        fsm.act("WAIT-FIFO-SPACE",
+            # A command can be much larger than the FIFO: LiteSATA propagates
+            # ready/valid backpressure to the drive while paced output makes
+            # room. Start with half the reservoir free so useful read data can
+            # arrive before the first HOLD/backpressure interval.
+            If(output_fifo.level <= (fifo_depth >> 1),
+                NextState("SEND-CMD")
+            )
         )
         fsm.act("SEND-CMD",
-            # Send read command for 1 sector.
+            # Send one command for the complete burst.
             port.sink.valid.eq(1),
             port.sink.last.eq(1),
             port.sink.read.eq(1),
             port.sink.sector.eq(crt_sec),
-            port.sink.count.eq(1),
+            port.sink.count.eq(command_sectors),
             If(port.sink.ready,
+                NextValue(receive_count, 0),
                 NextState("RECEIVE-DATA-STREAM")
             )
         )
         fsm.act("RECEIVE-DATA-STREAM",
-            # Connect Converter to Stream.
-            self.source.valid.eq(conv.source.valid),
-            self.source.data.eq(conv.source.data),
-
-            # End-of-transfer framing:
-            # Assert last only on the last word of the last sector.
-            self.source.last.eq(conv.source.last & (crt_sec == last_sec)),
-
-            conv.source.ready.eq(self.source.ready),
-
-            If(self.source.valid & self.source.ready,
-                If(conv.source.last,
-                    If(crt_sec == last_sec,
-                        *_finish_transfer(self.done, self.irq),
-                        NextState("IDLE")
+            # A multi-sector read can contain multiple DATA FIS packets, each
+            # with last asserted. Count payload words and wait for the separate
+            # end response instead of treating a packet boundary as command
+            # completion.
+            conv.sink.valid.eq(port.source.valid & port.source.read & ~port.source.end),
+            conv.sink.last.eq(receive_count == (command_port_words - 1)),
+            port.source.ready.eq(
+                conv.sink.ready & port.source.read & ~port.source.end),
+            If(port.source.valid & port.source.ready,
+                If(port.source.failed,
+                    *_fail_transfer(self.done, self.error, self.irq),
+                    NextState("IDLE")
+                ).Elif(receive_count == (command_port_words - 1),
+                    NextState("WAIT-RESPONSE")
+                ).Else(
+                    NextValue(receive_count, receive_count + 1)
+                )
+            )
+        )
+        fsm.act("WAIT-RESPONSE",
+            port.source.ready.eq(1),
+            If(port.source.valid & port.source.ready,
+                If(port.source.failed,
+                    *_fail_transfer(self.done, self.error, self.irq),
+                    NextState("IDLE")
+                ).Elif(port.source.read & port.source.end,
+                    NextValue(progress, progress + command_sectors),
+                    If(remaining_sectors <= command_sectors,
+                        NextState("DRAIN-FINAL")
                     ).Else(
-                        NextValue(crt_sec, crt_sec + 1),
-                        NextState("SEND-CMD")
+                        NextValue(remaining_sectors, remaining_sectors - command_sectors),
+                        NextValue(crt_sec, crt_sec + command_sectors),
+                        NextState("LOAD-BURST")
                     )
                 )
-            ),
-
-            # Monitor errors.
-            If(port.source.valid & port.source.ready & port.source.failed,
-                *_fail_transfer(self.done, self.error, self.irq),
+            )
+        )
+        fsm.act("DRAIN-FINAL",
+            If(final_output_seen,
+                *_finish_transfer(self.done, self.irq),
                 NextState("IDLE")
             )
         )

--- a/litex_m2sdr/gateware/sata.py
+++ b/litex_m2sdr/gateware/sata.py
@@ -489,6 +489,7 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         self.progress = CSRStatus(32, description="Number of SATA sectors written in the current recording.")
         self.tap      = CSRStorage(description=
             "Duplicate the selected host RX stream into this recorder while preserving the host path.")
+        self.stop     = CSR()
         self.irq      = Signal()
 
         self.sink     = stream.Endpoint([("data", data_width)])
@@ -534,6 +535,14 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
         crt_sec           = Signal(48)
         progress          = Signal(32)
         drain_enabled     = Signal()
+
+        # An accepted ATA command cannot be aborted, so a stop request is
+        # honored at the next command boundary instead of mid-transfer.
+        stop_pending = Signal()
+        self.sync += [
+            If(self.stop.re,  stop_pending.eq(1)),
+            If(self.start.re, stop_pending.eq(0)),
+        ]
 
         # Converter.
         self.conv = conv = stream.Converter(nbits_from=data_width, nbits_to=port.dw)
@@ -583,7 +592,12 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
             NextState("WAIT-BURST-DATA")
         )
         fsm.act("WAIT-BURST-DATA",
-            If(input_fifo.level >= preload_stream_words,
+            # No command is in flight while the reservoir fills: a stop can
+            # complete immediately.
+            If(stop_pending,
+                *_finish_transfer(self.done, self.irq),
+                NextState("IDLE")
+            ).Elif(input_fifo.level >= preload_stream_words,
                 NextValue(drain_enabled, 1),
                 NextState("SEND-CMD-AND-DATA")
             )
@@ -633,7 +647,7 @@ class M2SDRLiteSATAStream2Sectors(LiteXModule):
                     NextState("IDLE")
                 ).Else(
                     NextValue(progress, progress + command_sectors),
-                    If(remaining_sectors <= command_sectors,
+                    If(stop_pending | (remaining_sectors <= command_sectors),
                         *_finish_transfer(self.done, self.irq),
                         NextState("IDLE")
                     ).Else(
@@ -672,6 +686,7 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
         self.error    = CSRStatus(description="Asserted when playback has failed.")
         self.progress = CSRStatus(32, description=
             "Number of SATA sectors read in the current playback.")
+        self.stop     = CSR()
         self.irq      = Signal()
 
         self.source   = stream.Endpoint([("data", data_width)])
@@ -699,6 +714,16 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
         receive_count      = Signal(32)
         progress           = Signal(32)
         final_output_seen  = Signal()
+
+        # An accepted ATA command cannot be aborted, so a stop request is
+        # honored at the next command boundary instead of mid-transfer. Words
+        # left in the output FIFO are the host's to flush with the frontend
+        # reset.
+        stop_pending = Signal()
+        self.sync += [
+            If(self.stop.re,  stop_pending.eq(1)),
+            If(self.start.re, stop_pending.eq(0)),
+        ]
 
         # FIFO after width conversion lets SATA fetch the next burst while the
         # current one is being released at the RF stream rate.
@@ -805,11 +830,16 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
             NextState("WAIT-FIFO-SPACE")
         )
         fsm.act("WAIT-FIFO-SPACE",
+            # No command is in flight while waiting for FIFO space: a stop
+            # can complete immediately.
+            If(stop_pending,
+                *_finish_transfer(self.done, self.irq),
+                NextState("IDLE")
             # A command can be much larger than the FIFO: LiteSATA propagates
             # ready/valid backpressure to the drive while paced output makes
             # room. Start with half the reservoir free so useful read data can
             # arrive before the first HOLD/backpressure interval.
-            If(output_fifo.level <= (fifo_depth >> 1),
+            ).Elif(output_fifo.level <= (fifo_depth >> 1),
                 NextState("SEND-CMD")
             )
         )
@@ -853,7 +883,10 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
                     NextState("IDLE")
                 ).Elif(port.source.read & port.source.end,
                     NextValue(progress, progress + command_sectors),
-                    If(remaining_sectors <= command_sectors,
+                    If(stop_pending,
+                        *_finish_transfer(self.done, self.irq),
+                        NextState("IDLE")
+                    ).Elif(remaining_sectors <= command_sectors,
                         NextState("DRAIN-FINAL")
                     ).Else(
                         NextValue(remaining_sectors, remaining_sectors - command_sectors),
@@ -864,7 +897,9 @@ class M2SDRLiteSATASectors2Stream(LiteXModule):
             )
         )
         fsm.act("DRAIN-FINAL",
-            If(final_output_seen,
+            # A stopped playback does not wait for the paced output to drain;
+            # the host flushes the remaining words with the frontend reset.
+            If(final_output_seen | stop_pending,
                 *_finish_transfer(self.done, self.irq),
                 NextState("IDLE")
             )

--- a/litex_m2sdr/software/user/libliteeth/etherbone.c
+++ b/litex_m2sdr/software/user/libliteeth/etherbone.c
@@ -838,8 +838,7 @@ struct eb_connection *eb_connect(const char *addr, const char *port, int is_dire
     struct addrinfo* res = 0;
     int err;
     int sock = -1;
-    int rx_socket = -1;
-    int tx_socket = -1;
+    int direct_socket = -1;
 
     struct eb_connection *conn = malloc(sizeof(struct eb_connection));
     if (!conn) {
@@ -867,43 +866,29 @@ struct eb_connection *eb_connect(const char *addr, const char *port, int is_dire
     conn->is_direct = is_direct;
 
     if (is_direct) {
-        // Rx half
+        /* Use one ephemeral UDP socket for both request and reply traffic.
+         * The shared gateware Etherbone frontend returns replies to the
+         * request's source port, so every process can own an independent
+         * socket instead of racing on a shared bind to the service port. */
         struct sockaddr_in si_me;
 
         memset((char *) &si_me, 0, sizeof(si_me));
         si_me.sin_family = res->ai_family;
-        si_me.sin_port = ((struct sockaddr_in *)res->ai_addr)->sin_port;
+        si_me.sin_port = htobe16(0);
         si_me.sin_addr.s_addr = htobe32(INADDR_ANY);
 
-        if ((rx_socket = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
-            fprintf(stderr, "Unable to create Rx socket: %s\n", strerror(errno));
+        direct_socket = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        if (direct_socket == -1) {
+            fprintf(stderr, "Unable to create Etherbone socket: %s\n", strerror(errno));
             goto error;
         }
-        /* Enable address reuse on RX Socket */
-        int opt = 1;
-        if (setsockopt(rx_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-            fprintf(stderr, "setsockopt(SO_REUSEADDR) on rx_socket failed: %s\n", strerror(errno));
-            goto error;
-        }
-        if (bind(rx_socket, (struct sockaddr*)&si_me, sizeof(si_me)) == -1) {
-            fprintf(stderr, "Unable to bind Rx socket to port: %s\n", strerror(errno));
+        if (bind(direct_socket, (struct sockaddr*)&si_me, sizeof(si_me)) == -1) {
+            fprintf(stderr, "Unable to bind Etherbone socket: %s\n", strerror(errno));
             goto error;
         }
 
-        // Tx half
-        tx_socket = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-        if (tx_socket == -1) {
-            fprintf(stderr, "Unable to create socket: %s\n", strerror(errno));
-            goto error;
-        }
-        /* Enable address reuse on TX Socket */
-        if (setsockopt(tx_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-            fprintf(stderr, "setsockopt(SO_REUSEADDR) on tx_socket failed: %s\n", strerror(errno));
-            goto error;
-        }
-
-        conn->read_fd = rx_socket;
-        conn->fd = tx_socket;
+        conn->read_fd = direct_socket;
+        conn->fd = direct_socket;
         conn->addr = res;
         eb_drain_direct_rx(conn);
         usleep(EB_DIRECT_RX_SETTLE_US);
@@ -938,10 +923,8 @@ struct eb_connection *eb_connect(const char *addr, const char *port, int is_dire
     return conn;
 
 error:
-    if (rx_socket >= 0)
-        close(rx_socket);
-    if (tx_socket >= 0)
-        close(tx_socket);
+    if (direct_socket >= 0)
+        close(direct_socket);
     if (sock >= 0)
         close(sock);
     if (res)
@@ -958,7 +941,7 @@ void eb_disconnect(struct eb_connection **conn) {
         freeaddrinfo((*conn)->addr);
     if ((*conn)->fd >= 0)
         close((*conn)->fd);
-    if ((*conn)->read_fd >= 0)
+    if ((*conn)->read_fd >= 0 && (*conn)->read_fd != (*conn)->fd)
         close((*conn)->read_fd);
     free(*conn);
     *conn = NULL;

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
@@ -1403,6 +1403,40 @@ int m2sdr_rf_bind(struct m2sdr_dev *dev, void *phy)
 
 /* Execute the full RF bring-up sequence: clocks, AD9361 init, rates, gains,
  * loopback, bit mode, and optional built-in tests. */
+/* Publish the applied stream parameters to the active-config mailbox CSRs so
+ * other processes (e.g. m2sdr_sata capture-current) can read them. Best
+ * effort: the CSRs only exist on gateware built with the mailbox. */
+static void m2sdr_publish_active_sample_rate(struct m2sdr_dev *dev, int64_t rate)
+{
+#ifdef CSR_AD9361_ACTIVE_SAMPLE_RATE_ADDR
+    (void)m2sdr_reg_write(dev, CSR_AD9361_ACTIVE_SAMPLE_RATE_ADDR, (uint32_t)rate);
+#else
+    (void)dev;
+    (void)rate;
+#endif
+}
+
+static void m2sdr_publish_active_rx_freq(struct m2sdr_dev *dev, int64_t freq)
+{
+#ifdef CSR_AD9361_ACTIVE_RX_FREQUENCY_KHZ_ADDR
+    (void)m2sdr_reg_write(dev, CSR_AD9361_ACTIVE_RX_FREQUENCY_KHZ_ADDR,
+                          (uint32_t)(freq / 1000));
+#else
+    (void)dev;
+    (void)freq;
+#endif
+}
+
+static void m2sdr_publish_active_bandwidth(struct m2sdr_dev *dev, int64_t bw)
+{
+#ifdef CSR_AD9361_ACTIVE_BANDWIDTH_ADDR
+    (void)m2sdr_reg_write(dev, CSR_AD9361_ACTIVE_BANDWIDTH_ADDR, (uint32_t)bw);
+#else
+    (void)dev;
+    (void)bw;
+#endif
+}
+
 int m2sdr_apply_config(struct m2sdr_dev *dev, const struct m2sdr_config *cfg)
 {
     void *conn;
@@ -1538,6 +1572,9 @@ int m2sdr_apply_config(struct m2sdr_dev *dev, const struct m2sdr_config *cfg)
     }
 
     m2sdr_store_applied_config(dev, cfg);
+    m2sdr_publish_active_sample_rate(dev, cfg->sample_rate);
+    m2sdr_publish_active_rx_freq(dev, cfg->rx_freq);
+    m2sdr_publish_active_bandwidth(dev, cfg->bandwidth);
     return M2SDR_ERR_OK;
 }
 
@@ -1593,6 +1630,7 @@ int m2sdr_set_frequency(struct m2sdr_dev *dev, enum m2sdr_direction direction, u
         /* The RX LO retune re-runs the AD9361 quad cal, which reverts the QEC
          * loop gain to the inert default; re-apply the fix so it sticks. */
         m2sdr_apply_rx_qec_kexp(phy);
+        m2sdr_publish_active_rx_freq(dev, freq);
     }
 
     return M2SDR_ERR_OK;
@@ -1650,6 +1688,7 @@ int m2sdr_set_sample_rate(struct m2sdr_dev *dev, int64_t rate)
 
         dev->rf_oversample_enabled = wide ? 1 : 0;
     }
+    m2sdr_publish_active_sample_rate(dev, rate);
     return M2SDR_ERR_OK;
 }
 
@@ -1671,6 +1710,7 @@ int m2sdr_set_bandwidth(struct m2sdr_dev *dev, int64_t bw)
         return M2SDR_ERR_IO;
     if (m2sdr_from_ad9361_rc(ad9361_set_tx_rf_bandwidth(phy, bw)) != M2SDR_ERR_OK)
         return M2SDR_ERR_IO;
+    m2sdr_publish_active_bandwidth(dev, bw);
     return M2SDR_ERR_OK;
 }
 

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_sata.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_sata.c
@@ -15,7 +15,9 @@
 
 #if defined(CSR_SATA_PHY_BASE) && defined(CSR_SATA_IDENTIFY_BASE)
 
-#define SATA_IDENT_WORDS 128
+/* Full 512-byte ATA IDENTIFY block. Draining all of it keeps no residue in
+ * the identify FIFO for the next identify. */
+#define SATA_IDENT_WORDS 256
 #define SATA_DEFAULT_IDENT_TIMEOUT_MS 1000u
 
 static int sata_read32(struct m2sdr_dev *dev, uint32_t addr, uint32_t *val)
@@ -99,6 +101,24 @@ static void sata_decode_identify(struct m2sdr_sata_info *info, const uint16_t *w
     info->logical_sector_size = logical_sector_size;
 }
 
+/* Poll the identify engine's done flag; *done reflects the last read. */
+static int sata_identify_wait_done(struct m2sdr_dev *dev, unsigned timeout_ms,
+                                   unsigned poll_ms, bool *done)
+{
+    unsigned elapsed_ms = 0;
+    uint32_t value = 0;
+
+    for (;;) {
+        if (sata_read32(dev, CSR_SATA_IDENTIFY_DONE_ADDR, &value) != 0)
+            return M2SDR_ERR_IO;
+        *done = (value & 0x1u) != 0;
+        if (*done || elapsed_ms >= timeout_ms)
+            return M2SDR_ERR_OK;
+        sata_msleep(poll_ms);
+        elapsed_ms += poll_ms;
+    }
+}
+
 #endif
 
 int m2sdr_get_sata_info(struct m2sdr_dev *dev, struct m2sdr_sata_info *info, unsigned timeout_ms)
@@ -108,6 +128,11 @@ int m2sdr_get_sata_info(struct m2sdr_dev *dev, struct m2sdr_sata_info *info, uns
     uint16_t words[SATA_IDENT_WORDS];
     unsigned elapsed_ms = 0;
     unsigned poll_ms = 10;
+    /* Link training completes within milliseconds or not at all; only the
+     * identify phases need the extended budget for drives stalled by
+     * garbage collection. */
+    unsigned phy_timeout_ms = timeout_ms < 1000 ? timeout_ms : 1000;
+    bool idle = false;
 
     if (!dev || !info)
         return M2SDR_ERR_INVAL;
@@ -141,39 +166,60 @@ int m2sdr_get_sata_info(struct m2sdr_dev *dev, struct m2sdr_sata_info *info, uns
 
         if (info->phy_ready)
             break;
-        if (elapsed_ms >= timeout_ms)
+        if (elapsed_ms >= phy_timeout_ms)
             return M2SDR_ERR_OK;
         sata_msleep(poll_ms);
         elapsed_ms += poll_ms;
     }
+
+    /* A previous identify can still be in flight: a drive busy with garbage
+     * collection can spread the PIO data over hundreds of milliseconds, and
+     * the identify FSM silently ignores a start while it is receiving. Wait
+     * for it to go idle instead of firing a start into a busy engine. */
+    if (sata_identify_wait_done(dev, timeout_ms, poll_ms, &idle) != M2SDR_ERR_OK)
+        return M2SDR_ERR_IO;
+    if (!idle)
+        return M2SDR_ERR_OK;
 
     if (sata_write32(dev, CSR_SATA_IDENTIFY_START_ADDR, 1) != 0)
         return M2SDR_ERR_IO;
 
-    elapsed_ms = 0;
-    for (;;) {
-        if (sata_read32(dev, CSR_SATA_IDENTIFY_DONE_ADDR, &value) != 0)
-            return M2SDR_ERR_IO;
-        info->identify_done = (value & 0x1u) != 0;
-        if (info->identify_done)
-            break;
-        if (elapsed_ms >= timeout_ms)
-            return M2SDR_ERR_OK;
-        sata_msleep(poll_ms);
-        elapsed_ms += poll_ms;
-    }
+    if (sata_identify_wait_done(dev, timeout_ms, poll_ms,
+                                &info->identify_done) != M2SDR_ERR_OK)
+        return M2SDR_ERR_IO;
+    if (!info->identify_done)
+        return M2SDR_ERR_OK;
 
-    for (unsigned i = 0; i < SATA_IDENT_WORDS; i += 2) {
+    /* Drain the complete identify block. The FIFO can momentarily run empty
+     * while a slow transfer is still arriving, so retry on empty until the
+     * block is complete or the timeout budget is spent. Draining everything
+     * also keeps no residue behind for the next identify. */
+    unsigned drained  = 0;
+    unsigned empty_ms = 0;
+    while (drained < SATA_IDENT_WORDS && empty_ms < timeout_ms) {
         if (sata_read32(dev, CSR_SATA_IDENTIFY_SOURCE_VALID_ADDR, &value) != 0)
             return M2SDR_ERR_IO;
-        if ((value & 0x1u) == 0)
-            break;
+        if ((value & 0x1u) == 0) {
+            sata_msleep(poll_ms);
+            empty_ms += poll_ms;
+            continue;
+        }
+        empty_ms = 0;
         if (sata_read32(dev, CSR_SATA_IDENTIFY_SOURCE_DATA_ADDR, &value) != 0)
             return M2SDR_ERR_IO;
         if (sata_write32(dev, CSR_SATA_IDENTIFY_SOURCE_READY_ADDR, 1) != 0)
             return M2SDR_ERR_IO;
-        words[i + 0] = (uint16_t)((value >>  0) & 0xffffu);
-        words[i + 1] = (uint16_t)((value >> 16) & 0xffffu);
+        words[drained + 0] = (uint16_t)((value >>  0) & 0xffffu);
+        words[drained + 1] = (uint16_t)((value >> 16) & 0xffffu);
+        drained += 2;
+    }
+
+    /* A half-up link (e.g. right after drive hot-plug) can complete with a
+     * partial identify block. Decoding the zero-filled tail silently reports
+     * a bogus LBA28-sized drive, so require the full block. */
+    if (drained < SATA_IDENT_WORDS) {
+        info->identify_done = false;
+        return M2SDR_ERR_OK;
     }
 
     sata_decode_identify(info, words);

--- a/litex_m2sdr/software/user/m2sdr_sata.c
+++ b/litex_m2sdr/software/user/m2sdr_sata.c
@@ -3070,7 +3070,9 @@ static void status(void)
 #ifdef CSR_SATA_PHY_BASE
     {
         struct m2sdr_sata_info sata_info;
-        int sata_rc = m2sdr_get_sata_info(conn, &sata_info, 1000);
+        /* A drive busy with garbage collection can stall IDENTIFY for
+         * seconds; a short budget misreports it as absent. */
+        int sata_rc = m2sdr_get_sata_info(conn, &sata_info, 5000);
 
         printf("SATA:\n");
         if (sata_rc == M2SDR_ERR_OK) {

--- a/litex_m2sdr/software/user/m2sdr_sata.c
+++ b/litex_m2sdr/software/user/m2sdr_sata.c
@@ -655,6 +655,79 @@ static enum sata_wait_result wait_done_quiet(const char *name,
         0.0, 0.0, false);
 }
 
+/* An accepted ATA command cannot be aborted: resetting the streamer frontend
+ * abandons it mid-transfer and the SATA core keeps its crossbar grant until
+ * the FPGA bitstream is reloaded. When a streamer wait is interrupted,
+ * request a stop at the current command boundary when the gateware supports
+ * it, otherwise finish the programmed transfer; unpacing a replay lets the
+ * remainder drain as fast as the destination accepts. A second interrupt
+ * abandons the transfer with an explicit recovery warning.
+ *
+ * A stopped transfer is deliberately reported as interrupted so callers
+ * reset the frontend (flushing FIFO leftovers) and do not register a
+ * partial capture; a fully drained transfer keeps its normal result. */
+static enum sata_wait_result wait_finish_interrupted(const char *name,
+                                                     uint32_t (*done_fn)(void *),
+                                                     uint32_t (*err_fn)(void *),
+                                                     uint32_t (*progress_fn)(void *),
+                                                     void *conn,
+                                                     int timeout_ms,
+                                                     uint64_t nsectors,
+                                                     bool rx, bool tx,
+                                                     bool allow_stop)
+{
+    bool graceful = allow_stop && sata_streamer_stop_supported(rx, tx);
+    enum sata_wait_result rc;
+
+    keep_running = 1;
+    if (tx)
+        sata_tx_set_pace(conn, 0);
+    if (graceful) {
+        sata_streamer_request_stop(conn, rx, tx);
+        fprintf(stderr,
+            "%s: interrupted; stopping at the current SATA command boundary "
+            "(Ctrl-C again to abandon immediately).\n", name);
+    } else {
+        fprintf(stderr,
+            "%s: interrupted; finishing the programmed transfer so the SATA "
+            "core stays usable (Ctrl-C again to abandon it).\n", name);
+    }
+    rc = wait_done_report(name, done_fn, err_fn, progress_fn, conn, timeout_ms,
+        nsectors, 0.0, 0.0, true);
+    if (rc != SATA_WAIT_OK) {
+        fprintf(stderr,
+            "%s: abandoned with a SATA command in flight; SATA commands will "
+            "hang until the FPGA bitstream is reloaded.\n", name);
+        return rc;
+    }
+    return graceful ? SATA_WAIT_INTERRUPTED : SATA_WAIT_OK;
+}
+
+/* Wait for a streamer transfer, finishing it cleanly when interrupted. The
+ * direction selects the done/error/progress accessors; allow_stop selects
+ * whether an interrupt may stop at the next command boundary (a multi-step
+ * caller like copy finishes its current single-sector command instead). */
+static enum sata_wait_result wait_streamer_transfer(const char *name, bool rx,
+                                                    void *conn, int timeout_ms,
+                                                    uint64_t nsectors,
+                                                    double capture_mibps,
+                                                    double capture_seconds,
+                                                    bool allow_stop)
+{
+    uint32_t (*done_fn)(void *) = rx ? sata_rx_done  : sata_tx_done;
+    uint32_t (*err_fn)(void *)  = rx ? sata_rx_error : sata_tx_error;
+    uint32_t (*progress_fn)(void *) = rx ?
+        (sata_rx_progress_supported() ? sata_rx_progress : NULL) :
+        (sata_tx_progress_supported() ? sata_tx_progress : NULL);
+    enum sata_wait_result rc;
+
+    rc = wait_done_report(name, done_fn, err_fn, progress_fn, conn, timeout_ms,
+        nsectors, capture_mibps, capture_seconds, true);
+    if (rc == SATA_WAIT_INTERRUPTED)
+        rc = wait_finish_interrupted(name, done_fn, err_fn, progress_fn, conn,
+            timeout_ms, nsectors, rx, !rx, allow_stop);
+    return rc;
+}
 
 static void print_planned_transfer(const char *name,
                                    uint64_t src_sector,
@@ -2326,11 +2399,10 @@ static int do_record(uint64_t dst_sector, uint32_t nsectors, int timeout_ms,
 
     sata_rx_set_tap(conn, tap);
     sata_rx_start(conn);
-    uint32_t (*progress_fn)(void *) =
-        sata_rx_progress_supported() ? sata_rx_progress : NULL;
-    enum sata_wait_result rc = wait_done_report(name, sata_rx_done,
-        sata_rx_error, progress_fn, conn, timeout_ms, nsectors,
-        capture_mibps, capture_seconds, true);
+    enum sata_wait_result rc = wait_streamer_transfer(name, true, conn,
+        timeout_ms, nsectors, capture_mibps, capture_seconds, true);
+    /* The tap keeps feeding the reservoir while an interrupted transfer
+     * finishes; disabling it earlier would starve the in-flight command. */
     sata_rx_set_tap(conn, false);
     if (rc != SATA_WAIT_OK)
         sata_streamers_reset(conn, true, false);
@@ -2383,10 +2455,8 @@ static int do_play(uint64_t src_sector, uint32_t nsectors, int timeout_ms, bool 
     sata_tx_set_pace(conn, 0);
     sata_tx_start(conn);
 
-    uint32_t (*play_progress_fn)(void *) =
-        sata_tx_progress_supported() ? sata_tx_progress : NULL;
-    enum sata_wait_result rc = wait_done_report("SATA_TX(play)", sata_tx_done,
-        sata_tx_error, play_progress_fn, conn, timeout_ms, nsectors, 0.0, 0.0, true);
+    enum sata_wait_result rc = wait_streamer_transfer("SATA_TX(play)", false,
+        conn, timeout_ms, nsectors, 0.0, 0.0, true);
     if (rc != SATA_WAIT_OK)
         sata_streamers_reset(conn, false, true);
     sata_operation_finish(&op);
@@ -2455,10 +2525,8 @@ static int do_replay(uint64_t src_sector, uint32_t nsectors, const char *dst_s,
     }
     sata_tx_start(conn);
 
-    uint32_t (*replay_progress_fn)(void *) =
-        sata_tx_progress_supported() ? sata_tx_progress : NULL;
-    enum sata_wait_result rc = wait_done_report("SATA_TX(replay)", sata_tx_done,
-        sata_tx_error, replay_progress_fn, conn, timeout_ms, nsectors, 0.0, 0.0, true);
+    enum sata_wait_result rc = wait_streamer_transfer("SATA_TX(replay)", false,
+        conn, timeout_ms, nsectors, 0.0, 0.0, true);
     if (rc != SATA_WAIT_OK)
         sata_streamers_reset(conn, false, true);
     sata_operation_finish(&op);
@@ -2499,12 +2567,31 @@ static int do_copy(uint64_t src_sector, uint64_t dst_sector, uint32_t nsectors, 
         usleep(SATA_COPY_RX_TX_START_DELAY_US);
         sata_tx_start(conn);
 
+        bool user_abort = false;
+
         tx_rc = wait_done_quiet("SATA_TX(copy-src)", sata_tx_done, sata_tx_error, conn, timeout_ms);
-        if (tx_rc == SATA_WAIT_OK)
+        if (tx_rc == SATA_WAIT_INTERRUPTED) {
+            tx_rc = wait_finish_interrupted("SATA_TX(copy-src)", sata_tx_done,
+                sata_tx_error, NULL, conn, timeout_ms, 1, false, true, false);
+            user_abort = true;
+        }
+        if (tx_rc == SATA_WAIT_OK) {
             rx_rc = wait_done_quiet("SATA_RX(copy-dst)", sata_rx_done, sata_rx_error, conn, timeout_ms);
+            if (rx_rc == SATA_WAIT_INTERRUPTED) {
+                rx_rc = wait_finish_interrupted("SATA_RX(copy-dst)", sata_rx_done,
+                    sata_rx_error, NULL, conn, timeout_ms, 1, true, false, false);
+                user_abort = true;
+            }
+        }
 
         if (tx_rc != SATA_WAIT_OK || rx_rc != SATA_WAIT_OK) {
             sata_streamers_reset(conn, true, true);
+            rc = 1;
+            break;
+        }
+        if (user_abort) {
+            fprintf(stderr, "copy: interrupted after %" PRIu32
+                " sectors; both streamers are idle.\n", i + 1);
             rc = 1;
             break;
         }
@@ -2565,6 +2652,23 @@ static int do_stream_stop(const char *which_s, bool dry_run)
 #ifdef M2SDR_CSR_SATA_STREAMER_CONTROL_ADDR
     if (rx)
         sata_rx_set_tap(conn, false);
+    /* Stop an active transfer at its command boundary before resetting the
+     * frontend, so a reset never abandons an accepted ATA command (which
+     * would keep the SATA core busy until a bitstream reload). */
+    if (sata_streamer_stop_supported(rx, tx)) {
+        bool rx_busy = rx && !sata_rx_done(conn);
+        bool tx_busy = tx && !sata_tx_done(conn);
+
+        if (rx_busy || tx_busy) {
+            sata_streamer_request_stop(conn, rx_busy, tx_busy);
+            for (int waited_ms = 0; waited_ms < 10000; waited_ms += 10) {
+                if ((!rx_busy || sata_rx_done(conn)) &&
+                    (!tx_busy || sata_tx_done(conn)))
+                    break;
+                usleep(10000);
+            }
+        }
+    }
     sata_streamers_reset(conn, rx, tx);
     printf("SATA streamer reset: %s\n", which_s);
     m2sdr_close_dev(conn);

--- a/litex_m2sdr/software/user/m2sdr_sata.c
+++ b/litex_m2sdr/software/user/m2sdr_sata.c
@@ -2424,6 +2424,15 @@ static int do_replay(uint64_t src_sector, uint32_t nsectors, const char *dst_s,
 
     int rxdst = parse_rxdst(dst_s);
 
+    /* An Ethernet replay needs a resolvable UDP destination before the RX
+     * path is routed to the LiteEth streamer; see
+     * sata_eth_replay_destination_prepare(). */
+    if (rxdst == RXDST_ETH && !dry_run &&
+        sata_eth_replay_destination_prepare(conn) != 0) {
+        sata_operation_finish(&op);
+        return 1;
+    }
+
     /* SATA -> TX -> loopback -> RX destination. */
     crossbar_set(conn, TXSRC_SATA, rxdst);
     txrx_loopback_set(conn, 1);

--- a/litex_m2sdr/software/user/m2sdr_sata.c
+++ b/litex_m2sdr/software/user/m2sdr_sata.c
@@ -341,29 +341,49 @@ static unsigned capture_volume_entry_channel_count(const struct sata_capture_ent
     return 0;
 }
 
-static void format_capture_duration(char *buf, size_t len, const struct sata_capture_entry *e)
+/* Byte rate of a capture entry's sample stream; 0 when the metadata is
+ * invalid or the rate overflows. */
+static uint64_t capture_volume_entry_bytes_per_second(const struct sata_capture_entry *e)
 {
     enum m2sdr_format format;
     unsigned channels;
     size_t sample_bytes;
-    uint64_t bytes;
-    long double seconds;
 
     if (!e || e->sample_rate <= 0 ||
-        m2sdr_cli_parse_format(e->format, &format) != 0) {
-        snprintf(buf, len, "-");
-        return;
-    }
-    channels = capture_volume_entry_channel_count(e);
+        m2sdr_cli_parse_format(e->format, &format) != 0)
+        return 0;
+    channels     = capture_volume_entry_channel_count(e);
     sample_bytes = m2sdr_format_size(format);
-    bytes = capture_volume_entry_payload_bytes(e);
-    if (channels == 0 || sample_bytes == 0 || bytes == 0) {
+    if (channels == 0 || sample_bytes == 0 ||
+        (uint64_t)e->sample_rate > UINT64_MAX / channels / sample_bytes)
+        return 0;
+    return (uint64_t)e->sample_rate * channels * sample_bytes;
+}
+
+static void format_capture_duration(char *buf, size_t len, const struct sata_capture_entry *e)
+{
+    uint64_t bytes_per_second = capture_volume_entry_bytes_per_second(e);
+    uint64_t bytes            = capture_volume_entry_payload_bytes(e);
+
+    if (bytes_per_second == 0 || bytes == 0) {
         snprintf(buf, len, "-");
         return;
     }
-    seconds = (long double)bytes /
-              ((long double)e->sample_rate * (long double)channels * (long double)sample_bytes);
-    snprintf(buf, len, "%.3Lfs", seconds);
+    snprintf(buf, len, "%.3Lfs", (long double)bytes / (long double)bytes_per_second);
+}
+
+static int capture_volume_entry_replay_word_rate(
+    const struct sata_capture_entry *e, uint32_t *words_per_second)
+{
+    uint64_t bytes_per_second = capture_volume_entry_bytes_per_second(e);
+
+    if (!words_per_second || bytes_per_second == 0 ||
+        bytes_per_second > (uint64_t)UINT32_MAX * 8u) {
+        fprintf(stderr, "Capture has an invalid or out-of-range replay rate.\n");
+        return 1;
+    }
+    *words_per_second = (uint32_t)((bytes_per_second + 7u) / 8u);
+    return 0;
 }
 
 #endif
@@ -527,10 +547,13 @@ static enum sata_wait_result wait_done_report(const char *name,
                     double rate_error = mibps / capture_mibps;
                     double time_error = elapsed_s - capture_seconds;
 
-                    if (rate_error < 0.95 || rate_error > 1.05) {
+                    if ((rate_error < 0.95 || rate_error > 1.05) &&
+                        (time_error < -0.5 || time_error > 0.5)) {
                         fprintf(stderr,
                             "%s: warning: stream average %.2f MiB/s differs from requested capture %.2f MiB/s; "
-                            "elapsed %.3f s vs requested %.3f s. Check RF clock/sample-rate configuration.\n",
+                            "elapsed %.3f s vs requested %.3f s. The RX source may exceed sustained SATA "
+                            "write throughput and backpressure the live host stream; check the RF sample "
+                            "rate and reduce sample rate, bit depth, or channel count.\n",
                             name, mibps, capture_mibps, elapsed_s, capture_seconds);
                     } else if (time_error < -0.5 || time_error > 0.5) {
                         fprintf(stderr,
@@ -622,31 +645,6 @@ static enum sata_wait_result wait_done_report(const char *name,
     }
 }
 
-static enum sata_wait_result wait_done(const char *name,
-                                       uint32_t (*done_fn)(void *),
-                                       uint32_t (*err_fn)(void *),
-                                       void *conn,
-                                       int timeout_ms,
-                                       uint64_t nsectors)
-{
-    return wait_done_report(name, done_fn, err_fn, NULL, conn, timeout_ms, nsectors,
-        0.0, 0.0, true);
-}
-
-static enum sata_wait_result wait_done_capture(const char *name,
-                                               uint32_t (*done_fn)(void *),
-                                               uint32_t (*err_fn)(void *),
-                                               uint32_t (*progress_fn)(void *),
-                                               void *conn,
-                                               int timeout_ms,
-                                               uint64_t nsectors,
-                                               double capture_mibps,
-                                               double capture_seconds)
-{
-    return wait_done_report(name, done_fn, err_fn, progress_fn, conn, timeout_ms, nsectors,
-        capture_mibps, capture_seconds, true);
-}
-
 static enum sata_wait_result wait_done_quiet(const char *name,
                                              uint32_t (*done_fn)(void *),
                                              uint32_t (*err_fn)(void *),
@@ -656,6 +654,7 @@ static enum sata_wait_result wait_done_quiet(const char *name,
     return wait_done_report(name, done_fn, err_fn, NULL, conn, timeout_ms, 1,
         0.0, 0.0, false);
 }
+
 
 static void print_planned_transfer(const char *name,
                                    uint64_t src_sector,
@@ -2282,38 +2281,59 @@ static int do_verify_pattern(uint64_t src_sector, uint32_t nsectors,
 #endif
 
 static int do_record(uint64_t dst_sector, uint32_t nsectors, int timeout_ms,
-                     bool dry_run, double capture_mibps, double capture_seconds)
+                     bool dry_run, double capture_mibps, double capture_seconds,
+                     bool tap)
 {
+    if (tap && !sata_rx_tap_supported()) {
+        fprintf(stderr,
+            "capture-current requires gateware with the SATA RX tap. "
+            "Rebuild and reload the FPGA bitstream.\n");
+        return 1;
+    }
+
     struct sata_operation op = sata_operation_begin();
     struct m2sdr_dev *conn = op.conn;
     int txsrc = (int)m2sdr_read32(conn, CSR_CROSSBAR_MUX_SEL_ADDR);
+    int rxdst = RXDST_SATA;
+    const char *name = tap ? "SATA_RX(tap)" : "SATA_RX(record)";
 
-    /* Normal path: RX -> demux -> SATA_RX_STREAMER. */
-    txrx_loopback_set(conn, 0);
-    crossbar_set(conn,
-        txsrc,
-        RXDST_SATA
-    );
+    if (tap) {
+        /* Tap mode duplicates the live host RX stream without rerouting it. */
+        rxdst = (int)m2sdr_read32(conn, CSR_CROSSBAR_DEMUX_SEL_ADDR);
+        if (rxdst != RXDST_PCIE && rxdst != RXDST_ETH) {
+            fprintf(stderr,
+                "capture-current requires an active PCIe or Ethernet RX path; "
+                "the current RX destination is %d.\n", rxdst);
+            sata_operation_finish(&op);
+            return 1;
+        }
+    } else {
+        /* Normal path: RX -> demux -> SATA_RX_STREAMER. */
+        txrx_loopback_set(conn, 0);
+        crossbar_set(conn, txsrc, RXDST_SATA);
+    }
 
+    /* A previous capture (or a still-tapped source) can leave prefetched
+     * words in the reservoir; start every capture from an empty FIFO. */
+    sata_streamers_reset(conn, true, false);
     sata_rx_program(conn, dst_sector, nsectors);
     if (dry_run) {
-        print_planned_transfer("record", UINT64_MAX, dst_sector, nsectors, txsrc, RXDST_SATA, 0, timeout_ms);
+        print_planned_transfer(tap ? "record-current" : "record", UINT64_MAX,
+            dst_sector, nsectors, txsrc, rxdst, 0, timeout_ms);
         sata_operation_finish(&op);
         return 0;
     }
-    sata_rx_start(conn);
 
+    sata_rx_set_tap(conn, tap);
+    sata_rx_start(conn);
     uint32_t (*progress_fn)(void *) =
         sata_rx_progress_supported() ? sata_rx_progress : NULL;
-    enum sata_wait_result rc;
-
-    if (capture_mibps > 0.0) {
-        rc = wait_done_capture("SATA_RX(record)", sata_rx_done, sata_rx_error,
-            progress_fn, conn, timeout_ms, nsectors, capture_mibps, capture_seconds);
-    } else {
-        rc = wait_done_report("SATA_RX(record)", sata_rx_done, sata_rx_error,
-            progress_fn, conn, timeout_ms, nsectors, 0.0, 0.0, true);
-    }
+    enum sata_wait_result rc = wait_done_report(name, sata_rx_done,
+        sata_rx_error, progress_fn, conn, timeout_ms, nsectors,
+        capture_mibps, capture_seconds, true);
+    sata_rx_set_tap(conn, false);
+    if (rc != SATA_WAIT_OK)
+        sata_streamers_reset(conn, true, false);
     sata_operation_finish(&op);
     return rc == SATA_WAIT_OK ? 0 : 1;
 }
@@ -2326,6 +2346,7 @@ static int do_record_start(uint64_t dst_sector, uint32_t nsectors, int timeout_m
     sata_require_csrs();
     txrx_loopback_set(conn, 0);
     crossbar_set(conn, txsrc, RXDST_SATA);
+    sata_streamers_reset(conn, true, false);
     sata_rx_program(conn, dst_sector, nsectors);
     if (dry_run) {
         print_planned_transfer("record-start", UINT64_MAX, dst_sector, nsectors, txsrc, RXDST_SATA, 0, timeout_ms);
@@ -2352,16 +2373,22 @@ static int do_play(uint64_t src_sector, uint32_t nsectors, int timeout_ms, bool 
         rxdst
     );
 
+    sata_streamers_reset(conn, false, true);
     sata_tx_program(conn, src_sector, nsectors);
     if (dry_run) {
         print_planned_transfer("play", src_sector, UINT64_MAX, nsectors, TXSRC_SATA, rxdst, 0, timeout_ms);
         sata_operation_finish(&op);
         return 0;
     }
+    sata_tx_set_pace(conn, 0);
     sata_tx_start(conn);
 
-    enum sata_wait_result rc =
-        wait_done("SATA_TX(play)", sata_tx_done, sata_tx_error, conn, timeout_ms, nsectors);
+    uint32_t (*play_progress_fn)(void *) =
+        sata_tx_progress_supported() ? sata_tx_progress : NULL;
+    enum sata_wait_result rc = wait_done_report("SATA_TX(play)", sata_tx_done,
+        sata_tx_error, play_progress_fn, conn, timeout_ms, nsectors, 0.0, 0.0, true);
+    if (rc != SATA_WAIT_OK)
+        sata_streamers_reset(conn, false, true);
     sata_operation_finish(&op);
     return rc == SATA_WAIT_OK ? 0 : 1;
 }
@@ -2374,12 +2401,14 @@ static int do_play_start(uint64_t src_sector, uint32_t nsectors, int timeout_ms,
     sata_require_csrs();
     txrx_loopback_set(conn, 0);
     crossbar_set(conn, TXSRC_SATA, rxdst);
+    sata_streamers_reset(conn, false, true);
     sata_tx_program(conn, src_sector, nsectors);
     if (dry_run) {
         print_planned_transfer("play-start", src_sector, UINT64_MAX, nsectors, TXSRC_SATA, rxdst, 0, timeout_ms);
         m2sdr_close_dev(conn);
         return 0;
     }
+    sata_tx_set_pace(conn, 0);
     sata_tx_start(conn);
     printf("SATA_TX(play): started sector=0x%016" PRIx64 " nsectors=%" PRIu32 "\n",
         src_sector, nsectors);
@@ -2387,7 +2416,8 @@ static int do_play_start(uint64_t src_sector, uint32_t nsectors, int timeout_ms,
     return 0;
 }
 
-static int do_replay(uint64_t src_sector, uint32_t nsectors, const char *dst_s, int timeout_ms, bool dry_run)
+static int do_replay(uint64_t src_sector, uint32_t nsectors, const char *dst_s,
+                     uint32_t words_per_second, int timeout_ms, bool dry_run)
 {
     struct sata_operation op = sata_operation_begin();
     struct m2sdr_dev *conn = op.conn;
@@ -2398,16 +2428,30 @@ static int do_replay(uint64_t src_sector, uint32_t nsectors, const char *dst_s, 
     crossbar_set(conn, TXSRC_SATA, rxdst);
     txrx_loopback_set(conn, 1);
 
+    sata_streamers_reset(conn, false, true);
     sata_tx_program(conn, src_sector, nsectors);
     if (dry_run) {
         print_planned_transfer("replay", src_sector, UINT64_MAX, nsectors, TXSRC_SATA, rxdst, 1, timeout_ms);
+        printf("  Replay pace        %" PRIu32 " x 64-bit words/s\n",
+            words_per_second);
         sata_operation_finish(&op);
         return 0;
     }
+    sata_tx_set_pace(conn, words_per_second);
+    if (words_per_second != 0) {
+        printf("SATA_TX(replay): pacing at %" PRIu32
+               " x 64-bit words/s (%.2f MiB/s)\n",
+            words_per_second,
+            (double)words_per_second * 8.0 / (1024.0 * 1024.0));
+    }
     sata_tx_start(conn);
 
-    enum sata_wait_result rc =
-        wait_done("SATA_TX(replay)", sata_tx_done, sata_tx_error, conn, timeout_ms, nsectors);
+    uint32_t (*replay_progress_fn)(void *) =
+        sata_tx_progress_supported() ? sata_tx_progress : NULL;
+    enum sata_wait_result rc = wait_done_report("SATA_TX(replay)", sata_tx_done,
+        sata_tx_error, replay_progress_fn, conn, timeout_ms, nsectors, 0.0, 0.0, true);
+    if (rc != SATA_WAIT_OK)
+        sata_streamers_reset(conn, false, true);
     sata_operation_finish(&op);
     return rc == SATA_WAIT_OK ? 0 : 1;
 }
@@ -2435,6 +2479,7 @@ static int do_copy(uint64_t src_sector, uint64_t dst_sector, uint32_t nsectors, 
         sata_operation_finish(&op);
         return 0;
     }
+    sata_tx_set_pace(conn, 0);
 
     for (uint32_t i = 0; i < nsectors; i++) {
         sata_rx_program(conn, dst_sector + i, 1);
@@ -2509,6 +2554,8 @@ static int do_stream_stop(const char *which_s, bool dry_run)
     sata_require_csrs();
 
 #ifdef M2SDR_CSR_SATA_STREAMER_CONTROL_ADDR
+    if (rx)
+        sata_rx_set_tap(conn, false);
     sata_streamers_reset(conn, rx, tx);
     printf("SATA streamer reset: %s\n", which_s);
     m2sdr_close_dev(conn);
@@ -2536,6 +2583,46 @@ static void capture_options_init(struct capture_options *opts)
 {
     memset(opts, 0, sizeof(*opts));
     named_transfer_options_init(&opts->named);
+}
+
+static int capture_options_from_active_stream(struct capture_options *opts)
+{
+#if defined(CSR_AD9361_ACTIVE_SAMPLE_RATE_ADDR) && \
+    defined(CSR_AD9361_ACTIVE_RX_FREQUENCY_KHZ_ADDR) && \
+    defined(CSR_AD9361_ACTIVE_BANDWIDTH_ADDR) && \
+    defined(CSR_AD9361_BITMODE_ADDR) && defined(CSR_AD9361_PHY_CONTROL_ADDR)
+    struct m2sdr_dev *conn = m2sdr_open_dev();
+    uint32_t sample_rate = m2sdr_read32(conn, CSR_AD9361_ACTIVE_SAMPLE_RATE_ADDR);
+    uint32_t frequency_khz = m2sdr_read32(conn, CSR_AD9361_ACTIVE_RX_FREQUENCY_KHZ_ADDR);
+    uint32_t bandwidth = m2sdr_read32(conn, CSR_AD9361_ACTIVE_BANDWIDTH_ADDR);
+    uint32_t format = m2sdr_read32(conn, CSR_AD9361_BITMODE_ADDR) & 0x3;
+    uint32_t one_channel = m2sdr_read32(conn, CSR_AD9361_PHY_CONTROL_ADDR) & 0x1;
+
+    m2sdr_close_dev(conn);
+    if (sample_rate == 0) {
+        fprintf(stderr,
+            "No active RF stream configuration is published. Start GQRX "
+            "and enable its DSP before capture-current.\n");
+        return 1;
+    }
+    if (format > 1) {
+        fprintf(stderr, "capture-current does not yet support active sample format %u.\n", format);
+        return 1;
+    }
+    opts->named.sample_rate = sample_rate;
+    opts->named.rx_freq = (uint64_t)frequency_khz * 1000;
+    opts->named.bandwidth = bandwidth;
+    opts->named.format = format ? M2SDR_FORMAT_SC8_Q7 : M2SDR_FORMAT_SC16_Q11;
+    opts->named.channel_layout = one_channel ?
+        M2SDR_CHANNEL_LAYOUT_1T1R : M2SDR_CHANNEL_LAYOUT_2T2R;
+    return 0;
+#else
+    (void)opts;
+    fprintf(stderr,
+        "capture-current requires active-stream status CSRs. "
+        "Rebuild the software and FPGA bitstream.\n");
+    return 1;
+#endif
 }
 
 static int parse_capture_option(struct capture_options *opts, int argc, char **argv, int *index)
@@ -2783,7 +2870,7 @@ static void parse_replay_rf_overrides(struct named_transfer_options *opts,
 
 static int do_capture_named(const char *name, int argc, char **argv, int argi,
                             int timeout_ms, bool timeout_explicit,
-                            bool start_only, bool dry_run)
+                            bool start_only, bool current_stream, bool dry_run)
 {
     struct sata_capture_volume cat;
     struct capture_options opts;
@@ -2797,6 +2884,8 @@ static int do_capture_named(const char *name, int argc, char **argv, int argi,
     double capture_mibps = 0.0;
 
     capture_options_init(&opts);
+    if (current_stream && capture_options_from_active_stream(&opts) != 0)
+        return 1;
     while (argi < argc) {
         if (!parse_capture_option(&opts, argc, argv, &argi)) {
             fprintf(stderr, "Unexpected argument: %s\n", argv[argi]);
@@ -2824,7 +2913,7 @@ static int do_capture_named(const char *name, int argc, char **argv, int argi,
         printf("%s dry-run: name=%s sector=0x%016" PRIx64 " nsectors=%" PRIu32
                " bytes=%" PRIu64 " sigmf_sector=0x%016" PRIx64 " sigmf_nsectors=%u"
                " sample_rate=%" PRId64 " format=%s channels=%s capture_rate=%.2f MiB/s\n",
-            start_only ? "capture-start" : "capture",
+            start_only ? "capture-start" : (current_stream ? "capture-current" : "capture"),
             name, sector, nsectors, bytes,
             meta_sector, M2SDR_SATA_SIGMF_META_SECTORS,
             opts.named.sample_rate,
@@ -2833,7 +2922,7 @@ static int do_capture_named(const char *name, int argc, char **argv, int argi,
         return 0;
     }
 
-    if (apply_rf_config_from_options(&opts.named) != 0)
+    if (!current_stream && apply_rf_config_from_options(&opts.named) != 0)
         return 1;
     if (start_only) {
         capture_volume_entry_from_options(&entry, name, &opts.named, sector, nsectors, bytes,
@@ -2850,8 +2939,12 @@ static int do_capture_named(const char *name, int argc, char **argv, int argi,
             name, sector, nsectors);
         return 0;
     } else {
-        if (do_record(sector, nsectors, timeout_ms, false,
-                      capture_mibps, capture_seconds) != 0)
+        int record_rc = current_stream ?
+            do_record(sector, nsectors, timeout_ms, false,
+                      capture_mibps, capture_seconds, true) :
+            do_record(sector, nsectors, timeout_ms, false,
+                      capture_mibps, capture_seconds, false);
+        if (record_rc != 0)
             return 1;
     }
 
@@ -2874,6 +2967,7 @@ static int do_replay_host_named(const char *name, int argc, char **argv, int arg
     struct sata_capture_volume cat;
     struct sata_capture_entry *e;
     const char *dst = NULL;
+    uint32_t words_per_second;
 
     while (argi < argc) {
         if (!strcmp(argv[argi], "--dst")) {
@@ -2905,7 +2999,10 @@ static int do_replay_host_named(const char *name, int argc, char **argv, int arg
         fprintf(stderr, "Capture '%s' not found.\n", name);
         return 1;
     }
-    return do_replay(e->sector, e->nsectors, dst, timeout_ms, dry_run);
+    if (capture_volume_entry_replay_word_rate(e, &words_per_second) != 0)
+        return 1;
+    return do_replay(e->sector, e->nsectors, dst, words_per_second,
+        timeout_ms, dry_run);
 }
 
 static int do_replay_rf_named(const char *name, int argc, char **argv, int argi,
@@ -3139,6 +3236,9 @@ static void help(void)
            "capture NAME --seconds SEC|--size BYTES [RF options]\n"
            "    Tune RF, record RX stream to SATA, and store SigMF metadata.\n"
            "\n"
+           "capture-current NAME --seconds SEC|--size BYTES [metadata overrides]\n"
+           "    Tap the active GQRX/host RX stream to SATA without retuning or interrupting it.\n"
+           "\n"
            "capture-start NAME --seconds SEC|--size BYTES [RF options]\n"
            "    Start a named RX-to-SATA capture and return immediately.\n"
            "\n"
@@ -3343,7 +3443,18 @@ int main(int argc, char **argv)
         }
         const char *name = argv[optind++];
         return do_capture_named(name, argc, argv, optind, timeout_ms,
-            timeout_explicit, false, dry_run);
+            timeout_explicit, false, false, dry_run);
+    }
+
+    if (!strcmp(cmd, "capture-current")) {
+        const char *name;
+        if (optind >= argc) {
+            help();
+            return 1;
+        }
+        name = argv[optind++];
+        return do_capture_named(name, argc, argv, optind, timeout_ms,
+            timeout_explicit, false, true, dry_run);
     }
 
     if (!strcmp(cmd, "capture-start")) {
@@ -3353,7 +3464,7 @@ int main(int argc, char **argv)
         }
         const char *name = argv[optind++];
         return do_capture_named(name, argc, argv, optind, timeout_ms,
-            timeout_explicit, true, dry_run);
+            timeout_explicit, true, false, dry_run);
     }
 
     if (!strcmp(cmd, "import")) {
@@ -3419,6 +3530,7 @@ int main(int argc, char **argv)
 #else
     if (!strcmp(cmd, "init") || !strcmp(cmd, "list") || !strcmp(cmd, "show") ||
         !strcmp(cmd, "delete") || !strcmp(cmd, "check") || !strcmp(cmd, "capture") ||
+        !strcmp(cmd, "capture-current") ||
         !strcmp(cmd, "capture-start") || !strcmp(cmd, "import") || !strcmp(cmd, "export") ||
         !strcmp(cmd, "play") || !strcmp(cmd, "serve") || !strcmp(cmd, "stop")) {
         fprintf(stderr, "Command '%s' not available: SATA not present in this gateware.\n", cmd);
@@ -3491,7 +3603,7 @@ int main(int argc, char **argv)
             if (reject_extra_args(argc, argv, optind) != 0)
                 return 1;
             return !strcmp(diag_cmd, "record") ?
-                do_record(dst_sector, nsectors, timeout_ms, dry_run, 0.0, 0.0) :
+                do_record(dst_sector, nsectors, timeout_ms, dry_run, 0.0, 0.0, false) :
                 do_record_start(dst_sector, nsectors, timeout_ms, dry_run);
         }
 
@@ -3527,7 +3639,7 @@ int main(int argc, char **argv)
             }
             if (reject_extra_args(argc, argv, optind) != 0)
                 return 1;
-            return do_replay(src_sector, nsectors, dst, timeout_ms, dry_run);
+            return do_replay(src_sector, nsectors, dst, 0, timeout_ms, dry_run);
         }
 
         if (!strcmp(diag_cmd, "copy")) {

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
@@ -656,6 +656,33 @@ void sata_host_buffer_write(struct m2sdr_dev *conn, const uint8_t *buf, size_t b
     }
 }
 
+/* Etherbone read pipelining depth for the current session. Reads are only
+ * held to one outstanding burst while a live SoapySDR/GQRX client is actually
+ * streaming through the shared endpoint: RX routed to Ethernet with the
+ * streamer enabled and a programmed destination. The enable bit alone is not
+ * a client indicator since it resets to 1. Checked once per process, matching
+ * the bulk-words probe. */
+static size_t sata_etherbone_read_window(struct m2sdr_dev *conn)
+{
+#if defined(CSR_ETH_RX_STREAMER_ENABLE_ADDR) && \
+    defined(CSR_ETH_RX_STREAMER_IP_ADDRESS_ADDR)
+    static bool checked = false;
+    static size_t cached_window = M2SDR_SATA_ETHERBONE_READ_WINDOW;
+
+    if (!checked) {
+        if ((m2sdr_read32(conn, CSR_CROSSBAR_DEMUX_SEL_ADDR) == RXDST_ETH) &&
+            (m2sdr_read32(conn, CSR_ETH_RX_STREAMER_ENABLE_ADDR) & 0x1u) &&
+            (m2sdr_read32(conn, CSR_ETH_RX_STREAMER_IP_ADDRESS_ADDR) != 0))
+            cached_window = M2SDR_SATA_ETHERBONE_READ_WINDOW_SHARED;
+        checked = true;
+    }
+    return cached_window;
+#else
+    (void)conn;
+    return M2SDR_SATA_ETHERBONE_READ_WINDOW;
+#endif
+}
+
 void sata_host_buffer_read(struct m2sdr_dev *conn, uint8_t *buf, size_t bytes)
 {
     uint32_t burst = sata_host_buffer_bulk_words(conn);
@@ -668,7 +695,7 @@ void sata_host_buffer_read(struct m2sdr_dev *conn, uint8_t *buf, size_t bytes)
 
         if (eb && pipeline_words) {
             int rc = eb_read32_bulk_pipeline_checked(eb, SATA_HOST_BUFFER_BASE,
-                pipeline_words, word_count, burst, M2SDR_SATA_ETHERBONE_READ_WINDOW);
+                pipeline_words, word_count, burst, sata_etherbone_read_window(conn));
 
             if (rc == EB_ERR_OK) {
                 for (size_t i = 0; i < word_count; i++)

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
@@ -258,7 +258,6 @@ void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors)
     m2sdr_write32(conn, CSR_SATA_TX_STREAMER_NSECTORS_ADDR, nsectors);
 }
 
-
 bool sata_rx_tap_supported(void)
 {
 #ifdef CSR_SATA_RX_STREAMER_TAP_ADDR
@@ -276,6 +275,39 @@ void sata_rx_set_tap(void *conn, bool enable)
     (void)conn;
     (void)enable;
 #endif
+}
+
+bool sata_streamer_stop_supported(bool rx, bool tx)
+{
+    bool supported = true;
+
+#ifndef CSR_SATA_RX_STREAMER_STOP_ADDR
+    if (rx)
+        supported = false;
+#endif
+#ifndef CSR_SATA_TX_STREAMER_STOP_ADDR
+    if (tx)
+        supported = false;
+#endif
+    return supported && (rx || tx);
+}
+
+/* Request a stop at the next ATA command boundary. The streamer keeps its
+ * done/error semantics: poll done afterwards, then reset the frontend to
+ * flush any words left in its FIFO. */
+void sata_streamer_request_stop(void *conn, bool rx, bool tx)
+{
+#ifdef CSR_SATA_RX_STREAMER_STOP_ADDR
+    if (rx)
+        m2sdr_write32(conn, CSR_SATA_RX_STREAMER_STOP_ADDR, 1);
+#endif
+#ifdef CSR_SATA_TX_STREAMER_STOP_ADDR
+    if (tx)
+        m2sdr_write32(conn, CSR_SATA_TX_STREAMER_STOP_ADDR, 1);
+#endif
+    (void)conn;
+    (void)rx;
+    (void)tx;
 }
 
 void sata_tx_set_pace(void *conn, uint32_t words_per_second)
@@ -550,7 +582,6 @@ int sata_eth_replay_destination_prepare(void *conn)
     return 0;
 #endif
 }
-
 
 void etherbone_fill_test_words(uint32_t *words, uint32_t count)
 {

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
@@ -258,6 +258,40 @@ void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors)
     m2sdr_write32(conn, CSR_SATA_TX_STREAMER_NSECTORS_ADDR, nsectors);
 }
 
+bool sata_rx_tap_supported(void)
+{
+#ifdef CSR_SATA_RX_STREAMER_TAP_ADDR
+    return true;
+#else
+    return false;
+#endif
+}
+
+void sata_rx_set_tap(void *conn, bool enable)
+{
+#ifdef CSR_SATA_RX_STREAMER_TAP_ADDR
+    m2sdr_write32(conn, CSR_SATA_RX_STREAMER_TAP_ADDR, enable ? 1 : 0);
+#else
+    (void)conn;
+    (void)enable;
+#endif
+}
+
+void sata_tx_set_pace(void *conn, uint32_t words_per_second)
+{
+#ifdef CSR_SATA_TX_STREAMER_PACE_ADDR
+    m2sdr_write32(conn, CSR_SATA_TX_STREAMER_PACE_ADDR, words_per_second);
+#else
+    (void)conn;
+    if (words_per_second != 0) {
+        fprintf(stderr,
+            "Paced replay requires gateware with the SATA TX pace CSR. "
+            "Rebuild and reload the FPGA bitstream.\n");
+        exit(1);
+    }
+#endif
+}
+
 void sata_rx_start(void *conn)
 {
     m2sdr_write32(conn, CSR_SATA_RX_STREAMER_START_ADDR, 1);
@@ -318,6 +352,25 @@ uint32_t sata_rx_progress(void *conn)
 {
 #ifdef CSR_SATA_RX_STREAMER_PROGRESS_ADDR
     return m2sdr_read32(conn, CSR_SATA_RX_STREAMER_PROGRESS_ADDR);
+#else
+    (void)conn;
+    return 0;
+#endif
+}
+
+bool sata_tx_progress_supported(void)
+{
+#ifdef CSR_SATA_TX_STREAMER_PROGRESS_ADDR
+    return true;
+#else
+    return false;
+#endif
+}
+
+uint32_t sata_tx_progress(void *conn)
+{
+#ifdef CSR_SATA_TX_STREAMER_PROGRESS_ADDR
+    return m2sdr_read32(conn, CSR_SATA_TX_STREAMER_PROGRESS_ADDR);
 #else
     (void)conn;
     return 0;
@@ -453,6 +506,7 @@ static bool etherbone_is_liteeth(struct m2sdr_dev *conn)
     return m2sdr_get_transport(conn, &transport) == M2SDR_ERR_OK &&
            transport == M2SDR_TRANSPORT_KIND_LITEETH;
 }
+
 
 void etherbone_fill_test_words(uint32_t *words, uint32_t count)
 {

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.c
@@ -258,6 +258,7 @@ void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors)
     m2sdr_write32(conn, CSR_SATA_TX_STREAMER_NSECTORS_ADDR, nsectors);
 }
 
+
 bool sata_rx_tap_supported(void)
 {
 #ifdef CSR_SATA_RX_STREAMER_TAP_ADDR
@@ -505,6 +506,49 @@ static bool etherbone_is_liteeth(struct m2sdr_dev *conn)
 
     return m2sdr_get_transport(conn, &transport) == M2SDR_ERR_OK &&
            transport == M2SDR_TRANSPORT_KIND_LITEETH;
+}
+
+int sata_eth_replay_destination_prepare(void *conn)
+{
+#if defined(CSR_ETH_RX_STREAMER_ENABLE_ADDR) && \
+    defined(CSR_ETH_RX_STREAMER_IP_ADDRESS_ADDR) && \
+    defined(CSR_ETH_RX_STREAMER_UDP_PORT_ADDR)
+    uint32_t enable = m2sdr_read32(conn, CSR_ETH_RX_STREAMER_ENABLE_ADDR) & 0x1u;
+    uint32_t ip     = m2sdr_read32(conn, CSR_ETH_RX_STREAMER_IP_ADDRESS_ADDR);
+
+    /* A live SoapySDR/GQRX client owns the destination; leave it in place.
+     * The enable bit alone cannot identify a client because it resets to 1;
+     * a programmed destination address is what marks an active session. */
+    if (enable && ip != 0)
+        return 0;
+
+    /* The streamer resets with ip=0.0.0.0 after a bitstream load, and a
+     * SoapySDR stream deactivation leaves it disabled. A replay toward an
+     * unresolvable destination stalls LiteEth's shared TX path on ARP and
+     * takes Etherbone and ICMP down with it until the FPGA is reloaded; one
+     * toward a disabled streamer backpressures the SATA command mid-transfer.
+     * Program this host as the destination and enable the streamer. */
+    if (etherbone_is_liteeth(conn)) {
+        struct m2sdr_liteeth_rx_stream_config config;
+
+        m2sdr_liteeth_rx_stream_config_init(&config);
+        if (m2sdr_liteeth_rx_stream_prepare(conn, &config) != M2SDR_ERR_OK) {
+            m2sdr_cli_error("Failed to program the Ethernet replay destination");
+            return -1;
+        }
+    } else if (ip == 0) {
+        m2sdr_cli_error("Ethernet replay destination is unset and no local IP "
+                        "could be determined; start a SoapySDR/GQRX session or "
+                        "use the Etherbone transport");
+        return -1;
+    }
+    if (!enable)
+        m2sdr_write32(conn, CSR_ETH_RX_STREAMER_ENABLE_ADDR, 1);
+    return 0;
+#else
+    (void)conn;
+    return 0;
+#endif
 }
 
 

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
@@ -20,9 +20,11 @@
 #include "mem.h"
 
 #define M2SDR_SATA_ETHERBONE_BULK_WORDS  128u
-/* One outstanding bulk read keeps catalog traffic cooperative with a live
- * SoapySDR/GQRX client sharing the same gateware Etherbone endpoint. */
-#define M2SDR_SATA_ETHERBONE_READ_WINDOW 1u
+/* Pipelined bulk reads when the Etherbone endpoint is otherwise idle. A
+ * single outstanding read keeps catalog traffic cooperative while a live
+ * SoapySDR/GQRX client shares the same gateware Etherbone endpoint. */
+#define M2SDR_SATA_ETHERBONE_READ_WINDOW        8u
+#define M2SDR_SATA_ETHERBONE_READ_WINDOW_SHARED 1u
 
 enum {
     TXSRC_PCIE = 0,

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
@@ -20,7 +20,9 @@
 #include "mem.h"
 
 #define M2SDR_SATA_ETHERBONE_BULK_WORDS  128u
-#define M2SDR_SATA_ETHERBONE_READ_WINDOW 8u
+/* One outstanding bulk read keeps catalog traffic cooperative with a live
+ * SoapySDR/GQRX client sharing the same gateware Etherbone endpoint. */
+#define M2SDR_SATA_ETHERBONE_READ_WINDOW 1u
 
 enum {
     TXSRC_PCIE = 0,
@@ -93,6 +95,9 @@ void sata_require_csrs(void);
 void txrx_loopback_set(void *conn, int enable);
 void sata_rx_program(void *conn, uint64_t sector, uint32_t nsectors);
 void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors);
+bool sata_rx_tap_supported(void);
+void sata_rx_set_tap(void *conn, bool enable);
+void sata_tx_set_pace(void *conn, uint32_t words_per_second);
 void sata_rx_start(void *conn);
 void sata_tx_start(void *conn);
 int  sata_streamers_reset(void *conn, bool rx, bool tx);
@@ -103,6 +108,8 @@ uint32_t sata_rx_error(void *conn);
 uint32_t sata_tx_error(void *conn);
 bool     sata_rx_progress_supported(void);
 uint32_t sata_rx_progress(void *conn);
+bool     sata_tx_progress_supported(void);
+uint32_t sata_tx_progress(void *conn);
 
 void m2sdr_sata_set_no_bulk_etherbone(bool no_bulk);
 enum sata_pattern_kind parse_pattern(const char *text);

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
@@ -95,6 +95,7 @@ void sata_require_csrs(void);
 void txrx_loopback_set(void *conn, int enable);
 void sata_rx_program(void *conn, uint64_t sector, uint32_t nsectors);
 void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors);
+int  sata_eth_replay_destination_prepare(void *conn);
 bool sata_rx_tap_supported(void);
 void sata_rx_set_tap(void *conn, bool enable);
 void sata_tx_set_pace(void *conn, uint32_t words_per_second);

--- a/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
+++ b/litex_m2sdr/software/user/m2sdr_sata_lowlevel.h
@@ -100,6 +100,8 @@ void sata_tx_program(void *conn, uint64_t sector, uint32_t nsectors);
 int  sata_eth_replay_destination_prepare(void *conn);
 bool sata_rx_tap_supported(void);
 void sata_rx_set_tap(void *conn, bool enable);
+bool sata_streamer_stop_supported(bool rx, bool tx);
+void sata_streamer_request_stop(void *conn, bool rx, bool tx);
 void sata_tx_set_pace(void *conn, uint32_t words_per_second);
 void sata_rx_start(void *conn);
 void sata_tx_start(void *conn);

--- a/test/test_sata_stream_tap.py
+++ b/test/test_sata_stream_tap.py
@@ -1,0 +1,77 @@
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import passive, run_simulation
+
+from litex_m2sdr.gateware.sata import SATAStreamTap
+
+
+def _layout():
+    return [("data", 32)]
+
+
+def test_sata_stream_tap_disabled_keeps_primary_path_independent():
+    dut = SATAStreamTap(_layout())
+    primary = []
+    tapped = []
+
+    @passive
+    def monitor():
+        while True:
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                primary.append((yield dut.source.data))
+            if (yield dut.tap.valid) and (yield dut.tap.ready):
+                tapped.append((yield dut.tap.data))
+            yield
+
+    def generator():
+        yield dut.enable.eq(0)
+        yield dut.source.ready.eq(1)
+        yield dut.tap.ready.eq(0)
+        yield dut.sink.valid.eq(1)
+        yield dut.sink.data.eq(0x12345678)
+        yield
+        yield dut.sink.valid.eq(0)
+        for _ in range(6):
+            yield
+
+    run_simulation(dut, [generator(), monitor()])
+    assert primary == [0x12345678]
+    assert tapped == []
+
+
+def test_sata_stream_tap_advances_only_when_both_consumers_accept():
+    dut = SATAStreamTap(_layout())
+    primary = []
+    tapped = []
+
+    @passive
+    def monitor():
+        while True:
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                primary.append((yield dut.source.data))
+            if (yield dut.tap.valid) and (yield dut.tap.ready):
+                tapped.append((yield dut.tap.data))
+            yield
+
+    def generator():
+        yield dut.enable.eq(1)
+        yield dut.source.ready.eq(1)
+        yield dut.tap.ready.eq(1)
+        for value in range(12):
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(0x1000 + value)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+        yield dut.sink.valid.eq(0)
+        for _ in range(10):
+            yield
+
+    run_simulation(dut, [generator(), monitor()])
+    expected = [0x1000 + value for value in range(12)]
+    assert primary == expected
+    assert tapped == expected

--- a/test/test_sata_streamers.py
+++ b/test/test_sata_streamers.py
@@ -232,3 +232,98 @@ def test_sata_to_stream_reads_a_burst_and_paces_output():
     assert len(output_cycles) == 2 * 512 // 8
     assert output_last == [0] * (len(output_last) - 1) + [1]
     assert all((b - a) >= 9 for a, b in zip(output_cycles, output_cycles[1:]))
+
+
+def test_stream_to_sata_stop_finishes_at_the_command_boundary():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATAStream2Sectors(
+        port, data_width=64, burst_sectors=2, fifo_sectors=4)
+    stats = write_stats()
+
+    def producer():
+        # 6 sectors would take 3 commands of 2 sectors; stop after the data
+        # for the first command so the recorder finishes at its boundary.
+        yield dut.nsectors.storage.eq(6)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        for value in range(2 * 512 // 8):
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(value)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+        yield dut.sink.valid.eq(0)
+        yield dut.stop.re.eq(1)
+        yield
+        yield dut.stop.re.eq(0)
+        for _ in range(700):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+        assert (yield dut.error.status) == 0
+        assert (yield dut.progress.status) == 2
+
+    run_simulation(dut, [producer(), make_write_controller(port, stats)()])
+    assert stats["command_counts"] == [2]
+
+
+def test_sata_to_stream_stop_finishes_at_the_command_boundary():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATASectors2Stream(
+        port, data_width=64, sys_clk_freq=100,
+        burst_sectors=2, fifo_sectors=4)
+    command_counts = []
+
+    def controller():
+        # Serve exactly one 2-sector read command, then stay idle: a stopped
+        # playback must not issue the second command.
+        yield port.sink.ready.eq(1)
+        while not ((yield port.sink.valid) and (yield port.sink.ready)):
+            yield
+        command_counts.append((yield port.sink.count))
+        yield
+
+        for response_index in range(2 * 512 // 4):
+            yield port.source.valid.eq(1)
+            yield port.source.read.eq(1)
+            yield port.source.end.eq(0)
+            yield port.source.data.eq(response_index)
+            yield port.source.last.eq(1 if response_index == 255 else 0)
+            yield port.source.failed.eq(0)
+            while not (yield port.source.ready):
+                yield
+            yield
+        yield port.source.end.eq(1)
+        yield port.source.last.eq(1)
+        while not (yield port.source.ready):
+            yield
+        yield
+        yield port.source.valid.eq(0)
+        yield port.source.read.eq(0)
+        yield port.source.end.eq(0)
+        yield port.source.last.eq(0)
+
+    def consumer():
+        yield dut.nsectors.storage.eq(6)
+        yield dut.pace.storage.eq(0)
+        yield dut.source.ready.eq(1)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        while (yield dut.done.status):
+            yield
+        yield dut.stop.re.eq(1)
+        yield
+        yield dut.stop.re.eq(0)
+        for _ in range(3000):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+        assert (yield dut.error.status) == 0
+        assert (yield dut.progress.status) == 2
+
+    run_simulation(dut, [consumer(), controller()])
+    assert command_counts == [2]

--- a/test/test_sata_streamers.py
+++ b/test/test_sata_streamers.py
@@ -1,0 +1,234 @@
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import passive, run_simulation
+from litesata.frontend.arbitration import LiteSATAUserPort
+
+from litex_m2sdr.gateware.sata import (
+    M2SDRLiteSATAStream2Sectors, M2SDRLiteSATASectors2Stream)
+
+
+def write_stats():
+    return {"command_counts": [], "write_cycles": [], "cycle": 0}
+
+
+def make_write_controller(port, stats):
+    """Accept streamer write commands and acknowledge each one at its last
+    word, collecting the count of every command, the cycle of every accepted
+    word, and a running cycle counter shared with the producers."""
+    @passive
+    def controller():
+        acknowledging = False
+        first_word = True
+        while True:
+            yield port.sink.ready.eq(1)
+            if (yield port.sink.valid) and (yield port.sink.ready):
+                if first_word:
+                    stats["command_counts"].append((yield port.sink.count))
+                    first_word = False
+                stats["write_cycles"].append(stats["cycle"])
+                if (yield port.sink.last):
+                    acknowledging = True
+                    first_word = True
+            yield port.source.valid.eq(1 if acknowledging else 0)
+            yield port.source.last.eq(1 if acknowledging else 0)
+            yield port.source.failed.eq(0)
+            if acknowledging and (yield port.source.ready):
+                acknowledging = False
+            stats["cycle"] += 1
+            yield
+    return controller
+
+
+def test_stream_to_sata_waits_for_and_writes_a_contiguous_burst():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATAStream2Sectors(
+        port, data_width=64, burst_sectors=2, fifo_sectors=4)
+    stats = write_stats()
+    producer_done_cycle = None
+
+    def producer():
+        nonlocal producer_done_cycle
+        yield dut.sector.storage.eq(0x1234)
+        yield dut.nsectors.storage.eq(2)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        for value in range(2 * 512 // 8):
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(value)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+        yield dut.sink.valid.eq(0)
+        producer_done_cycle = stats["cycle"]
+        for _ in range(700):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+        assert (yield dut.error.status) == 0
+        assert (yield dut.progress.status) == 2
+
+    run_simulation(dut, [producer(), make_write_controller(port, stats)()])
+    write_cycles = stats["write_cycles"]
+    assert stats["command_counts"] == [2]
+    assert len(write_cycles) == 2 * 512 // 4
+    assert write_cycles == list(range(write_cycles[0], write_cycles[0] + len(write_cycles)))
+    assert producer_done_cycle is not None
+
+
+def test_stream_to_sata_preloads_then_keeps_one_long_command_open():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATAStream2Sectors(
+        port, data_width=64, burst_sectors=4, preload_sectors=2,
+        fifo_sectors=4)
+    stats = write_stats()
+    producer_done_cycle = None
+
+    def producer():
+        nonlocal producer_done_cycle
+        yield dut.nsectors.storage.eq(4)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        for value in range(4 * 512 // 8):
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(value)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+        yield dut.sink.valid.eq(0)
+        producer_done_cycle = stats["cycle"]
+        for _ in range(1200):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+        assert (yield dut.error.status) == 0
+
+    run_simulation(dut, [producer(), make_write_controller(port, stats)()])
+    assert stats["command_counts"] == [4]
+    assert len(stats["write_cycles"]) == 4 * 512 // 4
+    assert producer_done_cycle is not None
+    assert stats["write_cycles"][0] < producer_done_cycle
+
+
+def test_stream_to_sata_refills_between_contiguous_reservoir_bursts():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATAStream2Sectors(
+        port, data_width=64, burst_sectors=4, preload_sectors=2,
+        low_watermark_sectors=1, fifo_sectors=4)
+    stats = write_stats()
+
+    def sparse_producer():
+        yield dut.nsectors.storage.eq(4)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        for value in range(4 * 512 // 8):
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(value)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+            yield dut.sink.valid.eq(0)
+            for _ in range(4):
+                yield
+        for _ in range(3000):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+
+    run_simulation(dut, [sparse_producer(), make_write_controller(port, stats)()])
+    write_cycles = stats["write_cycles"]
+    assert stats["command_counts"] == [4]
+    assert len(write_cycles) == 4 * 512 // 4
+    # The ATA command remains open, but valid pauses while the reservoir
+    # refills instead of falling back to the sparse producer cadence.
+    gaps = [b - a for a, b in zip(write_cycles, write_cycles[1:])]
+    assert max(gaps) > 4
+    assert sum(gap > 1 for gap in gaps) < (len(gaps) // 4)
+
+
+def test_sata_to_stream_reads_a_burst_and_paces_output():
+    port = LiteSATAUserPort(32)
+    dut = M2SDRLiteSATASectors2Stream(
+        port, data_width=64, sys_clk_freq=100,
+        burst_sectors=2, fifo_sectors=4)
+    command_counts = []
+    output_cycles = []
+    output_last = []
+    cycle = 0
+
+    def controller():
+        yield port.sink.ready.eq(1)
+        while not ((yield port.sink.valid) and (yield port.sink.ready)):
+            yield
+        command_counts.append((yield port.sink.count))
+        yield
+
+        for response_index in range(2 * 512 // 4):
+            yield port.source.valid.eq(1)
+            yield port.source.read.eq(1)
+            yield port.source.end.eq(0)
+            yield port.source.data.eq(response_index)
+            # Two DATA FIS packets: neither packet boundary completes the
+            # multi-sector command.
+            yield port.source.last.eq(1 if response_index in (127, 255) else 0)
+            yield port.source.failed.eq(0)
+            while not (yield port.source.ready):
+                yield
+            yield
+        yield port.source.end.eq(1)
+        yield port.source.last.eq(1)
+        while not (yield port.source.ready):
+            yield
+        yield
+        yield port.source.valid.eq(0)
+        yield port.source.read.eq(0)
+        yield port.source.end.eq(0)
+        yield port.source.last.eq(0)
+
+    @passive
+    def clock_monitor():
+        nonlocal cycle
+        while True:
+            cycle += 1
+            yield
+
+    @passive
+    def output_monitor():
+        while True:
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                output_cycles.append(cycle)
+                output_last.append((yield dut.source.last))
+            yield
+
+    def consumer():
+        yield dut.sector.storage.eq(0x2345)
+        yield dut.nsectors.storage.eq(2)
+        yield dut.pace.storage.eq(10)
+        yield dut.source.ready.eq(1)
+        yield dut.start.re.eq(1)
+        yield
+        yield dut.start.re.eq(0)
+        while (yield dut.done.status):
+            yield
+        for _ in range(3000):
+            if (yield dut.done.status):
+                break
+            yield
+        assert (yield dut.done.status) == 1
+        assert (yield dut.error.status) == 0
+        assert (yield dut.progress.status) == 2
+
+    run_simulation(dut, [consumer(), controller(), output_monitor(), clock_monitor()])
+    assert command_counts == [2]
+    assert len(output_cycles) == 2 * 512 // 8
+    assert output_last == [0] * (len(output_last) - 1) + [1]
+    assert all((b - a) >= 9 for a, b in zip(output_cycles, output_cycles[1:]))

--- a/test/test_shared_etherbone.py
+++ b/test/test_shared_etherbone.py
@@ -1,0 +1,38 @@
+from migen.sim import run_simulation
+
+from litex_m2sdr.gateware.etherbone import SharedLiteEthEtherbonePacketTX
+
+
+def test_etherbone_reply_uses_request_source_port():
+    dut = SharedLiteEthEtherbonePacketTX(udp_port=1234)
+    observed = []
+
+    def generator():
+        yield dut.source.ready.eq(1)
+        yield dut.sink.valid.eq(1)
+        yield dut.sink.last.eq(1)
+        yield dut.sink.last_be.eq(0xf)
+        yield dut.sink.data.eq(0x11223344)
+        yield dut.sink.length.eq(4)
+        yield dut.sink.src_port.eq(49152)
+        yield dut.sink.ip_address.eq(0xc0a80164)
+
+        accepted = False
+        for _ in range(32):
+            if (yield dut.sink.valid) and (yield dut.sink.ready):
+                accepted = True
+                yield dut.sink.valid.eq(0)
+            if (yield dut.source.valid):
+                observed.append({
+                    "src_port": (yield dut.source.src_port),
+                    "dst_port": (yield dut.source.dst_port),
+                    "ip":       (yield dut.source.ip_address),
+                })
+            yield
+        assert accepted
+
+    run_simulation(dut, generator())
+    assert observed
+    assert {beat["src_port"] for beat in observed} == {1234}
+    assert {beat["dst_port"] for beat in observed} == {49152}
+    assert {beat["ip"] for beat in observed} == {0xc0a80164}


### PR DESCRIPTION
Adds shared SATA/host streaming so a SATA capture or replay can run while a live SoapySDR/GQRX session keeps using the board, plus the robustness work that came out of validating it on hardware.

## What's included

- **sata: support concurrent GQRX capture and replay** — lossless RX tap so recording shares the live host stream, Etherbone replies routed to each client's UDP source port for concurrent control users, long multi-sector buffered writes, multi-FIS reads, paced replay from capture metadata, and progress reporting for `capture-current`/`serve`.
- **libm2sdr: make SATA identify robust against slow multi-FIS transfers** — drives can split the IDENTIFY block into several DRQ chunks and stall it during garbage collection (seen on a Samsung 850 EVO at ~60% failure rate); the host now sequences and drains identify correctly. Pairs with the LiteSATA multi-FIS identify fix (see below).
- **sata: program the Ethernet replay destination before starting a replay** — `serve` on a freshly loaded bitstream used to stream UDP at 0.0.0.0, stalling LiteEth's shared TX path on ARP and taking Etherbone/ICMP down until an FPGA reload.
- **sata: pipeline Etherbone catalog reads when the RX path is idle** — exports back to 26–30 MiB/s while staying cooperative (single-burst window) during a live GQRX session.
- **sata: stop interrupted streamer transfers at the current command boundary** — new stop CSRs in both streamers; Ctrl-C on a capture/serve now exits in well under a second instead of abandoning an accepted ATA command (which wedged the SATA core until reload) or draining gigabytes.
- **doc: record the SATA bandwidth investigation and 850 EVO validation** — the sustained capture rate is a drive property: a degraded DRAM-less WD Green sustained 10–25 MiB/s while a Samsung 850 EVO captures 30.72 MS/s SC16 2T2R (233 MiB/s) in real time.

## Validation

Every commit builds and passes the simulation suites (170 Python tests, libm2sdr/CLI/hostio C tests). Validated on Acorn Baseboard Mini Ethernet+SATA hardware with a Samsung 850 EVO: real-time captures up to 30.72 MS/s SC16 2T2R past the drive's TurboWrite cache, concurrent GQRX capture and paced replay, serve from a freshly loaded bitstream and from the disabled-streamer state a closed GQRX session leaves behind, sub-second interrupt aborts with the board healthy afterwards, and 60 consecutive clean identify runs. Timing closes cleanly.

## Dependency

The identify robustness relies on the LiteSATA multi-FIS IDENTIFY fix (`fix-multi-fis-identify` branch in litesata: count the 128-dword block in the command layer and identify frontend, accept intermediate PIO Setup FISes). Without it, drives that segment identify data regress to intermittent `Drive: not present` reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)