### PR TITLE
Fix SoapySDR RX zero buffers on IOMMU hosts + opt-in interface delay calibration (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 The LiteX M2 SDR project is actively under development. We maintain this changelog to allow users and potential clients of the hardware to follow the project's progress and stay up to date with the latest features and improvements. Date-named bitstream archive releases complement the development summaries below.
 
+[> 2026 Q3 to date (Jul - )
+---------------------------
+**Host Stack Fixes**
+- Fixed zero-copy DMA mmap on IOMMU/SMMU platforms (e.g. Jetson Orin): the kernel driver mapped the wrong pages on ARM/AArch64, so SoapySDR RX delivered mostly-zero buffers while the copy-mode tools streamed correctly (#149).
+- Added opt-in FPGA <-> AD9361 interface delay calibration to the SoapySDR driver (`calibrate_delay=1`) with cached delays re-applied across RFIC reconfigurations, plus the matching `libm2sdr` interface-delay API.
+
 [> 2026-05-15 First Date-Named Release
 --------------------------------------
 **Feature Status at Release**

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ If you are an SDR enthusiast looking to get started with the LiteX-M2SDR board, 
 
 ### Host Requirements & Expectations
 
-- **IOMMU / DMA**: For PCIe streaming, set IOMMU to passthrough mode. If you don't see I/Q data streams in your SDR app, this is the first thing to check.
+- **IOMMU / DMA**: PCIe streaming works with the IOMMU enabled on current `m2sdr.ko` builds. If you don't see I/Q data streams in your SDR app with an older kernel module, update the driver first; setting the IOMMU to passthrough mode is the legacy workaround.
 - **CPU Governor**: For sustained high sample rates, set the CPU frequency governor to `performance`; on-demand frequency scaling can cause RX overflows/TX underflows.
 - **PCIe Gen & Lanes**: Oversampling (122.88 MSPS) requires PCIe Gen2 x2/x4 bandwidth. Gen2 x1 is enough for standard 61.44 MSPS.
 - **Runtime transport selection**: The installed user tools and SoapySDR module support both transports in one build. Use `--device pcie:/dev/m2sdr0` or `--device eth:192.168.1.50:1234` with the CLI tools, and `driver=LiteXM2SDR,path=/dev/m2sdr0` or `driver=LiteXM2SDR,eth_ip=192.168.1.50` with SoapySDR.
@@ -375,7 +375,13 @@ scripts/github_release.py --date 2026_05_15
 The helper requires the GitHub CLI `gh` to be installed and authenticated with release write access. It checks for a clean tracked tree, verifies that the expected `build/*_2026_05_15.zip` files exist, reads each archive manifest, creates and pushes the annotated `2026_05_15` tag on the manifest git revision, extracts the matching `CHANGELOG.md` section as release notes, and uploads the archive set to the GitHub release.
 
 > [!TIP]
-> If you don't see I/Q data streams in your SDR app, make sure IOMMU is set to passthrough mode. Add the following to your GRUB configuration:
+> If you don't see I/Q data streams in your SDR app, first make sure the
+> `m2sdr.ko` kernel module matches this source tree: older builds mapped the
+> wrong pages for zero-copy DMA on hosts with an active IOMMU/SMMU (mostly/all-
+> zero RX buffers through SoapySDR), which made IOMMU passthrough look like a
+> requirement. Current builds stream with the IOMMU enabled (verified on Jetson
+> Orin, JetPack 7 / L4T R39, without `iommu.passthrough=1`). When running an
+> older driver, passthrough remains the legacy workaround:
 >
 > **x86/PC**:
 > ```bash
@@ -390,8 +396,7 @@ The helper requires the GitHub CLI `gh` to be installed and authenticated with r
 > APPEND ... iommu.passthrough=1
 > sudo reboot
 > ```
-> Keep the Tegra SMMU driver enabled. `iommu.passthrough=1` is the safer first
-> test knob for current L4T kernels; disabling `arm-smmu` globally can break
+> Keep the Tegra SMMU driver enabled; disabling `arm-smmu` globally can break
 > other Jetson devices. See [Jetson Orin host notes](doc/hosts/jetson-orin.md).
 
 > [!WARNING]

--- a/doc/hosts/jetson-orin.md
+++ b/doc/hosts/jetson-orin.md
@@ -27,12 +27,19 @@ the `KERNEL_PATH=...` make variable.
 
 ## IOMMU / SMMU
 
-Keep the Tegra SMMU driver enabled. Do not add `arm-smmu.disable=1` as a
-default workaround; it disables the SMMU globally and can break unrelated
-Jetson peripherals.
+The SMMU can stay fully enabled: current `m2sdr.ko` builds stream correctly
+with SMMU address translation active (verified on JetPack 7 / L4T R39 with the
+stock kernel command line, no `iommu.passthrough=1`). Older kernel-module
+builds mapped the wrong pages for zero-copy DMA behind an IOMMU/SMMU, which
+made SoapySDR RX return mostly/all-zero buffers and made IOMMU passthrough
+look like a requirement on Jetson; that driver bug is fixed.
 
-If PCIe enumeration works but DMA streaming does not produce samples, first try
-IOMMU passthrough:
+Do not add `arm-smmu.disable=1` as a default workaround; it disables the SMMU
+globally and can break unrelated Jetson peripherals.
+
+If you must run an older driver build and DMA streaming does not produce
+samples even though PCIe enumeration works, IOMMU passthrough remains the
+legacy workaround:
 
 ```bash
 # /boot/extlinux/extlinux.conf

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -44,9 +44,6 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 #include <linux/cc_platform.h>
 #endif
-#if defined(__arm__) || defined(__aarch64__)
-#include <linux/dma-direct.h>
-#endif
 #include <linux/ptp_clock_kernel.h>
 
 /* LiteX Includes */
@@ -1071,11 +1068,7 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan *chan = chan_priv->chan;
 	struct litepcie_device *s = chan->litepcie_dev;
-#if defined(__arm__) || defined(__aarch64__)
-	unsigned long pfn;
-#else
 	int ret;
-#endif
 	int is_tx, i;
 
 	if (vma->vm_end - vma->vm_start != DMA_BUFFER_TOTAL_SIZE)
@@ -1089,35 +1082,18 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 		return -EINVAL;
 
 	for (i = 0; i < DMA_BUFFER_COUNT; i++) {
-#if defined(__arm__) || defined(__aarch64__)
-		void *va;
-		if (i == 0)
-			dev_info(&s->dev->dev, "Using ARM/AArch64 DMA buffer handling");
-		if (is_tx)
-			va = phys_to_virt(dma_to_phys(&s->dev->dev, chan->dma.reader_handle[i]));
-		else
-			va = phys_to_virt(dma_to_phys(&s->dev->dev, chan->dma.writer_handle[i]));
-		pfn = page_to_pfn(virt_to_page(va));
-		/*
-		 * Note: the memory is cached, so the user must explicitly
-		 * flush the CPU caches on architectures which require it.
-		 */
-		if (remap_pfn_range(vma, vma->vm_start + i * DMA_BUFFER_SIZE, pfn,
-					DMA_BUFFER_SIZE, vma->vm_page_prot)) {
-			dev_err(&s->dev->dev, "mmap remap_pfn_range failed\n");
-			return -EAGAIN;
-		}
-#else
 		void *cpu_addr;
-
-		if (i == 0)
-			dev_info(&s->dev->dev, "Using non-ARM DMA buffer handling");
 
 		if (is_tx)
 			cpu_addr = chan->dma.reader_addr[i];
 		else
 			cpu_addr = chan->dma.writer_addr[i];
 
+		/* Map through the coherent cpu_addr on every architecture: the
+		 * dma_addr_t handle is an IOVA when the device sits behind an
+		 * IOMMU/SMMU (e.g. PCIe on Jetson Orin), so deriving pages via
+		 * phys_to_virt(dma_to_phys(handle)) maps unrelated memory and
+		 * zero-copy readers see stale/empty buffers. */
 		ret = litepcie_dma_buffer_mmap(&s->dev->dev, vma,
 					       vma->vm_start + i * DMA_BUFFER_SIZE,
 					       cpu_addr);
@@ -1126,7 +1102,6 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 				"mmap remap_pfn_range failed for buffer %d (ret=%d)\n", i, ret);
 			return ret;
 		}
-#endif
 	}
 
 	return 0;

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.cpp
@@ -945,6 +945,35 @@ SoapyLiteXM2SDR::SoapyLiteXM2SDR(const SoapySDR::Kwargs &args)
         channel_configure(SOAPY_SDR_TX, 1);
     }
 
+    /* FPGA <-> AD9361 interface delay calibration (opt-in via
+     * calibrate_delay=1): scans the digital interface clock/data delays with
+     * the PRBS path, like `m2sdr_rf --calibrate-delay`, for boards where the
+     * header defaults sit at the edge of the timing eye. Runs here because
+     * the RFIC is still in its bring-up 2T2R layout (gateware without a
+     * 1R1T-aware PRBS checker cannot converge in 1T1R) and no stream is
+     * active yet; the result is cached and re-applied whenever a later RFIC
+     * re-initialization resets the delay registers. */
+    if (args.count("calibrate_delay") > 0)
+        _ifaceDelayCalRequested = args.at("calibrate_delay") != "0";
+    if (_ifaceDelayCalRequested && do_init) {
+        int rc = m2sdr_rf_calibrate_interface_delay(_dev);
+        if (rc == M2SDR_ERR_OK &&
+            m2sdr_rf_get_interface_delay(_dev, M2SDR_RX, &_rxIfaceDelayReg) == M2SDR_ERR_OK &&
+            m2sdr_rf_get_interface_delay(_dev, M2SDR_TX, &_txIfaceDelayReg) == M2SDR_ERR_OK) {
+            _ifaceDelayCalValid = true;
+            SoapySDR::logf(SOAPY_SDR_INFO,
+                "Interface delay calibration done: RX reg 0x%02x, TX reg 0x%02x",
+                _rxIfaceDelayReg, _txIfaceDelayReg);
+        } else {
+            SoapySDR::logf(SOAPY_SDR_WARNING,
+                "Interface delay calibration failed (%s); keeping default delays",
+                m2sdr_strerror(rc));
+        }
+    } else if (_ifaceDelayCalRequested) {
+        SoapySDR::log(SOAPY_SDR_WARNING,
+            "calibrate_delay=1 ignored with bypass_init=1 (the PRBS scan would disturb the external RF configuration)");
+    }
+
     if (args.count("rx_antenna0") > 0)
         _rx_stream.antenna[0] = args.at("rx_antenna0");
     if (args.count("rx_antenna1") > 0)
@@ -1064,6 +1093,35 @@ void SoapyLiteXM2SDR::invalidateRfHardwareCache() {
     _txFrequencyHwApplied = false;
     _txAttHwApplied = false;
     _bitModeHwApplied = false;
+}
+
+void SoapyLiteXM2SDR::reapplyInterfaceDelays(const char *context) {
+    if (!_ifaceDelayCalValid)
+        return;
+    /* Rates above 61.44 MSPS use the wide-bandwidth bring-up, which programs
+     * its own delay tuning for the doubled DATA_CLK; the values calibrated at
+     * the regular interface rate do not apply there. */
+    if (_sampleRateHwApplied && _sampleRateHw > 61440000)
+        return;
+
+    uint8_t rx_reg = 0;
+    uint8_t tx_reg = 0;
+    if (m2sdr_rf_get_interface_delay(_dev, M2SDR_RX, &rx_reg) != M2SDR_ERR_OK ||
+        m2sdr_rf_get_interface_delay(_dev, M2SDR_TX, &tx_reg) != M2SDR_ERR_OK)
+        return;
+    if (rx_reg == _rxIfaceDelayReg && tx_reg == _txIfaceDelayReg)
+        return;
+
+    int rc_rx = m2sdr_rf_set_interface_delay(_dev, M2SDR_RX, _rxIfaceDelayReg);
+    int rc_tx = m2sdr_rf_set_interface_delay(_dev, M2SDR_TX, _txIfaceDelayReg);
+    if (rc_rx != M2SDR_ERR_OK || rc_tx != M2SDR_ERR_OK) {
+        SoapySDR::logf(SOAPY_SDR_WARNING,
+            "Re-applying calibrated interface delays failed after %s", context);
+        return;
+    }
+    SoapySDR::logf(SOAPY_SDR_DEBUG,
+        "Re-applied calibrated interface delays (RX 0x%02x, TX 0x%02x) after %s",
+        _rxIfaceDelayReg, _txIfaceDelayReg, context);
 }
 
 /***************************************************************************************************
@@ -1889,6 +1947,11 @@ void SoapyLiteXM2SDR::setSampleRate(
 #if USE_LITEETH
     timeout.throw_if_timed_out();
 #endif
+
+    /* Covers dropping back from the wide-bandwidth mode, whose bring-up
+     * leaves its own delay tuning in the registers. */
+    if (sample_rate_applied)
+        reapplyInterfaceDelays("sample-rate change");
 
     if (_autoBandwidth && sample_rate_applied)
         setBandwidthUnlocked(direction, auto_bandwidth_from_sample_rate(rate));

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRDevice.hpp
@@ -531,6 +531,15 @@ class DLL_EXPORT SoapyLiteXM2SDR : public SoapySDR::Device {
     uint32_t _rxChannelMaskHw = 0;
     uint32_t _txChannelMaskHw = 0;
 
+    /* FPGA <-> AD9361 interface delay calibration (calibrate_delay=1): the
+     * PRBS-scanned delay register values, cached so they can be re-applied
+     * after RFIC re-initializations (channel-mode changes) reset them. */
+    bool _ifaceDelayCalRequested = false;
+    bool _ifaceDelayCalValid = false;
+    uint8_t _rxIfaceDelayReg = 0;
+    uint8_t _txIfaceDelayReg = 0;
+    void reapplyInterfaceDelays(const char *context);
+
     void invalidateRfHardwareCache();
     std::recursive_mutex &streamAccessMutex(SoapySDR::Stream *stream) const;
     void resetDatapathUnlocked();

--- a/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
+++ b/litex_m2sdr/software/soapysdr/LiteXM2SDRStreaming.cpp
@@ -722,6 +722,9 @@ SoapySDR::Stream *SoapyLiteXM2SDR::setupStream(
     lock.unlock();
 
     if (channel_mode_changed) {
+        /* The channel-mode change re-ran the AD9361 bring-up, which resets
+         * the interface delay registers to the header defaults. */
+        reapplyInterfaceDelays("channel-mode change");
         if (_rx_stream.opened) {
             for (size_t chan : _rx_stream.channels)
                 channel_configure(SOAPY_SDR_RX, chan);
@@ -781,6 +784,10 @@ int SoapyLiteXM2SDR::activateStream(
         return SOAPY_SDR_NOT_SUPPORTED;
 
     std::lock_guard<std::recursive_mutex> stream_lock(streamAccessMutex(stream));
+
+    /* Last line of defense for calibrated interface delays: any RFIC
+     * re-initialization since calibration reset them to the defaults. */
+    reapplyInterfaceDelays("stream activation");
 
     /* RX */
     if (stream == RX_STREAM) {

--- a/litex_m2sdr/software/soapysdr/README.md
+++ b/litex_m2sdr/software/soapysdr/README.md
@@ -111,6 +111,9 @@ You can pass device arguments to configure the driver. These are most useful whe
   - `tx_late_margin_ns=M`: lateness tolerance before a timed write is rejected (default: one MTU duration).
 - **RX DMA headers** (PCIe): `rx_dma_header=1|0`
   - `1` (default) uses the FPGA per-buffer hardware timestamps for RX time reporting when the gateware supports them (probed at open; falls back to software accounting otherwise).
+- **Interface delay calibration**: `calibrate_delay=1|0`
+  - `0` (default) keeps the AD9361 digital-interface clock/data delays from the driver defaults, which suit most boards.
+  - `1` runs the PRBS delay scan (same procedure as `m2sdr_rf --calibrate-delay`, a few seconds at open) for boards whose timing eye sits at the edge of the defaults and RX/TX capture zeros or noise otherwise. The calibrated delays are cached and re-applied automatically after channel-mode or sample-rate reconfigurations. Ignored with `bypass_init=1`.
 
 Example:
 ```bash

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr.h
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr.h
@@ -794,6 +794,22 @@ int  m2sdr_set_fpga_prbs_tx(struct m2sdr_dev *dev, bool enable);
 int  m2sdr_get_fpga_prbs_rx_synced(struct m2sdr_dev *dev, bool *synced);
 /* Advanced integration hook used by the SoapySDR driver. */
 int  m2sdr_rf_bind(struct m2sdr_dev *dev, void *ad9361_phy);
+/* Scan/program the FPGA <-> AD9361 interface clock/data delays with the PRBS
+ * path (same procedure as m2sdr_rf --calibrate-delay). Requires an initialized
+ * RFIC and an idle datapath: the PRBS scan corrupts any active stream, and on
+ * gateware without a 1R1T-aware PRBS checker it only converges in 2T2R mode. */
+int  m2sdr_rf_calibrate_interface_delay(struct m2sdr_dev *dev);
+/* Read/write the raw AD9361 interface delay register for one direction
+ * (clock delay in bits [7:4], data delay in bits [3:0], ~0.3 ns per tap).
+ * The setter briefly forces the ENSM through ALERT so the new delays latch;
+ * unlike the PRBS scan it is cheap and safe to call between reconfigurations
+ * to re-apply a previously calibrated value (RFIC re-init resets it). */
+int  m2sdr_rf_get_interface_delay(struct m2sdr_dev *dev,
+                                  enum m2sdr_direction direction,
+                                  uint8_t *delay_reg);
+int  m2sdr_rf_set_interface_delay(struct m2sdr_dev *dev,
+                                  enum m2sdr_direction direction,
+                                  uint8_t delay_reg);
 /* Store the AD9361_InitParam an external integration initialized the RFIC
  * with, so m2sdr_set_channel_mode() re-initializes with the same reference
  * clock, SPI id and GPIO setup. init_param must point to an AD9361_InitParam

--- a/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
+++ b/litex_m2sdr/software/user/libm2sdr/m2sdr_rf.c
@@ -2023,3 +2023,59 @@ int m2sdr_get_fpga_prbs_rx_synced(struct m2sdr_dev *dev, bool *synced)
 {
     return m2sdr_read_prbs_synced(dev, synced);
 }
+
+int m2sdr_rf_calibrate_interface_delay(struct m2sdr_dev *dev)
+{
+    struct ad9361_rf_phy *phy;
+    int rc;
+
+    rc = m2sdr_require_phy(dev, &phy);
+    if (rc != M2SDR_ERR_OK)
+        return rc;
+
+    return m2sdr_calibrate_interface_delay(dev, phy);
+}
+
+int m2sdr_rf_get_interface_delay(struct m2sdr_dev *dev,
+                                 enum m2sdr_direction direction,
+                                 uint8_t *delay_reg)
+{
+    struct ad9361_rf_phy *phy;
+    int rc;
+
+    if (!delay_reg)
+        return M2SDR_ERR_INVAL;
+    if (direction != M2SDR_RX && direction != M2SDR_TX)
+        return M2SDR_ERR_INVAL;
+
+    rc = m2sdr_require_phy(dev, &phy);
+    if (rc != M2SDR_ERR_OK)
+        return rc;
+
+    *delay_reg = ad9361_spi_read(phy->spi,
+        direction == M2SDR_TX ? REG_TX_CLOCK_DATA_DELAY : REG_RX_CLOCK_DATA_DELAY);
+    return M2SDR_ERR_OK;
+}
+
+int m2sdr_rf_set_interface_delay(struct m2sdr_dev *dev,
+                                 enum m2sdr_direction direction,
+                                 uint8_t delay_reg)
+{
+    struct ad9361_rf_phy *phy;
+    int rc;
+
+    if (direction != M2SDR_RX && direction != M2SDR_TX)
+        return M2SDR_ERR_INVAL;
+
+    rc = m2sdr_require_phy(dev, &phy);
+    if (rc != M2SDR_ERR_OK)
+        return rc;
+
+    /* Delay changes only latch cleanly outside the active ENSM data states. */
+    ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);
+    rc = m2sdr_from_ad9361_rc(ad9361_spi_write(phy->spi,
+        direction == M2SDR_TX ? REG_TX_CLOCK_DATA_DELAY : REG_RX_CLOCK_DATA_DELAY,
+        delay_reg));
+    ad9361_ensm_force_state(phy, ENSM_STATE_FDD);
+    return rc;
+}


### PR DESCRIPTION
Fixes #149.

## Problem 2 (the actual streaming killer): zero-copy DMA mmap maps the wrong pages on IOMMU platforms

On the Jetson Orin (aarch64, kernel 6.8.12-1021-tegra, 2026-05-15 M2 PCIe x1 gateware), SoapySDR `readStream()` returned ~76% all-zero buffers while `m2sdr_record` was clean on the same board/config.

Instrumenting the zero-copy ring showed the DMA hardware looping over all 256 descriptors at the full stream rate (`WRITER_TABLE_LEVEL` = 256, loop status advancing), yet userspace only ever saw fresh data in 63 fixed ring slots — slots 5..197 stayed all-zero forever. The problem reproduces with a pure-C `m2sdr_get_buffer()` loop, with no SoapySDR involved.

Root cause: the kernel driver's `mmap()` had an ARM/AArch64 special case that derives buffer pages via `phys_to_virt(dma_to_phys(dma_handle))`. Behind an IOMMU/SMMU (as on Jetson Orin's PCIe), `dma_addr_t` is an IOVA, not a physical address, so the mapping exposes unrelated memory — and maps it cached against the coherent allocation attributes. The copy-mode `read()` path is unaffected because the kernel copies from its own `writer_addr[]` pointers, which is exactly why the C tools worked while every zero-copy consumer (the SoapySDR driver) failed.

Fix: drop the special case and use the existing generic `litepcie_dma_buffer_mmap()` on all architectures. It resolves pages from the coherent `cpu_addr` (handling both the dma-iommu vmalloc remap and the dma-direct linear map) and applies proper DMA pgprot attributes.

Verified on the Jetson Orin with the 2026-05-15 gateware:
- `test_record.py` (issue repro): **24.3% → 99.9% nonzero samples, 0 all-zero windows**, no timeouts at 10 MSPS.
- `m2sdr_util dma-test --zero-copy`: 2.83 Gbps, **0 errors** over 200k+ buffers (covers the TX/reader mmap too).
- `m2sdr_record` unchanged (92-95% nonzero, RF noise floor).

## Problem 1: SoapySDR driver cannot calibrate the FPGA↔AD9361 interface delays

With the mmap fix in place the header default delays stream fine on this board at 10 and 30.72 MSPS, so the all-zeros-without-calibration symptom from the issue did not reproduce today — but boards/temperatures whose timing eye sits at the edge of the defaults still have no way to run the PRBS scan through SoapySDR.

This PR adds:
- `libm2sdr`: `m2sdr_rf_calibrate_interface_delay()` (same procedure as `m2sdr_rf --calibrate-delay`) and `m2sdr_rf_get/set_interface_delay()` for cheap re-apply of the raw delay registers.
- SoapySDR device arg `calibrate_delay=1` (default off, ~5s at open): runs the scan at open while the RFIC is still in its bring-up 2T2R layout — on this gateware the PRBS checker cannot converge in 1T1R, which also means the scan must happen before `setupStream()` switches channel modes. The calibrated registers are cached and re-applied after channel-mode changes (full RFIC re-init), sample-rate changes (dropping back from the wide-bandwidth mode, which keeps its own delay tuning above 61.44 MSPS), and at stream activation as a final safety net.

Verified: with `calibrate_delay=1` the scan runs at open (e.g. RX clk 9 / dat 6, window 13), the register still holds the calibrated value while a 1T1R stream is live (read back via `m2sdr_util ad9361-dump` from a second process), and RX streams 99.9% nonzero.

## Docs: IOMMU passthrough no longer required

The README/Jetson notes recommended `iommu.passthrough=1` (or `iommu=pt` on x86) whenever no I/Q data shows up — in hindsight that was a workaround for exactly this mmap bug: passthrough makes the IOVA equal the physical address, so the broken `phys_to_virt(dma_to_phys(...))` derivation happened to work. All verification above ran on JetPack 7 (L4T R39.2.0) with the **stock kernel command line** — SMMU translation active, no passthrough. The docs now present passthrough as a legacy workaround for older driver builds instead of a requirement.

Happy to split the PR or adjust the device-arg default if you'd prefer calibration on by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
