### PR TITLE
kernel: survive PCIe link errors without a reboot (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 The LiteX M2 SDR project is actively under development. We maintain this changelog to allow users and potential clients of the hardware to follow the project's progress and stay up to date with the latest features and improvements. Date-named bitstream archive releases complement the development summaries below.
 
+[> 2026 Q3 to date (Jul - )
+---------------------------
+**Kernel Driver PCIe Fault Handling**
+- Added PCIe error recovery to the kernel driver: AER/DPC events now reach `error_detected`/`slot_reset`/`resume` handlers that stop using the device, re-initialize the core after the reset, and retire the file descriptors the reset invalidated, so a fatal link error no longer leaves the board dead until the host is rebooted (#156).
+- Bounded the probe identifier read on an unreachable core: the driver bails out on the first all-ones word instead of issuing 256 MMIO reads that each cost a full PCIe completion timeout, which stalled the machine for ~1 minute per failed probe (#156).
+- Ratelimited the DMA overrun/underrun messages, which could otherwise flood the log with thousands of lines during a stream overrun and starve the CPU the stream needed to catch up (#156).
+- Made DMA teardown wait for the engines to report idle before the coherent buffers behind their descriptors are released (#156).
+
 [> 2026-05-15 First Date-Named Release
 --------------------------------------
 **Feature Status at Release**

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -937,7 +937,11 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 	if (overflows) {
 		chan->dma.writer_overflow_events++;
 		chan->dma.writer_overflow_buffers += overflows;
-		dev_err(&s->dev->dev, "Reading too late, %d buffers lost\n", overflows);
+		/* Ratelimited: an overrun burst fires this once per read() call, and
+		 * thousands of console lines in a few seconds starve the very CPU the
+		 * stream needs to catch up (observed alongside RT throttling). The
+		 * exact counts stay available through LITEPCIE_IOCTL_DMA_STATS. */
+		dev_err_ratelimited(&s->dev->dev, "Reading too late, %d buffers lost\n", overflows);
 	}
 
 #ifdef DEBUG_READ
@@ -998,7 +1002,8 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 	if (underflows) {
 		chan->dma.reader_underflow_events++;
 		chan->dma.reader_underflow_buffers += underflows;
-		dev_err(&s->dev->dev, "Writing too late, %d buffers lost\n", underflows);
+		/* Ratelimited for the same reason as the read() overrun above. */
+		dev_err_ratelimited(&s->dev->dev, "Writing too late, %d buffers lost\n", underflows);
 	}
 
 #ifdef DEBUG_WRITE

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -2020,17 +2020,13 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 
 	litepcie_dev->channels = DMA_CHANNELS;
 
-	/* Create all chardev in /dev */
-	ret = litepcie_alloc_chdev(litepcie_dev);
-	if (ret) {
-		dev_err(&dev->dev, "Failed to allocate character device\n");
-		goto fail2;
-	}
-
+	/* Initialize the channels before publishing them: litepcie_alloc_chdev()
+	 * below creates the /dev nodes, and an open() racing with probe must not
+	 * find a channel without its device back-pointer or wait queues. */
 	for (i = 0; i < litepcie_dev->channels; i++) {
 		litepcie_dev->chan[i].index           = i;
 		litepcie_dev->chan[i].block_size      = DMA_BUFFER_SIZE;
-		litepcie_dev->chan[i].minor           = litepcie_dev->minor_base + i;
+		litepcie_dev->chan[i].minor           = litepcie_minor_idx + i;
 		litepcie_dev->chan[i].litepcie_dev    = litepcie_dev;
 		litepcie_dev->chan[i].dma.writer_lock = 0;
 		litepcie_dev->chan[i].dma.reader_lock = 0;
@@ -2068,6 +2064,13 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 		}
 		break;
 		}
+	}
+
+	/* Create all chardev in /dev */
+	ret = litepcie_alloc_chdev(litepcie_dev);
+	if (ret) {
+		dev_err(&dev->dev, "Failed to allocate character device\n");
+		goto fail2;
 	}
 
 	/* Allocate all DMA buffers */

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -74,6 +74,11 @@
 //#define DEBUG_READ
 //#define DEBUG_WRITE
 
+/* How long a recovery reset may take to make BAR0 respond again. Each failed
+ * read costs a PCIe completion timeout, so poll coarsely. */
+#define LITEPCIE_BAR0_READY_POLL_MS     50U
+#define LITEPCIE_BAR0_READY_TIMEOUT_MS  1000U
+
 #define LITEPCIE_SATA_SECTOR_SIZE 512U
 #define LITEPCIE_SATA_DMA_BUFFER_SIZE \
 	(LITEPCIE_SATA_DMA_MAX_SECTORS * LITEPCIE_SATA_SECTOR_SIZE)
@@ -149,6 +154,7 @@ struct litepcie_device {
 	int minor_base;                               /* Base minor number for the device */
 	int irqs;                                     /* Number of IRQs */
 	int channels;                                 /* Number of DMA channels */
+	unsigned int generation;                      /* Bumped by each PCIe recovery reset */
 	struct mutex sata_dma_lock;                   /* Serialize SATA userspace DMA copies */
 	void *sata_dma_cpu;                           /* Coherent buffer for SATA userspace DMA */
 	dma_addr_t sata_dma_handle;                   /* Bus address for SATA userspace DMA */
@@ -167,6 +173,7 @@ struct litepcie_chan_priv {
 	struct litepcie_chan *chan;
 	bool reader;
 	bool writer;
+	unsigned int generation; /* Device generation this fd was opened against */
 };
 
 static int litepcie_major;
@@ -280,6 +287,45 @@ static inline void litepcie_writel(struct litepcie_device *s, uint32_t addr, uin
 	dev_dbg(&s->dev->dev, "csr_write: 0x%08x @ 0x%08x", val, addr);
 #endif
 	writel(val, s->bar0_addr + addr - CSR_BASE);
+}
+
+/* -----------------------------------------------------------------------------------------------*/
+/*                                 PCIe Link State                                                */
+/* -----------------------------------------------------------------------------------------------*/
+
+/* True while the PCI core considers the link unusable: from error_detected() to
+ * resume() during AER/DPC recovery, and after a surprise removal. MMIO is not
+ * allowed then (and every read would return 0xffffffff after burning a full
+ * completion timeout), so the paths below give up instead of touching the
+ * device. */
+static bool litepcie_dev_offline(struct litepcie_device *s)
+{
+	return pci_channel_offline(s->dev);
+}
+
+/* True once a file descriptor can no longer be used: either the link is offline,
+ * or a PCIe recovery reset the core underneath it. A reset leaves the DMA engines
+ * disabled and their descriptor tables empty, so the counters this fd streams
+ * against describe hardware state that no longer exists; userspace has to close
+ * and reopen. */
+static bool litepcie_fd_stale(struct litepcie_chan_priv *chan_priv)
+{
+	struct litepcie_device *s = chan_priv->chan->litepcie_dev;
+
+	return litepcie_dev_offline(s) ||
+	       READ_ONCE(s->generation) != chan_priv->generation;
+}
+
+/* Wake every DMA waiter so blocked read()/write() calls re-test litepcie_fd_stale()
+ * and return -EIO, instead of waiting for counters that can never advance again. */
+static void litepcie_wake_all(struct litepcie_device *s)
+{
+	int i;
+
+	for (i = 0; i < s->channels; i++) {
+		wake_up_interruptible(&s->chan[i].wait_rd);
+		wake_up_interruptible(&s->chan[i].wait_wr);
+	}
 }
 
 /* -----------------------------------------------------------------------------------------------*/
@@ -743,6 +789,12 @@ static irqreturn_t litepcie_interrupt(int irq, void *data)
 	uint32_t clear_mask, irq_vector, irq_enable;
 	int i;
 
+	/* An offline link answers every register read with 0xffffffff, which would
+	 * look like "every interrupt fired" and feed garbage loop status into the
+	 * DMA counters. */
+	if (litepcie_dev_offline(s))
+		return IRQ_NONE;
+
 	/* Determine IRQ vector */
 #ifdef CSR_PCIE_MSI_CLEAR_ADDR
 	/* Single MSI */
@@ -834,13 +886,20 @@ static irqreturn_t litepcie_interrupt(int irq, void *data)
 static int litepcie_open(struct inode *inode, struct file *file)
 {
 	struct litepcie_chan *chan = container_of(inode->i_cdev, struct litepcie_chan, cdev);
-	struct litepcie_chan_priv *chan_priv = kzalloc(sizeof(*chan_priv), GFP_KERNEL);
+	struct litepcie_chan_priv *chan_priv;
 
+	/* Refuse to hand out a descriptor while the link is down: every access
+	 * through it would stall for a completion timeout and fail. */
+	if (litepcie_dev_offline(chan->litepcie_dev))
+		return -EIO;
+
+	chan_priv = kzalloc(sizeof(*chan_priv), GFP_KERNEL);
 	if (!chan_priv)
 		return -ENOMEM;
 
-	chan_priv->chan    = chan;
-	file->private_data = chan_priv;
+	chan_priv->chan       = chan;
+	chan_priv->generation = READ_ONCE(chan->litepcie_dev->generation);
+	file->private_data    = chan_priv;
 
 	if (chan->dma.reader_enable == 0) { /* Clear only if disabled */
 		chan->dma.reader_hw_count      = 0;
@@ -861,21 +920,29 @@ static int litepcie_release(struct inode *inode, struct file *file)
 {
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan *chan = chan_priv->chan;
+	/* Only touch the hardware while it is reachable. The DMA locks and enable
+	 * flags are software state and are always released, so a later open() is
+	 * not left locked out by a descriptor closed during an outage. */
+	bool offline = litepcie_dev_offline(chan->litepcie_dev);
 
 	if (chan_priv->reader) {
-		/* Disable interrupt */
-		litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
-		/* Disable DMA */
-		litepcie_dma_reader_stop(chan->litepcie_dev, chan->index);
+		if (!offline) {
+			/* Disable interrupt */
+			litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
+			/* Disable DMA */
+			litepcie_dma_reader_stop(chan->litepcie_dev, chan->index);
+		}
 		chan->dma.reader_lock   = 0;
 		chan->dma.reader_enable = 0;
 	}
 
 	if (chan_priv->writer) {
-		/* Disable interrupt */
-		litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.writer_interrupt);
-		/* Disable DMA */
-		litepcie_dma_writer_stop(chan->litepcie_dev, chan->index);
+		if (!offline) {
+			/* Disable interrupt */
+			litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.writer_interrupt);
+			/* Disable DMA */
+			litepcie_dma_writer_stop(chan->litepcie_dev, chan->index);
+		}
 		chan->dma.writer_lock   = 0;
 		chan->dma.writer_enable = 0;
 	}
@@ -895,6 +962,9 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 	struct litepcie_chan      *chan      = chan_priv->chan;
 	struct litepcie_device    *s         = chan->litepcie_dev;
 
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
+
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.writer_hw_count == chan->dma.writer_sw_count)
 			ret = -EAGAIN;
@@ -902,11 +972,18 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 			ret = 0;
 	} else {
 		ret = wait_event_interruptible(chan->wait_rd,
-						   (chan->dma.writer_hw_count - chan->dma.writer_sw_count) > 0);
+						   (chan->dma.writer_hw_count - chan->dma.writer_sw_count) > 0 ||
+						   litepcie_fd_stale(chan_priv));
 	}
 
 	if (ret < 0)
 		return ret;
+
+	/* The link went down (or the core was reset) while we were waiting: the
+	 * counters cannot advance any more, so report the error instead of
+	 * handing back stale buffer contents. */
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
 
 	i = 0;
 	overflows = 0;
@@ -961,6 +1038,9 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 	struct litepcie_chan      *chan      = chan_priv->chan;
 	struct litepcie_device    *s         = chan->litepcie_dev;
 
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
+
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.reader_hw_count == chan->dma.reader_sw_count)
 			ret = -EAGAIN;
@@ -968,11 +1048,17 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 			ret = 0;
 	} else {
 		ret = wait_event_interruptible(chan->wait_wr,
-						   (chan->dma.reader_sw_count - chan->dma.reader_hw_count) < DMA_BUFFER_COUNT/2);
+						   (chan->dma.reader_sw_count - chan->dma.reader_hw_count) < DMA_BUFFER_COUNT/2 ||
+						   litepcie_fd_stale(chan_priv));
 	}
 
 	if (ret < 0)
 		return ret;
+
+	/* See litepcie_read(): do not keep filling a ring the device stopped
+	 * draining because the link went down under us. */
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
 
 	i          = 0;
 	underflows = 0;
@@ -1083,6 +1169,9 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 #endif
 	int is_tx, i;
 
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
+
 	if (vma->vm_end - vma->vm_start != DMA_BUFFER_TOTAL_SIZE)
 		return -EINVAL;
 
@@ -1151,6 +1240,11 @@ static unsigned int litepcie_poll(struct file *file, poll_table *wait)
 	poll_wait(file, &chan->wait_rd, wait);
 	poll_wait(file, &chan->wait_wr, wait);
 
+	/* Report the error condition rather than "no data yet": an event-loop
+	 * waiting on this fd would otherwise never be told the device is gone. */
+	if (litepcie_fd_stale(chan_priv))
+		return POLLERR | POLLHUP;
+
 #ifdef DEBUG_POLL
 	dev_dbg(&s->dev->dev, "poll: writer hw_count: %10lld / sw_count %10lld\n",
 		chan->dma.writer_hw_count, chan->dma.writer_sw_count);
@@ -1176,6 +1270,11 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan      *chan      = chan_priv->chan;
 	struct litepcie_device    *dev       = chan->litepcie_dev;
+
+	/* Every command below either touches CSRs or reports DMA state that a
+	 * recovery reset invalidated, so none of them can be served. */
+	if (litepcie_fd_stale(chan_priv))
+		return -EIO;
 
 	switch (cmd) {
 	case LITEPCIE_IOCTL_REG:
@@ -1661,6 +1760,9 @@ static int litepcie_ptp_gettimex64(struct ptp_clock_info *ptp,
 							   ptp_caps);
 	unsigned long flags;
 
+	if (litepcie_dev_offline(dev))
+		return -EIO;
+
 	/* Acquire lock to ensure consistent time reading */
 	spin_lock_irqsave(&dev->tmreg_lock, flags);
 
@@ -1681,6 +1783,9 @@ static int litepcie_ptp_settime(struct ptp_clock_info *ptp, const struct timespe
 	struct litepcie_device *dev = container_of(ptp, struct litepcie_device,
 							   ptp_caps);
 	unsigned long flags;
+
+	if (litepcie_dev_offline(dev))
+		return -EIO;
 
 	/* Acquire lock to prevent concurrent access */
 	spin_lock_irqsave(&dev->tmreg_lock, flags);
@@ -1705,6 +1810,9 @@ static int litepcie_ptp_adjfine(struct ptp_clock_info *ptp, long scaled_ppm)
 	struct litepcie_device *dev = container_of(ptp, struct litepcie_device,
 							   ptp_caps);
 	unsigned long flags;
+
+	if (litepcie_dev_offline(dev))
+		return -EIO;
 
 	/* Acquire lock to prevent concurrent access */
 	spin_lock_irqsave(&dev->tmreg_lock, flags);
@@ -1740,6 +1848,9 @@ static int litepcie_ptp_adjtime(struct ptp_clock_info *ptp, s64 delta)
 	struct timespec64 now, then = ns_to_timespec64(delta);
 	unsigned long flags;
 
+	if (litepcie_dev_offline(dev))
+		return -EIO;
+
 	/* Acquire lock to prevent concurrent access */
 	spin_lock_irqsave(&dev->tmreg_lock, flags);
 
@@ -1772,6 +1883,9 @@ static int litepcie_phc_get_syncdevicetime(ktime_t *device,
 	u64 t1_curr;
 	ktime_t t1, t2_curr;
 	int count = 100;
+
+	if (litepcie_dev_offline(dev))
+		return -EIO;
 
 	/* Get a snapshot of system clocks to use as historic value */
 	ktime_get_snapshot(&dev->snapshot);
@@ -1868,6 +1982,38 @@ static struct ptp_clock_info litepcie_ptp_info = {
 	.getcrosststamp = litepcie_ptp_getcrosststamp,
 	.enable         = litepcie_ptp_enable,
 };
+
+/* Enable the board time counter and prime the PTM requester, leaving T1/T4 ready
+ * for the next request. Called at probe and again after a recovery reset, which
+ * puts both register blocks back to their defaults. */
+static void litepcie_time_ptm_init(struct litepcie_device *s)
+{
+	int count = 100;
+
+	/* Enable timer (time) counter */
+	litepcie_writel(s, CSR_TIME_GEN_CONTROL_ADDR, TIME_CONTROL_ENABLE | TIME_CONTROL_SYNC_ENABLE);
+
+	/* Enable PTM control and start first request */
+	litepcie_writel(s, CSR_PTM_REQUESTER_CONTROL_ADDR, PTM_CONTROL_ENABLE | PTM_CONTROL_TRIGGER);
+
+	/* Prepare T1 & T4 for next request */
+	do {
+		if ((litepcie_readl(s, CSR_PTM_REQUESTER_STATUS_ADDR) & PTM_STATUS_BUSY) == 0)
+			break;
+	} while (--count);
+
+	litepcie_writel(s, CSR_PTM_REQUESTER_CONTROL_ADDR, PTM_CONTROL_ENABLE | PTM_CONTROL_TRIGGER);
+	count = 100;
+	do {
+		if ((litepcie_readl(s, CSR_PTM_REQUESTER_STATUS_ADDR) & PTM_STATUS_BUSY) == 0)
+			break;
+	} while (--count);
+
+	s->t4_prev = litepcie_read64(s, CSR_PTM_REQUESTER_T4_TIME_ADDR);
+
+	s->t1_prev = (((u64)litepcie_readl(s, PTM_T1_TIME_L) << 32) |
+		litepcie_readl(s, PTM_T1_TIME_H));
+}
 #endif
 
 /* -----------------------------------------------------------------------------------------------*/
@@ -1885,9 +2031,6 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	struct litepcie_device *litepcie_dev = NULL;
 #ifdef CSR_UART_XOVER_RXTX_ADDR
 	struct resource *tty_res = NULL;
-#endif
-#ifdef CSR_PTM_REQUESTER_BASE
-	int count = 100;
 #endif
 
 	dev_info(&dev->dev, "\e[1m[Probing device]\e[0m\n");
@@ -2119,29 +2262,7 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	/* Display created PTP device */
 	dev_info(&dev->dev, "PTP clock registered as /dev/ptp%d\n", ptp_clock_index(litepcie_dev->litepcie_ptp_clock));
 
-	/* Enable timer (time) counter */
-	litepcie_writel(litepcie_dev, CSR_TIME_GEN_CONTROL_ADDR, TIME_CONTROL_ENABLE | TIME_CONTROL_SYNC_ENABLE);
-
-	/* Enable PTM control and start first request */
-	litepcie_writel(litepcie_dev, CSR_PTM_REQUESTER_CONTROL_ADDR, PTM_CONTROL_ENABLE | PTM_CONTROL_TRIGGER);
-
-	/* Prepare T1 & T4 for next request */
-	do {
-		if ((litepcie_readl(litepcie_dev, CSR_PTM_REQUESTER_STATUS_ADDR) & PTM_STATUS_BUSY) == 0)
-			break;
-	} while (--count);
-
-	litepcie_writel(litepcie_dev, CSR_PTM_REQUESTER_CONTROL_ADDR, PTM_CONTROL_ENABLE | PTM_CONTROL_TRIGGER);
-	count = 100;
-	do {
-		if ((litepcie_readl(litepcie_dev, CSR_PTM_REQUESTER_STATUS_ADDR) & PTM_STATUS_BUSY) == 0)
-			break;
-	} while (--count);
-
-	litepcie_dev->t4_prev = litepcie_read64(litepcie_dev, CSR_PTM_REQUESTER_T4_TIME_ADDR);
-
-	litepcie_dev->t1_prev = (((u64)litepcie_readl(litepcie_dev, PTM_T1_TIME_L) << 32) |
-		litepcie_readl(litepcie_dev, PTM_T1_TIME_H));
+	litepcie_time_ptm_init(litepcie_dev);
 
 	spin_lock_init(&litepcie_dev->tmreg_lock);
 #endif
@@ -2191,20 +2312,25 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 	/* Stop the DMAs */
 	litepcie_stop_dma(litepcie_dev);
 
+	/* Everything below only makes sense while the device answers MMIO: on an
+	 * offline link each access burns a completion timeout and changes nothing,
+	 * so skip straight to releasing the host-side resources. */
+	if (!litepcie_dev_offline(litepcie_dev)) {
 #ifdef CSR_SATA_PHY_BASE
-if (litepcie_soc_has_sata(litepcie_dev)) {
-	/* Disable SATA interrupts */
+	if (litepcie_soc_has_sata(litepcie_dev)) {
+		/* Disable SATA interrupts */
 #ifdef SATA_SECTOR2MEM_INTERRUPT
-    litepcie_disable_interrupt(litepcie_dev, SATA_SECTOR2MEM_INTERRUPT);
+	    litepcie_disable_interrupt(litepcie_dev, SATA_SECTOR2MEM_INTERRUPT);
 #endif
 #ifdef SATA_MEM2SECTOR_INTERRUPT
-    litepcie_disable_interrupt(litepcie_dev, SATA_MEM2SECTOR_INTERRUPT);
+	    litepcie_disable_interrupt(litepcie_dev, SATA_MEM2SECTOR_INTERRUPT);
 #endif
-}
+	}
 #endif
 
-	/* Disable all interrupts */
-	litepcie_writel(litepcie_dev, CSR_PCIE_MSI_ENABLE_ADDR, 0);
+		/* Disable all interrupts */
+		litepcie_writel(litepcie_dev, CSR_PCIE_MSI_ENABLE_ADDR, 0);
+	}
 
     /* Unregister PTP */
 #ifdef CSR_PTM_REQUESTER_BASE
@@ -2229,6 +2355,147 @@ if (litepcie_soc_has_sata(litepcie_dev)) {
 	pci_free_irq_vectors(dev);
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+/*                                    PCIe Error Recovery                                          */
+/* ----------------------------------------------------------------------------------------------- */
+
+/* Poll BAR0 until the core answers MMIO again. The identifier region starts with
+ * the ASCII version string, so an all-ones readback can only mean the access did
+ * not reach the core. */
+static bool litepcie_wait_bar0_ready(struct litepcie_device *s)
+{
+	unsigned int waited;
+
+	for (waited = 0; ; waited += LITEPCIE_BAR0_READY_POLL_MS) {
+		if (litepcie_readl(s, CSR_IDENTIFIER_MEM_BASE) != 0xffffffff)
+			return true;
+
+		if (waited >= LITEPCIE_BAR0_READY_TIMEOUT_MS)
+			return false;
+
+		msleep(LITEPCIE_BAR0_READY_POLL_MS);
+	}
+}
+
+/* Called by the PCI core when the port above us reports an error (AER/DPC).
+ *
+ * Without these callbacks the kernel gives up on a fatal error with
+ * "can't recover (no error_detected callback)" and the board stays dead until the
+ * host is rebooted. All we have to do here is stop using the device: MMIO is
+ * forbidden while the channel is frozen, and the recovery reset happens between
+ * this callback and slot_reset() below. */
+static pci_ers_result_t litepcie_pci_error_detected(struct pci_dev *dev,
+						    pci_channel_state_t state)
+{
+	struct litepcie_device *litepcie_dev = pci_get_drvdata(dev);
+
+	dev_err(&dev->dev, "PCIe error detected (channel state %u)\n", (unsigned int)state);
+
+	if (state == pci_channel_io_normal) {
+		/* Non-fatal: the link still works, nothing to tear down. */
+		return PCI_ERS_RESULT_CAN_RECOVER;
+	}
+
+	/* litepcie_dev_offline() already reports the device as unusable (the core
+	 * set the io state before calling us), which fences off the file
+	 * operations, the interrupt handler and the PTP callbacks. Waiters have to
+	 * be kicked explicitly: their DMA counters can never advance again. */
+	if (litepcie_dev)
+		litepcie_wake_all(litepcie_dev);
+
+	if (state == pci_channel_io_perm_failure)
+		return PCI_ERS_RESULT_DISCONNECT;
+
+	return PCI_ERS_RESULT_NEED_RESET;
+}
+
+/* Called after the core has reset the slot/bus for us: bring the endpoint back
+ * to the state litepcie_pci_probe() leaves it in, minus the host-side resources
+ * (chardevs, IRQs, DMA buffers) which were never released. */
+static pci_ers_result_t litepcie_pci_slot_reset(struct pci_dev *dev)
+{
+	struct litepcie_device *litepcie_dev = pci_get_drvdata(dev);
+	int i;
+
+	if (!litepcie_dev)
+		return PCI_ERS_RESULT_DISCONNECT;
+
+	/* Config space has been restored by the core, which may have re-enabled
+	 * bus mastering: hold it off until the core is reset and its engines are
+	 * known to be idle, for the same reason as in litepcie_pci_probe(). */
+	pci_clear_master(dev);
+
+	/* Wait for the endpoint to answer MMIO again. The PCI core waits for the
+	 * link to retrain and for config space to respond before calling us, but the
+	 * FPGA's PCIe block and the LiteX SoC behind it need longer than that: on a
+	 * Jetson Orin, BAR0 still read all-ones 24 ms after the root port reported
+	 * "link has been reset". */
+	if (!litepcie_wait_bar0_ready(litepcie_dev)) {
+		dev_err(&dev->dev, "Slot reset did not restore BAR0 access\n");
+		return PCI_ERS_RESULT_DISCONNECT;
+	}
+
+	/* Reset the LitePCIe core */
+#ifdef CSR_CTRL_RESET_ADDR
+	litepcie_writel(litepcie_dev, CSR_CTRL_RESET_ADDR, 1);
+	msleep(10);
+	if (!litepcie_wait_bar0_ready(litepcie_dev)) {
+		dev_err(&dev->dev, "Core did not come back from reset\n");
+		return PCI_ERS_RESULT_DISCONNECT;
+	}
+#endif
+
+	/* Mask all interrupts: the enables belong to DMA engines the reset has
+	 * disabled, and userspace re-arms them when it restarts a stream. */
+	litepcie_writel(litepcie_dev, CSR_PCIE_MSI_ENABLE_ADDR, 0);
+
+	/* Drop the DMA state the reset invalidated. The DMA locks are deliberately
+	 * left alone: they belong to the file descriptors that still hold them,
+	 * and those are retired by the generation bump below. */
+	for (i = 0; i < litepcie_dev->channels; i++) {
+		struct litepcie_dma_chan *dmachan = &litepcie_dev->chan[i].dma;
+
+		dmachan->writer_enable        = 0;
+		dmachan->reader_enable        = 0;
+		dmachan->writer_hw_count      = 0;
+		dmachan->writer_hw_count_last = 0;
+		dmachan->writer_sw_count      = 0;
+		dmachan->reader_hw_count      = 0;
+		dmachan->reader_hw_count_last = 0;
+		dmachan->reader_sw_count      = 0;
+	}
+
+	/* Retire every file descriptor opened before the reset: the streams they
+	 * were driving are gone and their counters mean nothing now. */
+	WRITE_ONCE(litepcie_dev->generation, litepcie_dev->generation + 1);
+
+#ifdef CSR_PTM_REQUESTER_BASE
+	/* The reset also cleared the time/PTM registers. */
+	litepcie_time_ptm_init(litepcie_dev);
+#endif
+
+	/* The DMA buffers are still allocated and mapped, so the core may DMA
+	 * again as soon as a stream is restarted. */
+	pci_set_master(dev);
+
+	dev_info(&dev->dev, "Core reset after PCIe error, reopen the device to stream again\n");
+
+	return PCI_ERS_RESULT_RECOVERED;
+}
+
+/* Called once recovery is complete; the core has already put the device back
+ * into the pci_channel_io_normal state, so new open() calls succeed from here. */
+static void litepcie_pci_resume(struct pci_dev *dev)
+{
+	dev_info(&dev->dev, "PCIe error recovery finished, device usable again\n");
+}
+
+static const struct pci_error_handlers litepcie_pci_err_handlers = {
+	.error_detected = litepcie_pci_error_detected,
+	.slot_reset     = litepcie_pci_slot_reset,
+	.resume         = litepcie_pci_resume,
+};
+
 /* PCI device ID table */
 static const struct pci_device_id litepcie_pci_ids[] = {
 	{ PCI_DEVICE(PCIE_XILINX_VENDOR_ID, PCIE_XILINX_DEVICE_ID_S7_GEN2_X1), },
@@ -2240,10 +2507,11 @@ MODULE_DEVICE_TABLE(pci, litepcie_pci_ids);
 
 /* PCI driver structure */
 static struct pci_driver litepcie_pci_driver = {
-	.name     = LITEPCIE_NAME,
-	.id_table = litepcie_pci_ids,
-	.probe    = litepcie_pci_probe,
-	.remove   = litepcie_pci_remove,
+	.name        = LITEPCIE_NAME,
+	.id_table    = litepcie_pci_ids,
+	.probe       = litepcie_pci_probe,
+	.remove      = litepcie_pci_remove,
+	.err_handler = &litepcie_pci_err_handlers,
 };
 
 /* Module initialization function */

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -1945,9 +1945,30 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	msleep(10);
 #endif
 
-	/* Read and display the FPGA identifier */
-	for (i = 0; i < 256; i++)
-		fpga_identifier[i] = litepcie_readl(litepcie_dev, CSR_IDENTIFIER_MEM_BASE + i * 4);
+	/* Read and display the FPGA identifier.
+	 *
+	 * Bail out on the first all-ones word: an unreachable core reads back
+	 * 0xffffffff on every access and each of those reads costs a full PCIe
+	 * completion timeout (up to 50 ms). Blindly reading the whole 256-word
+	 * region then stalls the machine for the best part of a minute before
+	 * logging a "Version \xff\xff..." string and continuing into a probe that
+	 * cannot work anyway. */
+	for (i = 0; i < sizeof(fpga_identifier) - 1; i++) {
+		uint32_t word = litepcie_readl(litepcie_dev, CSR_IDENTIFIER_MEM_BASE + i * 4);
+
+		if (word == 0xffffffff) {
+			dev_err(&dev->dev,
+				"BAR0 reads all-ones at identifier word %d: link down or core unresponsive\n",
+				i);
+			ret = -EIO;
+			goto fail1;
+		}
+
+		fpga_identifier[i] = word;
+		if (!fpga_identifier[i])
+			break;
+	}
+	fpga_identifier[sizeof(fpga_identifier) - 1] = '\0';
 	dev_info(&dev->dev, "Version %s\n", fpga_identifier);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)

--- a/litex_m2sdr/software/kernel/main.c
+++ b/litex_m2sdr/software/kernel/main.c
@@ -79,6 +79,15 @@
 #define LITEPCIE_BAR0_READY_POLL_MS     50U
 #define LITEPCIE_BAR0_READY_TIMEOUT_MS  1000U
 
+/* Bit 1 of a DMA engine's ENABLE register reads back the engine FSM being in its
+ * IDLE state (LitePCIe exports fsm.ongoing("IDLE") there); bit 0 is the enable
+ * itself. Polled at teardown to confirm no descriptor is still executing. */
+#define PCIE_DMA_IDLE_STATUS            (1 << 1)
+#define LITEPCIE_DMA_IDLE_POLL_US       10U
+/* One descriptor is at most DMA_BUFFER_SIZE, split into max_payload_size writes:
+ * a couple of microseconds on a healthy Gen2 link, so this is ~100x margin. */
+#define LITEPCIE_DMA_IDLE_TIMEOUT_US    1000U
+
 #define LITEPCIE_SATA_SECTOR_SIZE 512U
 #define LITEPCIE_SATA_DMA_BUFFER_SIZE \
 	(LITEPCIE_SATA_DMA_MAX_SECTORS * LITEPCIE_SATA_SECTOR_SIZE)
@@ -767,16 +776,69 @@ static void litepcie_dma_reader_stop(struct litepcie_device *s, int chan_num)
 	dmachan->reader_sw_count      = 0;
 }
 
-/* Stop all DMA channels */
+/* Wait for one DMA engine to report its FSM idle after ENABLE was cleared.
+ *
+ * Bounded: a core that is wedged (or whose requests can no longer complete)
+ * must not hold up teardown, so a timeout only warns. */
+static void litepcie_dma_wait_idle(struct litepcie_device *s, uint32_t enable_addr,
+				   const char *what)
+{
+	unsigned int i;
+	uint32_t val;
+
+	for (i = 0; i < LITEPCIE_DMA_IDLE_TIMEOUT_US / LITEPCIE_DMA_IDLE_POLL_US; i++) {
+		val = litepcie_readl(s, enable_addr);
+
+		/* Link gone: there is nothing left to wait for and nothing that
+		 * could still reach the host. */
+		if (val == 0xffffffff)
+			return;
+
+		if (val & PCIE_DMA_IDLE_STATUS)
+			return;
+
+		udelay(LITEPCIE_DMA_IDLE_POLL_US);
+	}
+
+	dev_warn(&s->dev->dev, "%s still busy %u us after being disabled\n",
+		 what, LITEPCIE_DMA_IDLE_TIMEOUT_US);
+}
+
+/* Stop all DMA channels and wait for the engines to go idle.
+ *
+ * Clearing ENABLE only tells the engine to stop taking new descriptors; the one
+ * being executed still runs to completion. Waiting for the idle status makes the
+ * "no descriptor is in flight" precondition explicit before the caller releases
+ * the coherent buffers those descriptors point at - a stale device write into
+ * freed memory is an IOMMU/fabric fault, i.e. exactly the class of failure this
+ * teardown path exists to avoid. */
 static void litepcie_stop_dma(struct litepcie_device *s)
 {
 	struct litepcie_dma_chan *dmachan;
 	int i;
 
+	if (litepcie_dev_offline(s)) {
+		dev_warn(&s->dev->dev, "Link offline, skipping DMA stop\n");
+		return;
+	}
+
 	for (i = 0; i < s->channels; i++) {
 		dmachan = &s->chan[i].dma;
 		litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_ENABLE_OFFSET, 0b0);
 		litepcie_writel(s, dmachan->base + PCIE_DMA_READER_ENABLE_OFFSET, 0b0);
+	}
+
+	/* Only an engine this driver actually started can have a descriptor in
+	 * flight. Skipping the others also keeps teardown quiet and prompt on
+	 * gateware predating the idle status bit, where the readback is always 0. */
+	for (i = 0; i < s->channels; i++) {
+		dmachan = &s->chan[i].dma;
+		if (dmachan->writer_enable)
+			litepcie_dma_wait_idle(s, dmachan->base + PCIE_DMA_WRITER_ENABLE_OFFSET,
+					       "DMA writer");
+		if (dmachan->reader_enable)
+			litepcie_dma_wait_idle(s, dmachan->base + PCIE_DMA_READER_ENABLE_OFFSET,
+					       "DMA reader");
 	}
 }
 


### PR DESCRIPTION
Fixes the driver-side half of #156.

That issue separates two problems, and this PR only addresses the second one:

1. **The link/endpoint failure itself** — root cause still unknown, not touched here.
2. **The driver turning a transient link error into a reboot and a ~1 minute machine
   stall** — that is what this fixes.

## Changes

- **`kernel: recover from PCIe errors instead of needing a reboot`**
  `litepcie_pci_driver` had no `.err_handler`, so a fatal AER event ended at
  `m2sdr: AER: can't recover (no error_detected callback)`. Adds
  `error_detected`/`slot_reset`/`resume`. `slot_reset` re-establishes the endpoint the
  way probe does — bus mastering held off, BAR0 polled until it answers, LitePCIe core
  reset, interrupts masked, DMA state dropped, time/PTM re-primed.

  For that to be safe, everything that touches the device now checks
  `pci_channel_offline()` first (file operations, interrupt handler, PTP callbacks,
  remove path) — using the PCI core's own I/O state rather than a private flag, which
  also covers surprise removal. File descriptors that predate a recovery reset are
  retired through a device generation counter, so they get `-EIO`/`POLLERR` instead of
  waiting on counters that can never advance again; their DMA locks survive until they
  are closed so a reopen cannot steal a channel.

- **`kernel: bail out of probe when BAR0 reads all-ones`**
  The identifier loop issued 256 MMIO reads unconditionally; on a dead link each one
  costs a full completion timeout, which is the ~56 s stall (224 `tegra234_cbb_isr`
  warnings) reported in the issue. Now stops at the first `0xffffffff` and fails with
  `-EIO`.

- **`kernel: ratelimit the DMA overrun/underrun messages`**
  `dev_err()` fired once per `read()`/`write()` that lost buffers.

- **`kernel: wait for the DMA engines to go idle before teardown`**
  `litepcie_stop_dma()` cleared `ENABLE` and returned, so the "engines are idle"
  precondition the caller relies on before releasing the coherent buffers was never
  actually established. Now polls the per-engine idle status (bit 1 of `ENABLE`, which
  LitePCIe drives from `fsm.ongoing("IDLE")`) with a 1 ms bound, and only for engines
  this driver started — a wedged core must not hold up teardown, and gateware predating
  that status bit reads back 0 forever.

- **`kernel: initialize DMA channels before creating their chardevs`**
  `litepcie_alloc_chdev()` published `/dev/m2sdrN` before the per-channel fields —
  including the `litepcie_dev` back-pointer and the wait queues — were filled in.

## Hardware validation

Jetson Orin, `6.8.12-1021-tegra`, SMMU active, `m2` gateware with 2 PCIe DMAs, Gen2 x1
— the host from the issue report.

- 5 minutes of sustained bidirectional `m2sdr_util dma-test` at 2.82–2.84 Gbps
  (13.3 M buffers each way): no PCIe errors while streaming, no false idle-wait
  warnings. The ratelimit suppressed **1,035,441 messages against 1,200 emitted**
  (1318 kernel log lines for the whole run).
- A fatal event then fired on the next module reload, and the new path ran:

  ```
  pcieport 0004:00:00.0: AER: Multiple Uncorrectable (Fatal) ... (Receiver ID)
  pcieport 0004:00:00.0:    [18] MalfTLP  (First)
  m2sdr 0004:01:00.0: PCIe error detected (channel state 2)
  pcieport 0004:00:00.0: AER: Root Port link has been reset (0)
  m2sdr 0004:01:00.0: Slot reset did not restore BAR0 access
  ```

  The host stayed fully responsive — no hang, no reboot, no MMIO stall. The subsequent
  `remove` took 78 ms and `rescan` + probe 143 ms.

Two notes on that event, as data for the issue rather than for this PR: the first error
was `MalfTLP` from the endpoint rather than `CmpltTO`, and it was triggered by a module
reload after sustained DMA. After `remove` + `rescan` MMIO was fully restored
(identifier, scratch round-trip, XADC, `bus_errors = 0`) but **DMA never resumed** —
both engines enable and their descriptor indices stay at 0 — so a root-port secondary
bus reset is not enough to bring the endpoint's bus mastering back, only a full FPGA
re-init is. That is issue item 1 and is not addressable from the driver.

Built clean (no new warnings) against both the repo's committed CSR headers
(1 DMA, PTM enabled) and the board's own export (2 DMA, no PTM); each commit compiles
individually. The `slot_reset` BAR0 poll replaced a single immediate check after that
check was measured failing 24 ms after the link reset while a later `rescan` succeeded;
the retry itself is not verified end to end, because `CONFIG_PCIEAER_INJECT` is not set
on this kernel and the AER path cannot be triggered on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
