### PR TITLE
gateware: enable reliable baseboard 2500BASE-X

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ In this design, the PCIe core will then be replaced with [LiteEth](https://githu
 
 The Ethernet SoC design supports control plus RX/TX sample streaming over the LiteEth UDP path. The achievable 2T2R sample rate is capped by link bandwidth, so Ethernet builds also cap the RFIC clock to the selected link speed.
 
+The 2.5GBASE-X mode has been hardware-validated in SFP0/J3 with a LianGuo LG 2.5GE copper SFP, the Acorn Baseboard Mini's JP1 and JP4 fitted, and the board reachable at `192.168.1.50`. Build it explicitly with `--eth-phy=2500basex`; this selects the 125MHz GTP reference, MMCM PHY clocking, Clause-37 timing, and gearbox constraints needed by the copper module. SFP EEPROM I2C is not required for link or packet traffic. On M2SDR r02, fit `R82`/`R83` only when the optional M.2 SMBus path is needed; an absent or NACKing EEPROM must not be treated as a link failure.
+
 Ethernet-only baseboard builds can also enable SATA storage with `--with-sata`, using SATA on PCIe lane 0 and Ethernet on the selected SFP lane. PCIe, Ethernet/White-Rabbit, and SATA cannot all be enabled in one image because the shared QPLL exposes two channels.
 
 When built with `--with-eth --with-eth-ptp`, LiteEth PTP disciplines the existing `time_gen` timebase instead of replacing it. This keeps PPS generation, VRT timestamps, RX/TX headers, and the PCIe PTM/PHC view on the same logical board clock while sourcing that time from Ethernet PTP. Runtime servo tuning, master/sourcePortIdentity reporting, and live status/counter monitoring are available from the host side. Ethernet PTP and White Rabbit are mutually exclusive. For SI5351C boards, `--with-eth-ptp-rfic-clock` adds an optional low-bandwidth PTP-to-FPGA-10MHz discipline loop; software must still select the FPGA clock input with `--sync fpga` / `clock_source=fpga` before the AD9361 reference is derived from that path.
@@ -500,6 +502,13 @@ For those who want to explore the full potential of the LiteX-M2SDR board, inclu
    ./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 --build --load
    ping 192.168.1.50
    ```
+   - For 2.5GBASE-X with the LianGuo LG 2.5GE copper SFP in SFP0/J3:
+   ```
+   ./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 --eth-phy=2500basex --build --load
+   ping 192.168.1.50
+   ```
+     The validated baseboard configuration has JP1 and JP4 fitted. `R82`/`R83`
+     are needed only for optional SFP EEPROM I2C access, not for Ethernet link.
    - After loading an Ethernet image, use `m2sdr_util` loopback tests to
      exercise the stream path before starting Soapy/Gqrx:
    ```

--- a/doc/debugging-guide.md
+++ b/doc/debugging-guide.md
@@ -388,6 +388,7 @@ probe that matches the current question:
 ./litex_m2sdr.py --variant=m2 --with-pcie --with-pcie-probe --build --load
 ./litex_m2sdr.py --variant=m2 --with-pcie --with-pcie-dma-probe --build --load
 ./litex_m2sdr.py --variant=baseboard --with-eth --with-eth-tx-probe --build --load
+./litex_m2sdr.py --variant=baseboard --with-eth --eth-phy=2500basex --with-eth-phy-rx-probe --build --load
 ./litex_m2sdr.py --with-ad9361-data-probe --build --load
 ```
 
@@ -397,6 +398,23 @@ Use `litescope_cli` through a running `litex_server`:
 litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv --list
 litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv --rising-edge <signal> --dump /tmp/capture.vcd
 ```
+
+The Ethernet PHY RX probe samples both raw 10-bit GTP symbols at 156.25MHz in
+2.5GBASE-X mode, avoiding analyzer logic on the 312.5MHz PCS clock. Through a
+JTAGBone `litex_server`, an untriggered capture should show the repeating
+`K28.5`/idle ordered set on a quiet link. To catch a packet start, trigger on
+either symbol lane for `/S/` (`K27.7`, encoded as `0x05b` or `0x3a4` depending
+on running disparity):
+
+```bash
+litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv --list
+litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv \
+  --value-trigger eth_phy_rx_symbol0 0x05b --offset 0x100 --dump /tmp/eth-rx.vcd
+```
+
+If one lane/disparity does not trigger, try `eth_phy_rx_symbol1` and the other
+encoded value. The PCS status CSR reports link state, SGMII detection, and the
+received link-partner ability word before a LiteScope capture is needed.
 
 If the predefined probes are too wide, add a temporary narrow probe and commit
 only the reusable version. For a one-off analyzer, document the captured signals

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -134,10 +134,24 @@ def get_rfic_clk_freq(with_eth=False, eth_phy="1000basex", with_rfic_oversamplin
         True  : 491.52e6, # Max rfic_clk for 122.88MSPS / 2T2R (Oversampling).
     }[with_rfic_oversampling]
 
+def get_eth_phy_kwargs(eth_phy):
+    if eth_phy == "2500basex":
+        # Keep the clocking and accelerated Clause-37 timers used by the original Acorn
+        # Baseboard Mini 2.5G bring-up. Some copper SFPs do not complete autonegotiation
+        # with wall-clock-scaled 2.5G timers.
+        return {
+            "tx_cm_type"       : "MMCM",
+            "rx_cm_type"       : "MMCM",
+            "pcs_kwargs"       : {"eth_tx_clk_freq": 125e6},
+            "with_pcs_buffers" : True,
+        }
+    return {}
+
 # CRG ----------------------------------------------------------------------------------------------
 
 class CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, with_eth=False, eth_refclk_freq=125e6, with_sata=False, with_white_rabbit=False):
+    def __init__(self, platform, sys_clk_freq, with_eth=False, eth_refclk_freq=125e6,
+        eth_refclk_direct=False, with_sata=False, with_white_rabbit=False):
         self.rst              = Signal()
         self.cd_sys           = ClockDomain()
         self.cd_clk10         = ClockDomain()
@@ -188,7 +202,14 @@ class CRG(LiteXModule):
 
         # Ethernet PLL.
         # -------------
-        if with_eth or with_sata or with_white_rabbit:
+        if eth_refclk_direct:
+            if sys_clk_freq != eth_refclk_freq:
+                raise ValueError("A direct Ethernet reference requires sys_clk_freq == eth_refclk_freq.")
+            self.comb += [
+                self.cd_refclk_eth.clk.eq(self.cd_sys.clk),
+                self.cd_refclk_eth.rst.eq(self.cd_sys.rst),
+            ]
+        elif with_eth or with_sata or with_white_rabbit:
             self.eth_pll = eth_pll = S7PLL()
             eth_pll.register_clkin(self.cd_sys.clk, sys_clk_freq)
             eth_pll.create_clkout(self.cd_refclk_eth, eth_refclk_freq, margin=0)
@@ -344,12 +365,15 @@ class BaseSoC(SoCMini):
 
         # Clocking ---------------------------------------------------------------------------------
 
-        eth_refclk_freq = 156.25e6 if (with_eth and eth_phy == "2500basex") else 125e6
+        # Match the Acorn 2.5G bring-up's 125MHz reference and x25 QPLL
+        # divider configuration. 1000BASE-X already uses 125MHz here.
+        eth_refclk_freq = 125e6
 
         # General.
         self.crg = CRG(platform, sys_clk_freq,
             with_eth          = with_eth,
             eth_refclk_freq   = eth_refclk_freq,
+            eth_refclk_direct = with_eth and (eth_phy == "2500basex"),
             with_sata         = with_sata,
             with_white_rabbit = with_white_rabbit,
         )
@@ -360,6 +384,7 @@ class BaseSoC(SoCMini):
             with_eth        = with_eth | with_white_rabbit,
             eth_phy         = eth_phy,
             eth_refclk_freq = eth_refclk_freq,
+            eth_refclk_direct = with_eth and (eth_phy == "2500basex"),
             with_sata       = with_sata,
         )
 
@@ -592,7 +617,9 @@ class BaseSoC(SoCMini):
                 sys_clk_freq = sys_clk_freq,
                 rx_polarity  = 1, # Inverted on M2SDR.
                 tx_polarity  = 0, # Inverted on M2SDR and Acorn Baseboard Mini.
+                **get_eth_phy_kwargs(eth_phy),
             )
+            self.eth_phy.pcs.add_csr()
 
             # Core + MMAP (Etherbone).
             # ------------------------
@@ -1120,6 +1147,20 @@ class BaseSoC(SoCMini):
             platform.add_period_constraint(self.eth_phy.txoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
             platform.add_period_constraint(self.eth_phy.rxoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
             platform.add_false_path_constraints(self.eth_phy.txoutclk, self.eth_phy.rxoutclk, self.crg.cd_sys.clk)
+            if eth_phy == "2500basex":
+                # The two halves of the RX gearbox exchange state/data on each
+                # 312.5MHz cycle. The named half-rate fabric net is optimized
+                # away, so recover its generated clock from RXUSRCLK2 and bound
+                # both directions to one full-rate period.
+                rx_period = 1e9/self.eth_phy.rx_clk_freq
+                platform.toolchain.pre_placement_commands += [
+                    "set _eth_rx_half_clk [get_clocks -quiet -of_objects [get_pins -quiet -hier -filter {{REF_PIN_NAME == RXUSRCLK2}}]]",
+                    "set _eth_rx_clk [get_clocks -quiet -of_objects [get_nets -quiet {{eth_rx_clk}}]]",
+                    "if {{[llength $_eth_rx_half_clk] && [llength $_eth_rx_clk]}} {{",
+                    f"    set_max_delay {rx_period} -datapath_only -from $_eth_rx_half_clk -to $_eth_rx_clk",
+                    f"    set_max_delay {rx_period} -datapath_only -from $_eth_rx_clk -to $_eth_rx_half_clk",
+                    "}}",
+                ]
 
         # RFIC clock domain.
         platform.add_period_constraint(self.ad9361.cd_rfic.clk, 1e9/platform.rfic_clk_freq)
@@ -1354,6 +1395,24 @@ class BaseSoC(SoCMini):
         )
 
     # Ethernet.
+    def add_eth_phy_rx_probe(self, depth=4096):
+        assert hasattr(self, "eth_phy")
+        self.eth_phy_rx_symbol0 = Signal(10)
+        self.eth_phy_rx_symbol1 = Signal(10)
+        self.comb += [
+            self.eth_phy_rx_symbol0.eq(self.eth_phy.gearbox.rx_data_half[0:10]),
+            self.eth_phy_rx_symbol1.eq(self.eth_phy.gearbox.rx_data_half[10:20]),
+        ]
+        self.analyzer = LiteScopeAnalyzer([
+            self.eth_phy_rx_symbol0,
+            self.eth_phy_rx_symbol1,
+        ],
+            depth        = depth,
+            clock_domain = "eth_rx_half",
+            register     = True,
+            csr_csv      = "test/analyzer.csv"
+        )
+
     def add_eth_tx_probe(self, depth=1024):
         assert hasattr(self, "eth_tx_streamer")
         analyzer_signals = [
@@ -1454,6 +1513,7 @@ def main():
     probeopts.add_argument("--with-pcie-probe",        action="store_true", help="Enable PCIe Probe.")
     probeopts.add_argument("--with-pcie-dma-probe",    action="store_true", help="Enable PCIe DMA Probe.")
     probeopts.add_argument("--with-si5351-i2c-probe",  action="store_true", help="Enable SI5351 I2C Probe.")
+    probeopts.add_argument("--with-eth-phy-rx-probe",  action="store_true", help="Enable raw Ethernet PHY RX Probe.")
     probeopts.add_argument("--with-eth-tx-probe",      action="store_true", help="Enable Ethernet Tx Probe.")
     probeopts.add_argument("--with-ad9361-spi-probe",  action="store_true", help="Enable AD9361 SPI Probe.")
     probeopts.add_argument("--with-ad9361-data-probe", action="store_true", help="Enable AD9361 Data Probe.")
@@ -1489,7 +1549,7 @@ def main():
     if args.wr_status and not args.with_white_rabbit:
         return
 
-    default_sys_clk_freq = 100e6 if args.with_eth else 125e6
+    default_sys_clk_freq = 125e6 if (args.with_eth and args.eth_phy == "2500basex") else (100e6 if args.with_eth else 125e6)
     if args.sys_clk_freq is None:
         args.sys_clk_freq = default_sys_clk_freq
 
@@ -1550,6 +1610,8 @@ def main():
         soc.add_pcie_dma_probe()
     if args.with_si5351_i2c_probe:
         soc.add_si5351_i2c_probe()
+    if args.with_eth_phy_rx_probe:
+        soc.add_eth_phy_rx_probe()
     if args.with_eth_tx_probe:
         soc.add_eth_tx_probe()
     if args.with_ad9361_spi_probe:
@@ -1566,6 +1628,8 @@ def main():
             r += f"_pcie_x{args.pcie_lanes}"
         if args.with_eth:
             r += f"_eth"
+            if args.eth_phy != "1000basex":
+                r += f"_{args.eth_phy}"
             if args.with_eth_ptp:
                 r += "_ptp"
                 if args.with_eth_ptp_rfic_clock:

--- a/litex_m2sdr/gateware/qpll.py
+++ b/litex_m2sdr/gateware/qpll.py
@@ -13,7 +13,8 @@ from liteeth.phy.a7_gtp import QPLLSettings, QPLL
 # Shared QPLL --------------------------------------------------------------------------------------
 
 class SharedQPLL(LiteXModule):
-    def __init__(self, platform, with_pcie=False, with_eth=False, eth_refclk_freq=156.25e6, eth_phy="1000basex", with_sata=False):
+    def __init__(self, platform, with_pcie=False, with_eth=False, eth_refclk_freq=156.25e6,
+        eth_refclk_direct=False, eth_phy="1000basex", with_sata=False):
         assert not (with_pcie and with_eth and with_sata) # QPLL only has 2 PLLs :(
 
         # PCIe QPLL Settings.
@@ -26,7 +27,9 @@ class SharedQPLL(LiteXModule):
 
         # Ethernet QPLL Settings.
         qpll_eth_settings = QPLLSettings(
-            refclksel  = 0b111,
+            # Match the original Acorn 2.5G topology on GTREFCLK0 while
+            # preserving the existing internal reference for 1000BASE-X.
+            refclksel  = {"1000basex": 0b111, "2500basex": 0b001}[eth_phy],
             fbdiv      = {"1000basex": 4, "2500basex": 5}[eth_phy],
             fbdiv_45   = {125e6: 5, 156.25e6 : 4}[eth_refclk_freq],
             refclk_div = 1,
@@ -54,7 +57,7 @@ class SharedQPLL(LiteXModule):
             )
         if with_eth:
             configs["eth"] = QPLLConfig(
-                refclk   = ClockSignal("refclk_eth"),
+                refclk   = ClockSignal("sys") if eth_refclk_direct else ClockSignal("refclk_eth"),
                 settings = qpll_eth_settings,
             )
         if with_sata:

--- a/test/test_cli_args.py
+++ b/test/test_cli_args.py
@@ -35,6 +35,18 @@ def test_rfic_clk_freq_policy():
     ) == 122.88e6
 
 
+def test_eth_phy_kwargs_policy():
+    soc_mod = _load_soc_module()
+
+    assert soc_mod.get_eth_phy_kwargs("1000basex") == {}
+    assert soc_mod.get_eth_phy_kwargs("2500basex") == {
+        "tx_cm_type"       : "MMCM",
+        "rx_cm_type"       : "MMCM",
+        "pcs_kwargs"       : {"eth_tx_clk_freq": 125e6},
+        "with_pcs_buffers" : True,
+    }
+
+
 def test_main_exposes_base_soc_optional_args(monkeypatch):
     soc_mod = _load_soc_module()
     captured = {}
@@ -118,6 +130,52 @@ def test_main_defaults_ethernet_pcie_builds_to_100mhz_sysclk(monkeypatch):
 
     assert captured["kwargs"]["sys_clk_freq"] == 100000000
     assert captured["build_name"] == "litex_m2sdr_baseboard_pcie_x1_eth"
+    assert captured["output_dir"].endswith(captured["build_name"])
+
+
+def test_main_selects_2500basex_and_raw_rx_probe(monkeypatch):
+    soc_mod = _load_soc_module()
+    captured = {}
+
+    class FakeSoC:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def add_eth_phy_rx_probe(self):
+            captured["eth_phy_rx_probe"] = True
+
+    class FakeBuilder:
+        def __init__(self, soc, **kwargs):
+            captured["builder_soc"] = soc
+            captured.update(kwargs)
+            self.gateware_dir = "build/fake/gateware"
+
+        def build(self, build_name, run):
+            captured["build_name"] = build_name
+            captured["run"] = run
+
+    monkeypatch.setattr(soc_mod, "BaseSoC", FakeSoC)
+    monkeypatch.setattr(soc_mod, "Builder", FakeBuilder)
+    monkeypatch.setattr(soc_mod, "generate_litepcie_software", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "litex_m2sdr.py",
+            "--variant=baseboard",
+            "--with-eth",
+            "--eth-sfp=0",
+            "--eth-phy=2500basex",
+            "--with-eth-phy-rx-probe",
+        ],
+    )
+
+    soc_mod.main()
+
+    assert captured["kwargs"]["eth_phy"] == "2500basex"
+    assert captured["kwargs"]["sys_clk_freq"] == 125_000_000
+    assert captured["eth_phy_rx_probe"] is True
+    assert captured["build_name"] == "litex_m2sdr_baseboard_eth_2500basex"
     assert captured["output_dir"].endswith(captured["build_name"])
 
 

--- a/test/test_qpll.py
+++ b/test/test_qpll.py
@@ -57,7 +57,7 @@ def test_shared_qpll_dual_configuration_assigns_distinct_channels(monkeypatch):
     assert dut.get_channel("pcie") is dut.qpll.channels[0]
     assert dut.get_channel("eth") is dut.qpll.channels[1]
     assert dut.qpll.kwargs["qpllsettings1"] == qpll_mod.QPLLSettings(
-        refclksel  = 0b111,
+        refclksel  = 0b001,
         fbdiv      = 5,
         fbdiv_45   = 4,
         refclk_div = 1,
@@ -80,6 +80,22 @@ def test_shared_qpll_eth_sata_configuration_assigns_distinct_channels(monkeypatc
         fbdiv_45   = 4,
         refclk_div = 1,
     )
+
+
+def test_shared_qpll_can_use_system_clock_as_eth_reference(monkeypatch):
+    monkeypatch.setattr(qpll_mod, "QPLL", _FakeQPLL)
+    platform = _DummyPlatform()
+
+    dut = SharedQPLL(
+        platform,
+        with_eth          = True,
+        eth_phy           = "2500basex",
+        eth_refclk_freq   = 125e6,
+        eth_refclk_direct = True,
+    )
+
+    assert dut.qpll.kwargs["gtrefclk0"].cd == "sys"
+    assert dut.qpll.kwargs["gtgrefclk0"] is None
 
 
 @pytest.mark.parametrize("eth_phy, refclk_freq, out_div, expected_linerate", [


### PR DESCRIPTION
## Summary

- use the Acorn-compatible 125 MHz direct GTP reference and QPLL selection for 2500BASE-X
- retain the interoperable Clause-37 timer constants and add PCS/MAC timing buffers
- constrain the RX half/full-rate gearbox in both directions to one 312.5 MHz cycle
- expose PCS status and an optional raw-symbol LiteScope probe
- document the tested LianGuo module, baseboard jumpers, optional SFP I2C resistors, and JTAG debug flow

## Dependency

Depends on https://github.com/enjoy-digital/liteeth/pull/215.

## Hardware validation

Command:

```console
./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 --eth-phy=2500basex --build --load
```

Setup: M2SDR on Acorn Baseboard Mini, SFP0/J3, JP1 + JP4 fitted, LianGuo LG 2.5GE copper SFP, host `192.168.1.53`, target `192.168.1.50`.

- PCS status: `0x41a00001` (link up, partner ability `0x41a0`)
- ping: 10/10 replies, 0% loss
- Ethernet timing: RX WNS +0.234 ns, TX WNS +0.002 ns at 312.5 MHz

The overall timing report still has an RFIC-domain WNS of -0.319 ns; this PR does not attempt to solve RFIC timing closure.

## Tests

- `pytest -q`: 158 passed
