### PR TITLE
gateware: add experimental baseboard 5000BASE-X bring-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Imagine a minimalist AD9361-based SDR with:
 - 2T2R / 12-bit @ 61.44MSPS (and 2T2R / 12-bit @ 122.88MSPS for those wanting to use/explore Cellwizard/BladeRF [findings](https://www.nuand.com/2023-02-release-122-88mhz-bandwidth/)).
 - PCIe Gen 2 X4 (~14Gbps of TX/RX bandwidth) with [LitePCIe](https://github.com/enjoy-digital/litepcie), providing MMAP and several possible DMAs (for direct I/Q samples transfer or processed I/Q samples). ⚡
 - A large XC7A200T FPGA where the base infrastructure only uses a fraction of the available resources, allowing you to integrate large RF processing blocks. 💪
-- The option to reuse some of the PCIe lanes of the M.2 connector for 1Gbps or 2.5Gbps Ethernet through [LiteEth](https://github.com/enjoy-digital/liteeth). 🌐
+- The option to reuse some of the PCIe lanes of the M.2 connector for 1Gbps, 2.5Gbps, or experimental 5Gbps Ethernet through [LiteEth](https://github.com/enjoy-digital/liteeth). 🌐
 - Or ... for SATA through the [LiteSATA](https://github.com/enjoy-digital/litesata) gateware core. 💾
 - Or ... for inter-board SerDes-based communication through [LiteICLink](https://github.com/enjoy-digital/liteiclink). 🔗
 - Powerful debug capabilities through LiteX [Host <-> FPGA bridges](https://github.com/enjoy-digital/litex/wiki/Use-Host-Bridge-to-control-debug-a-SoC) and [LiteScope](https://github.com/enjoy-digital/litescope) logic analyzer. 🛠️
@@ -60,7 +60,7 @@ This board is proudly developed in France 🇫🇷 by [Enjoy-Digital](http://enj
 
 Ideal for SDR enthusiasts, this versatile board fits directly into an M.2 slot or can team up with others in a PCIe M.2 carrier for more complex projects, including coherent MIMO SDRs. 🔧
 
-For Ethernet support with 1000BaseX/2500BaseX and SATA connectivity to directly record/play samples to/from an SSD, mount it on the LiteX Acorn Mini Baseboard! 💽
+For Ethernet support with 1000BaseX/2500BaseX (and experimental 5Gbps operation) and SATA connectivity to directly record/play samples to/from an SSD, mount it on the LiteX Acorn Mini Baseboard! 💽
 
 <div align="center">
   <img src="https://github.com/user-attachments/assets/fb75aeeb-4e99-45b5-9582-0c4dbd079af6" width="100%">
@@ -110,7 +110,7 @@ Both variants use the same **M.2 2280 Key M** module form factor.
 |                                 |                              |                              |                                               |
 | **Connectivity**                |                              |                              |                                               |
 | PCIe (up to Gen2 x4)            | ✅                           | ✅ (x1 only)                 | `--with-pcie --pcie-lanes=1|2|4`              |
-| Ethernet (1G/2.5G)              | ❌                           | ✅                           | `--with-eth`                                  |
+| Ethernet (1G/2.5G/experimental 5G) | ❌                        | ✅                           | `--with-eth --eth-phy=...`                    |
 | ├─ Ethernet RX (LiteEth)        | ❌                           | ✅                           | (included with `--with-eth`)                  |
 | └─ Ethernet TX (LiteEth)        | ❌                           | ✅                           | (included with `--with-eth`)                  |
 |                                 |                              |                              |                                               |
@@ -201,26 +201,60 @@ The SoC has the following architecture:
 
 The PCIe design has already been validated at the maximum AD9361 specified sample rate: 2T2R @ 61.44MSPS (and also seems to correctly handle the oversampling at 2T2R @ 122.88MSPS with 7.9 Gbps of bandwidth on the PCIe bus; this oversampling feature is already in place and more tests/experiments will be done with it in the future).
 
-[> Ethernet SoC Design (1/2.5Gbps x 1 or 2).
---------------------------------------------
+[> Ethernet SoC Design (1/2.5Gbps, Experimental 5Gbps).
+--------------------------------------------------------
 <a id="ethernet-soc-design"></a>
 
 > [!NOTE]
 >
 > Ethernet support is intended for LiteX Acorn Baseboard Mini deployments and
-> is bandwidth-limited by the selected 1000BaseX/2500BaseX link.
+> is bandwidth-limited by the selected Ethernet link. The 5Gbps mode is an
+> experimental 6.25Gbaud 8b/10b extension and is not IEEE 5GBASE-KR or 10GBASE-R.
 
 <div align="center">
   <img src="https://github.com/user-attachments/assets/bbcc0c79-4ae8-4e5b-94d8-aa7aff89bae2" width="100%">
 </div>
 
-The Ethernet design variant gives flexibility when deploying the SDR. The PCIe connector has 4 SerDes transceivers that are in most cases used for... PCIe :) But these are 4 classical GTP transceivers of the Artix7 FPGA that are connected to the PCIe hardened PHY in the case of a PCIe application but can be used for any other SerDes-based protocol: Ethernet 1000BaseX/2500BaseX, SATA, etc...
+The Ethernet design variant gives flexibility when deploying the SDR. The PCIe connector has 4 SerDes transceivers that are in most cases used for... PCIe :) But these are 4 classical GTP transceivers of the Artix7 FPGA that are connected to the PCIe hardened PHY in the case of a PCIe application but can be used for any other SerDes-based protocol: Ethernet 1000BaseX/2500BaseX, experimental 5Gbps Ethernet, SATA, etc...
 
-In this design, the PCIe core will then be replaced with [LiteEth](https://github.com/enjoy-digital/liteeth), providing the 1000BaseX or 2500BaseX PHY but also the UDP/IP hardware stack + Streaming/Etherbone front-end cores.
+In this design, the PCIe core will then be replaced with [LiteEth](https://github.com/enjoy-digital/liteeth), providing the Ethernet PHY but also the UDP/IP hardware stack + Streaming/Etherbone front-end cores.
 
 The Ethernet SoC design supports control plus RX/TX sample streaming over the LiteEth UDP path. The achievable 2T2R sample rate is capped by link bandwidth, so Ethernet builds also cap the RFIC clock to the selected link speed.
 
 The 2.5GBASE-X mode has been hardware-validated in SFP0/J3 with a LianGuo LG 2.5GE copper SFP, the Acorn Baseboard Mini's JP1 and JP4 fitted, and the board reachable at `192.168.1.50`. Build it explicitly with `--eth-phy=2500basex`; this selects the 125MHz GTP reference, MMCM PHY clocking, Clause-37 timing, and gearbox constraints needed by the copper module. SFP EEPROM I2C is not required for link or packet traffic. On M2SDR r02, fit `R82`/`R83` only when the optional M.2 SMBus path is needed; an absent or NACKing EEPROM must not be treated as a link failure.
+
+The `5000basex` mode is experimental. It runs the Artix-7 GTP at 6.25Gbaud,
+uses the GTPE2's 20-bit internal datapath clock at 312.5MHz and its 40-bit
+fabric/PCS interface at 156.25MHz, and deliberately keeps the validated
+61.44MSPS RFIC budget. It cannot operate a module whose host interface
+is fixed at 10.3125Gbaud: the M2SDR Artix-7 GTP is limited to 6.6Gbps. In
+particular, the public 6COM `6C-SFP-10G-T` data sheet specifies a 10GBASE-T/SFP+
+host interface and does not promise a 6.25Gbaud host mode. Hardware probing of
+this module found CDR lock but no 8b/10b comma/byte alignment at 6.25Gbaud;
+LiteScope showed a repeating, undecodable serial pattern. Its copper-side
+2.5/5Gbps negotiation therefore does not provide a compatible 6.25Gbaud host
+mode. The same image reached byte alignment and completed Clause-37 negotiation
+in normal-traffic near-PMA loopback, independently validating the four-symbol
+PCS. Use a module that explicitly supports 6.25Gbaud host signaling. The module
+is rated up to 2.5W, so provide airflow and monitor temperature.
+
+Build the instrumented image and load it only after timing passes:
+
+```bash
+./litex_m2sdr.py --variant=baseboard --sys-clk-freq=100000000 \
+  --with-eth --eth-sfp=0 \
+  --eth-phy=5000basex --with-sfp-i2c --with-eth-phy-probe --build --load
+```
+
+This debug build exposes stable GTP/PCS counters, internal PRBS controls, a
+narrow RX LiteScope analyzer, and the SFP management bus. Start JTAGBone with
+`litex_server --jtag --jtag-config=openocd_xc7_ft2232.cfg`, then run
+`python3 scripts/sfp_eeprom.py --repeat 10` and
+`python3 scripts/eth_phy_prbs.py --loopback near-pma --duration 10`. The EEPROM
+script performs identification reads only; it never writes vendor registers.
+After the internal PRBS test, return to normal PCS traffic and check
+`ping 192.168.1.50`. Ethernet PTP is intentionally rejected in this first 5G
+implementation.
 
 Ethernet-only baseboard builds can also enable SATA storage with `--with-sata`, using SATA on PCIe lane 0 and Ethernet on the selected SFP lane. PCIe, Ethernet/White-Rabbit, and SATA cannot all be enabled in one image because the shared QPLL exposes two channels.
 
@@ -341,7 +375,7 @@ If you are an SDR enthusiast looking to get started with the LiteX-M2SDR board, 
 - **PCIe PTM host-time sync**: Build with `--with-pcie --pcie-lanes=1 --with-pcie-ptm` and run `scripts/m2sdr_pcie_time_sync.py` on the host to make the board PHC follow `CLOCK_REALTIME` through `phc2sys`. If the host clock is locked by NTP/PTP, the board follows that disciplined host time over PCIe.
 - **Ethernet VRT (optional RX path)**: Build with `--with-eth --with-eth-vrt` to enable an Ethernet RX VRT UDP streamer in hardware. A simple host receiver utility is available at `litex_m2sdr/software/user/m2sdr_vrt_rx.py`.
 - **Ethernet / SATA**: Ethernet RX/TX streaming is supported on the LiteX Acorn Baseboard Mini. Source builds can combine Ethernet and SATA with `./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 --with-sata --build`. `m2sdr_sata` supports low-level sector tests and named capture workflows for RF-to-SATA recording, host import/export, SATA-to-RF replay, and SATA replay into the normal PCIe/Ethernet RX path used by SoapySDR/GQRX.
-- **Ethernet RFIC clocking**: Ethernet builds cap the RFIC clock to the link-speed streaming budget for 2T2R SC8: 122.88MHz with `1000basex` and 245.76MHz with `2500basex`. PCIe builds keep the full 245.76MHz/491.52MHz non-oversample/oversample options.
+- **Ethernet RFIC clocking**: Ethernet builds cap the RFIC clock to the link-speed streaming budget for 2T2R SC8: 122.88MHz with `1000basex` and 245.76MHz with `2500basex` or experimental `5000basex`. The initial 5G mode intentionally keeps the validated 61.44MSPS RFIC data rate. PCIe builds keep the full 245.76MHz/491.52MHz non-oversample/oversample options.
 - **Ethernet PTP (optional timing path)**: Build with `--with-eth --with-eth-ptp` to discipline the existing board `time_gen` from LiteEth PTP. `m2sdr_util info`, `m2sdr_util --watch ptp-status`, and `m2sdr_util ptp-config` expose the current lock/holdover state, learned port identity, runtime servo controls, and board-side discipline counters. While PTP discipline is active, host-side time writes are rejected to avoid two masters steering the same clock.
 - **Ethernet PTP RFIC reference (optional clock path)**: Add `--with-eth-ptp-rfic-clock` to expose a PTP-referenced FPGA 10MHz monitor/discipline loop. Enable it at runtime with `m2sdr_util ptp-clock10-config enable on`, verify `Reference Locked` and `Clock Locked`, then select the FPGA clock input for RF setup with `m2sdr_rf --sync fpga` or the matching SoapySDR `clock_source=fpga` setting. This gives RFIC reference frequency coherence; deterministic sample/RF phase alignment still needs AD9361 synchronization and timestamped stream start.
 
@@ -509,6 +543,21 @@ For those who want to explore the full potential of the LiteX-M2SDR board, inclu
    ```
      The validated baseboard configuration has JP1 and JP4 fitted. `R82`/`R83`
      are needed only for optional SFP EEPROM I2C access, not for Ethernet link.
+   - For experimental 6.25Gbaud/5Gbps bring-up with I2C, PRBS counters, and
+     LiteScope:
+   ```
+   ./litex_m2sdr.py --variant=baseboard --sys-clk-freq=100000000 \
+     --with-eth --eth-sfp=0 \
+     --eth-phy=5000basex --with-sfp-i2c --with-eth-phy-probe --build --load
+   litex_server --jtag --jtag-config=openocd_xc7_ft2232.cfg
+   python3 scripts/sfp_eeprom.py --repeat 10
+   python3 scripts/eth_phy_prbs.py --loopback near-pma --duration 10
+   ping 192.168.1.50
+   ```
+     A 6COM `6C-SFP-10G-T` was tested and is not compatible at 6.25Gbaud: its
+     public data sheet documents a 10.3125Gbaud SFP+ host interface, and the
+     capture did not achieve byte alignment. Do not attempt 10G line rate on
+     the Artix-7 GTP.
    - After loading an Ethernet image, use `m2sdr_util` loopback tests to
      exercise the stream path before starting Soapy/Gqrx:
    ```

--- a/doc/debugging-guide.md
+++ b/doc/debugging-guide.md
@@ -389,6 +389,7 @@ probe that matches the current question:
 ./litex_m2sdr.py --variant=m2 --with-pcie --with-pcie-dma-probe --build --load
 ./litex_m2sdr.py --variant=baseboard --with-eth --with-eth-tx-probe --build --load
 ./litex_m2sdr.py --variant=baseboard --with-eth --eth-phy=2500basex --with-eth-phy-rx-probe --build --load
+./litex_m2sdr.py --variant=baseboard --sys-clk-freq=100000000 --with-eth --eth-phy=5000basex --with-sfp-i2c --with-eth-phy-probe --build --load
 ./litex_m2sdr.py --with-ad9361-data-probe --build --load
 ```
 
@@ -415,6 +416,62 @@ litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv \
 If one lane/disparity does not trigger, try `eth_phy_rx_symbol1` and the other
 encoded value. The PCS status CSR reports link state, SGMII detection, and the
 received link-partner ability word before a LiteScope capture is needed.
+
+### Experimental 5Gbps PHY Bring-Up
+
+The `5000basex` target is a 6.25Gbaud, four-symbol-wide 8b/10b experiment. It is
+not 5GBASE-KR and cannot drive a 10.3125Gbaud SFP+ host interface. Qualify it in
+layers through JTAGBone before relying on packet traffic:
+
+```bash
+./litex_m2sdr.py --variant=baseboard --sys-clk-freq=100000000 \
+  --with-eth --eth-sfp=0 --eth-phy=5000basex --with-sfp-i2c \
+  --with-eth-phy-probe --build --load
+
+litex_server --jtag --jtag-config=openocd_xc7_ft2232.cfg
+
+# Probe A0/A2, read A0, verify its checksums, then repeat the identity read ten times.
+python3 scripts/sfp_eeprom.py --csr-csv scripts/csr.csv --repeat 10
+
+# Bypass the module and validate the FPGA GTP/QPLL/CDR with PRBS31.
+python3 scripts/eth_phy_prbs.py --csr-csv scripts/csr.csv \
+  --loopback near-pma --mode prbs31 --duration 10 --inject-error
+
+# Return to normal PCS traffic (the PRBS utility does this automatically).
+ping 192.168.1.50
+```
+
+The PRBS report includes QPLL lock, CDR lock, reset completion, byte alignment,
+PCS link, lock-loss counts, and 8b/10b code/disparity counters. The PCS counters
+are expected to advance while PRBS is selected because PRBS is not 8b/10b data;
+use them only after the utility restores normal traffic. `RXPRBSERR` is a
+per-word indication rather than an exact erroneous-bit count; zero indications
+is decisive, while a non-zero `minimum_BER` is only a lower bound. An injected
+error proves that the checker and counter path are live.
+
+The full Ethernet probe captures the 40-bit raw TBI word, GTP lock/alignment
+status, PCS decode errors, and stream framing in the 156.25MHz `eth_rx` domain.
+List the generated signal names before selecting a trigger:
+
+```bash
+litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv --list
+litescope_cli --csv test/analyzer.csv --csr-csv scripts/csr.csv \
+  --rising-edge <error_or_packet_signal> --dump /tmp/eth-5g-rx.vcd
+```
+
+The 6COM `6C-SFP-10G-T` has been probed with this flow. At 6.25Gbaud the GTP CDR
+locked, but comma detection, byte alignment, Clause-37 link, and ping all
+remained down; the capture contained a short repeating undecodable pattern.
+This is consistent with its documented fixed 10.3125Gbaud SFP+ host interface:
+the advertised 2.5/5Gbps rates are copper-side rates, not 6.25Gbaud host modes.
+With the module bypassed, normal-traffic near-PMA loopback achieved byte
+alignment and completed Clause-37 negotiation, confirming that the GTP and
+four-symbol PCS work together.
+
+For the Acorn Baseboard Mini management path, fit JP1/JP4 and populate M2SDR
+r02 `R82`/`R83`. An I2C NACK does not by itself imply that the high-speed link
+is bad. The EEPROM utility performs read-only identity transactions and does
+not alter vendor pages.
 
 If the predefined probes are too wide, add a temporary narrow probe and commit
 only the reusable version. For a one-off analyzer, document the captured signals

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -12,8 +12,10 @@ import argparse
 import subprocess
 
 from migen import *
+from migen.genlib.cdc import MultiReg, PulseSynchronizer
 
 from litex.gen import *
+from litex.gen.genlib.cdc import BusSynchronizer
 from litex.build.generic_platform import Subsignal, Pins
 
 from litex.soc.interconnect.csr import *
@@ -35,10 +37,10 @@ from litex.build.generic_platform import IOStandard
 
 from litepcie.common            import *
 from litepcie.phy.s7pciephy     import S7PCIEPHY
-from liteeth.phy.a7_1000basex import A7_1000BASEX, A7_2500BASEX
-from liteeth.core             import LiteEthUDPIPCore
-from liteeth.frontend.stream  import LiteEthStream2UDPTX, LiteEthUDP2StreamRX
-from liteeth.core.ptp         import LiteEthPTP
+from liteeth.phy.a7_1000basex   import A7_1000BASEX, A7_2500BASEX, A7_5000BASEX
+from liteeth.core               import LiteEthUDPIPCore
+from liteeth.frontend.stream    import LiteEthStream2UDPTX, LiteEthUDP2StreamRX
+from liteeth.core.ptp           import LiteEthPTP
 
 from litesata.phy                  import LiteSATAPHY
 from litesata.core                 import LiteSATACore
@@ -126,10 +128,13 @@ def _load_prepare_wr_environment(root_dir, wr_nic_dir=None):
 def get_rfic_clk_freq(with_eth=False, eth_phy="1000basex", with_rfic_oversampling=False):
     if with_eth:
         # Ethernet builds are limited by streaming bandwidth. Size the RFIC clock for 2T2R SC8:
-        # 1000BaseX -> 30.72MSPS, 2500BaseX -> 61.44MSPS.
+        # 1000BaseX -> 30.72MSPS, 2500/5000BaseX -> 61.44MSPS. The
+        # experimental 5G mode initially keeps the validated RFIC clock; full
+        # 122.88MSPS streaming is a separate qualification step.
         return {
             "1000basex" : 122.88e6,
             "2500basex" : 245.76e6,
+            "5000basex" : 245.76e6,
         }[eth_phy]
     return {
         False : 245.76e6, # Max rfic_clk for  61.44MSPS / 2T2R.
@@ -145,6 +150,12 @@ def get_eth_phy_kwargs(eth_phy):
             "tx_cm_type"       : "MMCM",
             "rx_cm_type"       : "MMCM",
             "pcs_kwargs"       : {"eth_tx_clk_freq": 125e6},
+            "with_pcs_buffers" : True,
+        }
+    if eth_phy == "5000basex":
+        return {
+            "tx_cm_type"       : "MMCM",
+            "rx_cm_type"       : "MMCM",
             "with_pcs_buffers" : True,
         }
     return {}
@@ -298,6 +309,7 @@ class BaseSoC(SoCMini):
         "si5351"           : 20,
         "clk10_discipline" : 40,
         "ptp_clk10_discipline" : 41,
+        "sfp_i2c"          : 42,
         "header"           : 23,
         "ad9361"           : 24,
         "crossbar"         : 25,
@@ -350,6 +362,8 @@ class BaseSoC(SoCMini):
             raise ValueError("White Rabbit SFP must be resolved before BaseSoC initialization.")
         if with_eth_ptp and not with_eth:
             raise ValueError("Ethernet PTP requires --with-eth.")
+        if with_eth_ptp and eth_phy == "5000basex":
+            raise ValueError("PTP is not yet qualified with experimental 5000BASE-X.")
         if with_eth_ptp and with_white_rabbit:
             raise ValueError("Ethernet PTP and White Rabbit cannot both own the board time generator in the same build yet.")
         if with_eth_ptp_rfic_clock and not with_eth_ptp:
@@ -369,25 +383,26 @@ class BaseSoC(SoCMini):
 
         # Match the Acorn 2.5G bring-up's 125MHz reference and x25 QPLL
         # divider configuration. 1000BASE-X already uses 125MHz here.
-        eth_refclk_freq = 125e6
+        eth_refclk_freq   = 125e6
+        eth_refclk_direct = with_eth and (eth_phy in ["2500basex", "5000basex"]) and (sys_clk_freq == eth_refclk_freq)
 
         # General.
         self.crg = CRG(platform, sys_clk_freq,
             with_eth          = with_eth,
             eth_refclk_freq   = eth_refclk_freq,
-            eth_refclk_direct = with_eth and (eth_phy == "2500basex"),
+            eth_refclk_direct = eth_refclk_direct,
             with_sata         = with_sata,
             with_white_rabbit = with_white_rabbit,
         )
 
         # Shared QPLL.
         self.qpll = SharedQPLL(platform,
-            with_pcie       = with_pcie,
-            with_eth        = with_eth | with_white_rabbit,
-            eth_phy         = eth_phy,
-            eth_refclk_freq = eth_refclk_freq,
-            eth_refclk_direct = with_eth and (eth_phy == "2500basex"),
-            with_sata       = with_sata,
+            with_pcie         = with_pcie,
+            with_eth          = with_eth | with_white_rabbit,
+            eth_phy           = eth_phy,
+            eth_refclk_freq   = eth_refclk_freq,
+            eth_refclk_direct = eth_refclk_direct,
+            with_sata         = with_sata,
         )
 
         # Capability -------------------------------------------------------------------------------
@@ -612,6 +627,7 @@ class BaseSoC(SoCMini):
             eth_phy_cls = {
                 "1000basex" : A7_1000BASEX,
                 "2500basex" : A7_2500BASEX,
+                "5000basex" : A7_5000BASEX,
             }[eth_phy]
             self.eth_phy = eth_phy_cls(
                 qpll_channel = self.qpll.get_channel("eth"),
@@ -1167,8 +1183,8 @@ class BaseSoC(SoCMini):
 
         # Ethernet transceiver clocks.
         if with_eth:
-            platform.add_period_constraint(self.eth_phy.txoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
-            platform.add_period_constraint(self.eth_phy.rxoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
+            platform.add_period_constraint(self.eth_phy.txoutclk, 1e9/self.eth_phy.gtp_clk_freq)
+            platform.add_period_constraint(self.eth_phy.rxoutclk, 1e9/self.eth_phy.gtp_clk_freq)
             platform.add_false_path_constraints(self.eth_phy.txoutclk, self.eth_phy.rxoutclk, self.crg.cd_sys.clk)
             if eth_phy == "2500basex":
                 # The two halves of the RX gearbox exchange state/data on each
@@ -1468,20 +1484,229 @@ class BaseSoC(SoCMini):
         )
 
     # Ethernet.
+    def add_sfp_i2c(self):
+        """Expose the baseboard SFP management bus through LiteI2C CSRs."""
+        sfp_i2c_io = [
+            ("sfp_i2c", 0,
+                Subsignal("sda", Pins("M2:SMB_DAT")),
+                Subsignal("scl", Pins("M2:SMB_CLK")),
+                IOStandard("LVCMOS33"),
+            ),
+        ]
+        self.platform.add_extension(sfp_i2c_io)
+        self.add_i2c_master(
+            name                     = "sfp_i2c",
+            pads                     = self.platform.request("sfp_i2c"),
+            i2c_master_tx_fifo_depth = 8,
+            i2c_master_rx_fifo_depth = 8,
+        )
+
+    def add_sfp_i2c_probe(self, depth=4096):
+        assert hasattr(self, "sfp_i2c")
+        analyzer_signals = [
+            self.sfp_i2c.phy.clkgen.scl_i,
+            self.sfp_i2c.phy.clkgen.scl_oe,
+            self.sfp_i2c.phy.sda_i,
+            self.sfp_i2c.phy.sda_o,
+            self.sfp_i2c.phy.sda_oe,
+            self.sfp_i2c.phy.active,
+            self.sfp_i2c.master.active,
+            self.sfp_i2c.master.source,
+            self.sfp_i2c.master.sink,
+        ]
+        self.analyzer = LiteScopeAnalyzer(analyzer_signals,
+            depth        = depth,
+            samplerate   = self.sys_clk_freq,
+            clock_domain = "sys",
+            register     = True,
+            csr_csv      = "test/analyzer.csv"
+        )
+
+    def add_eth_phy_probe(self, depth=2048):
+        """Add persistent GTP/PCS counters and a narrow RX-domain analyzer."""
+        assert hasattr(self, "eth_phy")
+
+        control = self.eth_phy._prbs_control = CSRStorage(name="prbs_control", fields=[
+            CSRField("loopback",      size=3, offset=0, description="GTPE2 LOOPBACK control."),
+            CSRField("tx_select",     size=3, offset=4, description="GTPE2 TXPRBSSEL control."),
+            CSRField("rx_select",     size=3, offset=8, description="GTPE2 RXPRBSSEL control."),
+            CSRField("force_error",   size=1, offset=12, pulse=True, description="Inject one TX PRBS error."),
+            CSRField("counter_reset", size=1, offset=13, pulse=True, description="Clear PRBS/PCS counters."),
+        ], description="Experimental Ethernet GTP PRBS controls.")
+        loopback_gt       = Signal(3)
+        tx_prbs_select_gt = Signal(3)
+        rx_prbs_select_gt = Signal(3)
+        gtp_tx_cd = self.eth_phy.gtp_tx_clock_domain
+        gtp_rx_cd = self.eth_phy.gtp_rx_clock_domain
+        self.specials += [
+            MultiReg(control.fields.loopback,  loopback_gt,       gtp_tx_cd),
+            MultiReg(control.fields.tx_select, tx_prbs_select_gt, gtp_tx_cd),
+            MultiReg(control.fields.rx_select, rx_prbs_select_gt, gtp_rx_cd),
+        ]
+        self.comb += [
+            self.eth_phy.loopback.eq(loopback_gt),
+            self.eth_phy.tx_prbs_config.eq(tx_prbs_select_gt),
+            self.eth_phy.rx_prbs_config.eq(rx_prbs_select_gt),
+        ]
+
+        force_error        = PulseSynchronizer("sys", gtp_tx_cd)
+        counter_reset      = PulseSynchronizer("sys", "eth_rx")
+        prbs_counter_reset = PulseSynchronizer("sys", gtp_rx_cd)
+        self.submodules += force_error, counter_reset, prbs_counter_reset
+        self.comb += [
+            force_error.i.eq(control.fields.force_error),
+            self.eth_phy.tx_prbs_force_error.eq(force_error.o),
+            counter_reset.i.eq(control.fields.counter_reset),
+            prbs_counter_reset.i.eq(control.fields.counter_reset),
+            self.eth_phy.rx_prbs_counter_reset.eq(prbs_counter_reset.o),
+        ]
+
+        rx_prbs_select = Signal(3)
+        self.specials += MultiReg(self.eth_phy.rx_prbs_config, rx_prbs_select, "eth_rx")
+
+        prbs_bits           = Signal(64)
+        prbs_errors         = Signal(64)
+        pcs_code_errors     = Signal(64)
+        pcs_disp_errors     = Signal(64)
+        cdr_lock_losses     = Signal(32)
+        rx_cdr_lock_d       = Signal()
+        rx_code_error       = getattr(self.eth_phy.pcs.rx, "code_error", Signal(4))
+        rx_disp_error       = getattr(self.eth_phy.pcs.rx, "disparity_error", Signal(4))
+        rx_overflow         = getattr(self.eth_phy.pcs.rx, "overflow", Signal())
+        rx_code_error_count = Signal(3)
+        rx_disp_error_count = Signal(3)
+        self.sync.eth_rx += [
+            rx_cdr_lock_d.eq(self.eth_phy.rx_cdr_lock),
+            If(counter_reset.o,
+                rx_code_error_count.eq(0),
+                rx_disp_error_count.eq(0),
+                prbs_bits.eq(0),
+                prbs_errors.eq(0),
+                pcs_code_errors.eq(0),
+                pcs_disp_errors.eq(0),
+                cdr_lock_losses.eq(0),
+            ).Else(
+                # Register the popcounts before the wide counters. This keeps
+                # the GTP/decode path independent of the 64-bit incrementers
+                # at the 156.25MHz experimental 5G PCS rate.
+                rx_code_error_count.eq(Reduce("ADD", [rx_code_error[n] for n in range(4)])),
+                rx_disp_error_count.eq(Reduce("ADD", [rx_disp_error[n] for n in range(4)])),
+                If(rx_prbs_select != 0,
+                    prbs_bits.eq(prbs_bits + self.eth_phy.gtp_dw),
+                    If(self.eth_phy.rx_prbs_error,
+                        prbs_errors.eq(prbs_errors + 1)
+                    )
+                ),
+                If(rx_code_error_count != 0,
+                    pcs_code_errors.eq(pcs_code_errors + rx_code_error_count)
+                ),
+                If(rx_disp_error_count != 0,
+                    pcs_disp_errors.eq(pcs_disp_errors + rx_disp_error_count)
+                ),
+                If(rx_cdr_lock_d & ~self.eth_phy.rx_cdr_lock,
+                    cdr_lock_losses.eq(cdr_lock_losses + 1)
+                )
+            )
+        ]
+
+        for name, signal in [
+            ("prbs_bits",       prbs_bits),
+            ("prbs_errors",     prbs_errors),
+            ("pcs_code_errors", pcs_code_errors),
+            ("pcs_disp_errors", pcs_disp_errors),
+        ]:
+            cdc = BusSynchronizer(64, "eth_rx", "sys")
+            self.submodules += cdc
+            self.comb += cdc.i.eq(signal)
+            status = CSRStatus(64, name=name, description=f"Wrapping Ethernet {name.replace('_', ' ')} counter.")
+            setattr(self.eth_phy, f"_{name}", status)
+            self.comb += status.status.eq(cdc.o)
+
+        cdr_losses_cdc = BusSynchronizer(32, "eth_rx", "sys")
+        self.submodules += cdr_losses_cdc
+        self.comb += cdr_losses_cdc.i.eq(cdr_lock_losses)
+        status_signals = [Signal() for _ in range(8)]
+        self.specials += [
+            MultiReg(self.qpll.get_channel("eth").lock, status_signals[0]),
+            MultiReg(self.eth_phy.rx_cdr_lock, status_signals[1]),
+            MultiReg(self.eth_phy.tx_reset_done, status_signals[2]),
+            MultiReg(self.eth_phy.rx_reset_done, status_signals[3]),
+            MultiReg(self.eth_phy.rx_byte_is_aligned, status_signals[4]),
+            MultiReg(self.eth_phy.pcs.link_up, status_signals[5]),
+            MultiReg(rx_overflow, status_signals[6]),
+            MultiReg(self.eth_phy.rx_prbs_error, status_signals[7]),
+        ]
+        self.eth_phy._cdr_lock_losses = CSRStatus(32,
+            name        = "cdr_lock_losses",
+            description = "Wrapping RX CDR lock-loss counter.",
+        )
+        self.comb += self.eth_phy._cdr_lock_losses.status.eq(cdr_losses_cdc.o)
+        self.eth_phy._debug_status = CSRStatus(name="debug_status", fields=[
+            CSRField("qpll_lock",       size=1, offset=0),
+            CSRField("rx_cdr_lock",     size=1, offset=1),
+            CSRField("tx_reset_done",   size=1, offset=2),
+            CSRField("rx_reset_done",   size=1, offset=3),
+            CSRField("byte_aligned",    size=1, offset=4),
+            CSRField("pcs_link_up",     size=1, offset=5),
+            CSRField("rx_overflow",     size=1, offset=6),
+            CSRField("rx_prbs_error",   size=1, offset=7),
+        ], description="Ethernet GTP/PCS status.")
+        self.comb += [
+            self.eth_phy._debug_status.fields.qpll_lock.eq(status_signals[0]),
+            self.eth_phy._debug_status.fields.rx_cdr_lock.eq(status_signals[1]),
+            self.eth_phy._debug_status.fields.tx_reset_done.eq(status_signals[2]),
+            self.eth_phy._debug_status.fields.rx_reset_done.eq(status_signals[3]),
+            self.eth_phy._debug_status.fields.byte_aligned.eq(status_signals[4]),
+            self.eth_phy._debug_status.fields.pcs_link_up.eq(status_signals[5]),
+            self.eth_phy._debug_status.fields.rx_overflow.eq(status_signals[6]),
+            self.eth_phy._debug_status.fields.rx_prbs_error.eq(status_signals[7]),
+        ]
+
+        analyzer_signals = [
+            self.eth_phy.pcs.tbi_rx,
+            self.eth_phy.rx_cdr_lock,
+            self.eth_phy.rx_byte_is_aligned,
+            self.eth_phy.rx_byte_realign,
+            self.eth_phy.rx_comma_detect,
+            self.eth_phy.rx_prbs_error,
+            rx_code_error,
+            rx_disp_error,
+            self.eth_phy.pcs.source.valid,
+            self.eth_phy.pcs.source.ready,
+            self.eth_phy.pcs.source.last,
+            self.eth_phy.pcs.source.last_be,
+            self.eth_phy.pcs.source.error,
+        ]
+        if hasattr(self.eth_phy.pcs.rx, "ctrl_state"):
+            analyzer_signals += [
+                self.eth_phy.pcs.rx.ctrl_state,
+                self.eth_phy.pcs.rx.in_packet,
+                self.eth_phy.pcs.rx.first_word,
+                self.eth_phy.pcs.rx.phase,
+            ]
+        self.analyzer = LiteScopeAnalyzer(analyzer_signals,
+            depth        = depth,
+            samplerate   = self.eth_phy.rx_clk_freq,
+            clock_domain = "eth_rx",
+            register     = True,
+            csr_csv      = "test/analyzer.csv"
+        )
+
     def add_eth_phy_rx_probe(self, depth=4096):
         assert hasattr(self, "eth_phy")
-        self.eth_phy_rx_symbol0 = Signal(10)
-        self.eth_phy_rx_symbol1 = Signal(10)
-        self.comb += [
-            self.eth_phy_rx_symbol0.eq(self.eth_phy.gearbox.rx_data_half[0:10]),
-            self.eth_phy_rx_symbol1.eq(self.eth_phy.gearbox.rx_data_half[10:20]),
-        ]
-        self.analyzer = LiteScopeAnalyzer([
-            self.eth_phy_rx_symbol0,
-            self.eth_phy_rx_symbol1,
-        ],
+        if hasattr(self.eth_phy, "gearbox"):
+            raw = self.eth_phy.gearbox.rx_data_half
+            clock_domain = "eth_rx_half"
+        else:
+            raw = self.eth_phy.pcs.tbi_rx
+            clock_domain = "eth_rx"
+        symbols = [Signal(10, name=f"eth_phy_rx_symbol{n}") for n in range(len(raw)//10)]
+        for n, symbol in enumerate(symbols):
+            setattr(self, f"eth_phy_rx_symbol{n}", symbol)
+            self.comb += symbol.eq(raw[10*n:10*(n + 1)])
+        self.analyzer = LiteScopeAnalyzer(symbols,
             depth        = depth,
-            clock_domain = "eth_rx_half",
+            clock_domain = clock_domain,
             register     = True,
             csr_csv      = "test/analyzer.csv"
         )
@@ -1550,7 +1775,7 @@ def main():
     # Ethernet parameters.
     parser.add_argument("--with-eth",        action="store_true",     help="Enable Ethernet Communication.")
     parser.add_argument("--eth-sfp",         default=0, type=int,     help="Ethernet SFP.", choices=[0, 1])
-    parser.add_argument("--eth-phy",         default="1000basex",     help="Ethernet PHY.", choices=["1000basex", "2500basex"])
+    parser.add_argument("--eth-phy",         default="1000basex",     help="Ethernet PHY.", choices=["1000basex", "2500basex", "5000basex"])
     parser.add_argument("--eth-local-ip",    default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
     parser.add_argument("--eth-udp-port",    default=2345, type=int,  help="Ethernet Remote port.")
     parser.add_argument("--with-eth-ptp",    action="store_true",     help="Enable LiteEth PTP and discipline the board time generator from it.")
@@ -1561,6 +1786,7 @@ def main():
     parser.add_argument("--with-eth-vrt",    action="store_true",     help="Enable Ethernet RX VRT UDP streamer path.")
     parser.add_argument("--vrt-dst-ip",      default="239.168.1.100", help="VRT destination IP address (when --with-eth-vrt).")
     parser.add_argument("--vrt-dst-port",    default=4991, type=int,  help="VRT destination UDP port (when --with-eth-vrt).")
+    parser.add_argument("--with-sfp-i2c",    action="store_true",     help="Enable CSR access to the baseboard SFP management bus.")
 
     # SATA parameters.
     parser.add_argument("--with-sata",       action="store_true", help="Enable SATA Storage.")
@@ -1586,6 +1812,8 @@ def main():
     probeopts.add_argument("--with-pcie-probe",        action="store_true", help="Enable PCIe Probe.")
     probeopts.add_argument("--with-pcie-dma-probe",    action="store_true", help="Enable PCIe DMA Probe.")
     probeopts.add_argument("--with-si5351-i2c-probe",  action="store_true", help="Enable SI5351 I2C Probe.")
+    probeopts.add_argument("--with-sfp-i2c-probe",     action="store_true", help="Enable SFP management-bus Probe (requires --with-sfp-i2c).")
+    probeopts.add_argument("--with-eth-phy-probe",     action="store_true", help="Enable Ethernet GTP/PCS counters and RX Probe.")
     probeopts.add_argument("--with-eth-phy-rx-probe",  action="store_true", help="Enable raw Ethernet PHY RX Probe.")
     probeopts.add_argument("--with-eth-tx-probe",      action="store_true", help="Enable Ethernet Tx Probe.")
     probeopts.add_argument("--with-ad9361-spi-probe",  action="store_true", help="Enable AD9361 SPI Probe.")
@@ -1622,9 +1850,22 @@ def main():
     if args.wr_status and not args.with_white_rabbit:
         return
 
+    # Keep 2500BASE-X on its validated direct 125MHz system/reference clock.
+    # The wider experimental 5G PCS closes timing reliably with a separate
+    # 125MHz reference PLL and a 100MHz system domain.
     default_sys_clk_freq = 125e6 if (args.with_eth and args.eth_phy == "2500basex") else (100e6 if args.with_eth else 125e6)
     if args.sys_clk_freq is None:
         args.sys_clk_freq = default_sys_clk_freq
+    if args.eth_phy == "5000basex" and args.with_eth_ptp:
+        parser.error("PTP is not yet qualified with experimental 5000BASE-X")
+    if args.with_sfp_i2c and args.variant != "baseboard":
+        parser.error("--with-sfp-i2c requires --variant=baseboard")
+    if args.with_sfp_i2c and args.with_white_rabbit:
+        parser.error("--with-sfp-i2c and White Rabbit cannot share the SFP management bus")
+    if args.with_sfp_i2c_probe and not args.with_sfp_i2c:
+        parser.error("--with-sfp-i2c-probe requires --with-sfp-i2c")
+    if (args.with_eth_phy_probe or args.with_eth_phy_rx_probe) and not args.with_eth:
+        parser.error("Ethernet PHY probes require --with-eth")
 
     # Build SoC.
     soc = BaseSoC(
@@ -1677,12 +1918,18 @@ def main():
     )
 
     # LiteScope Analyzer Probes.
+    if args.with_sfp_i2c:
+        soc.add_sfp_i2c()
     if args.with_pcie_probe:
         soc.add_pcie_probe()
     if args.with_pcie_dma_probe:
         soc.add_pcie_dma_probe()
     if args.with_si5351_i2c_probe:
         soc.add_si5351_i2c_probe()
+    if args.with_sfp_i2c_probe:
+        soc.add_sfp_i2c_probe()
+    if args.with_eth_phy_probe:
+        soc.add_eth_phy_probe()
     if args.with_eth_phy_rx_probe:
         soc.add_eth_phy_rx_probe()
     if args.with_eth_tx_probe:
@@ -1713,6 +1960,8 @@ def main():
                     r += "_no_igmp"
             if args.with_eth_vrt:
                 r += "_vrt"
+        if args.with_sfp_i2c:
+            r += "_sfp_i2c"
         if args.with_sata:
             r += f"_sata"
         if args.with_white_rabbit:

--- a/litex_m2sdr/gateware/capability.py
+++ b/litex_m2sdr/gateware/capability.py
@@ -75,13 +75,13 @@ class Capability(LiteXModule):
 
         # Ethernet Config.
         # ----------------
-        eth_speed_map  = {"1000basex": 0, "2500basex": 1}
+        eth_speed_map  = {"1000basex": 0, "2500basex": 1, "5000basex": 2}
         eth_speed_value = eth_speed_map[eth_speed] if eth_enabled else 0
         self._eth_config = CSRStatus(32, fields=[
             CSRField("speed", size=2, offset=0, reset=eth_speed_value, values=[
                 ("``0b00``", "1Gbps"),
                 ("``0b01``", "2.5Gbps"),
-                ("``0b10``", "Reserved"),
+                ("``0b10``", "5Gbps experimental 5000BASE-X"),
                 ("``0b11``", "Reserved"),
             ], description="Ethernet speed configuration."),
             CSRField("ptp", size=1, offset=2, reset=int(eth_ptp), description="Ethernet PTP time discipline build support."),

--- a/litex_m2sdr/gateware/qpll.py
+++ b/litex_m2sdr/gateware/qpll.py
@@ -29,8 +29,8 @@ class SharedQPLL(LiteXModule):
         qpll_eth_settings = QPLLSettings(
             # Match the original Acorn 2.5G topology on GTREFCLK0 while
             # preserving the existing internal reference for 1000BASE-X.
-            refclksel  = {"1000basex": 0b111, "2500basex": 0b001}[eth_phy],
-            fbdiv      = {"1000basex": 4, "2500basex": 5}[eth_phy],
+            refclksel  = {"1000basex": 0b111, "2500basex": 0b001, "5000basex": 0b001}[eth_phy],
+            fbdiv      = {"1000basex": 4, "2500basex": 5, "5000basex": 5}[eth_phy],
             fbdiv_45   = {125e6: 5, 156.25e6 : 4}[eth_refclk_freq],
             refclk_div = 1,
         )

--- a/litex_m2sdr/software/user/m2sdr_util.c
+++ b/litex_m2sdr/software/user/m2sdr_util.c
@@ -1310,7 +1310,7 @@ static void info(void)
 
     if (eth_enabled) {
         int eth_speed = (caps.eth_config >> CSR_CAPABILITY_ETH_CONFIG_SPEED_OFFSET) & ((1 << CSR_CAPABILITY_ETH_CONFIG_SPEED_SIZE) - 1);
-        const char *eth_speed_str[] = {"1Gbps", "2.5Gbps"};
+        const char *eth_speed_str[] = {"1Gbps", "2.5Gbps", "5Gbps experimental", "Reserved"};
         printf("  Ethernet Speed : %s\n", eth_speed_str[eth_speed]);
         {
             int eth_sfp  = (caps.board_info >> CSR_CAPABILITY_BOARD_INFO_ETH_SFP_OFFSET) & ((1 << CSR_CAPABILITY_BOARD_INFO_ETH_SFP_SIZE) - 1);

--- a/scripts/eth_phy_prbs.py
+++ b/scripts/eth_phy_prbs.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Exercise and inspect the experimental Ethernet GTP PRBS diagnostics."""
+
+import argparse
+import time
+
+from litex import RemoteClient
+
+
+PRBS_MODES = {
+    "disabled": 0b000,
+    "prbs7": 0b001,
+    "prbs15": 0b010,
+    "prbs23": 0b011,
+    "prbs31": 0b100,
+}
+LOOPBACK_MODES = {
+    "normal": 0b000,
+    "near-pcs": 0b001,
+    "near-pma": 0b010,
+    "far-pma": 0b100,
+    "far-pcs": 0b110,
+}
+STATUS_BITS = (
+    ("qpll_lock", 0),
+    ("rx_cdr_lock", 1),
+    ("tx_reset_done", 2),
+    ("rx_reset_done", 3),
+    ("byte_aligned", 4),
+    ("pcs_link_up", 5),
+    ("rx_overflow", 6),
+    ("rx_prbs_error", 7),
+)
+
+
+def control_word(loopback="normal", tx="disabled", rx="disabled",
+                 force_error=False, counter_reset=False):
+    value = LOOPBACK_MODES[loopback]
+    value |= PRBS_MODES[tx] << 4
+    value |= PRBS_MODES[rx] << 8
+    value |= int(force_error) << 12
+    value |= int(counter_reset) << 13
+    return value
+
+
+def decode_status(value):
+    return {name: bool(value & (1 << bit)) for name, bit in STATUS_BITS}
+
+
+def require_registers(regs):
+    required = (
+        "eth_phy_prbs_control",
+        "eth_phy_prbs_bits",
+        "eth_phy_prbs_errors",
+        "eth_phy_pcs_code_errors",
+        "eth_phy_pcs_disp_errors",
+        "eth_phy_cdr_lock_losses",
+        "eth_phy_debug_status",
+    )
+    missing = [name for name in required if not hasattr(regs, name)]
+    if missing:
+        raise RuntimeError(
+            "gateware has no Ethernet diagnostics; rebuild with --with-eth-phy-probe "
+            f"(missing {', '.join(missing)})"
+        )
+
+
+def read_counters(regs):
+    return {
+        "bits": regs.eth_phy_prbs_bits.read(),
+        "prbs_errors": regs.eth_phy_prbs_errors.read(),
+        "code_errors": regs.eth_phy_pcs_code_errors.read(),
+        "disparity_errors": regs.eth_phy_pcs_disp_errors.read(),
+        "cdr_lock_losses": regs.eth_phy_cdr_lock_losses.read(),
+        "status": decode_status(regs.eth_phy_debug_status.read()),
+    }
+
+
+def print_sample(elapsed, counters):
+    bits = counters["bits"]
+    events = counters["prbs_errors"]
+    minimum_ber = events / bits if bits else float("nan")
+    flags = " ".join(
+        f"{name}={int(value)}" for name, value in counters["status"].items()
+    )
+    print(
+        f"{elapsed:7.2f}s bits={bits:16d} prbs_error_indications={events:10d} "
+        f"minimum_BER={minimum_ber:.3e} code={counters['code_errors']} "
+        f"disp={counters['disparity_errors']} cdr_losses={counters['cdr_lock_losses']} "
+        f"{flags}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=1234)
+    parser.add_argument("--csr-csv", default="scripts/csr.csv")
+    parser.add_argument("--mode", choices=tuple(PRBS_MODES)[1:], default="prbs31")
+    parser.add_argument("--loopback", choices=LOOPBACK_MODES, default="near-pma")
+    parser.add_argument("--duration", type=float, default=10.0)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--inject-error", action="store_true",
+                        help="inject one TX PRBS error after the checker settles")
+    parser.add_argument("--leave-running", action="store_true")
+    args = parser.parse_args()
+    if args.duration <= 0 or args.interval <= 0:
+        parser.error("--duration and --interval must be positive")
+
+    with RemoteClient(
+        host=args.host,
+        port=args.port,
+        csr_csv=args.csr_csv,
+        timeout=3.0,
+        raise_on_timeout=True,
+    ) as bus:
+        regs = bus.regs
+        require_registers(regs)
+        running = control_word(args.loopback, args.mode, args.mode)
+        regs.eth_phy_prbs_control.write(running)
+        time.sleep(0.05)
+        regs.eth_phy_prbs_control.write(running | (1 << 13))
+        time.sleep(0.05)
+
+        start = time.monotonic()
+        next_sample = start
+        error_injected = False
+        try:
+            while True:
+                now = time.monotonic()
+                elapsed = now - start
+                if (
+                    args.inject_error
+                    and not error_injected
+                    and elapsed >= min(1.0, args.duration / 2)
+                ):
+                    regs.eth_phy_prbs_control.write(running | (1 << 12))
+                    error_injected = True
+                if now >= next_sample:
+                    print_sample(elapsed, read_counters(regs))
+                    next_sample += args.interval
+                if elapsed >= args.duration:
+                    break
+                time.sleep(min(0.05, max(0.0, next_sample - now)))
+        finally:
+            if not args.leave_running:
+                regs.eth_phy_prbs_control.write(control_word())
+
+    print(
+        "Note: RXPRBSERR is a per-word error indication; minimum_BER is not "
+        "an exact bit-error count."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sfp_eeprom.py
+++ b/scripts/sfp_eeprom.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Read and identify an SFP module through the baseboard management bus."""
+
+import argparse
+import time
+
+from litex import RemoteClient
+
+
+TX_READY = 1 << 0
+RX_READY = 1 << 1
+NACK = 1 << 8
+BUS_ERROR = 1 << 9
+
+
+def wait_status(regs, mask, timeout=0.5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = regs.sfp_i2c_master_status.read()
+        # Error flags accompany a valid RX FIFO reply. They can otherwise be
+        # stale, so only inspect them while RX_READY is asserted.
+        if (status & RX_READY) and (status & (NACK | BUS_ERROR)):
+            raise OSError(f"I2C transfer failed (status=0x{status:08x})")
+        if status & mask:
+            return status
+    raise TimeoutError(f"I2C timeout waiting for status mask 0x{mask:x}")
+
+
+def reset_master(regs):
+    regs.sfp_i2c_master_active.write(0)
+    regs.sfp_i2c_master_settings.write(0)
+    for _ in range(16):
+        if not (regs.sfp_i2c_master_status.read() & RX_READY):
+            return
+        regs.sfp_i2c_master_rxtx.read()
+    raise OSError("could not drain the I2C RX FIFO")
+
+
+def read_block(regs, slave, offset, length):
+    """Perform the offset write/repeated-start read required by SFP EEPROMs."""
+    if not 1 <= length <= 4:
+        raise ValueError("LiteI2C transaction length must be 1..4 bytes")
+    reset_master(regs)
+    regs.sfp_i2c_master_settings.write(1 | (length << 8))
+    regs.sfp_i2c_master_addr.write(slave)
+    regs.sfp_i2c_master_active.write(1)
+    wait_status(regs, TX_READY)
+    regs.sfp_i2c_master_rxtx.write(offset)
+    wait_status(regs, RX_READY)
+    status = regs.sfp_i2c_master_status.read()
+    if status & (NACK | BUS_ERROR):
+        raise OSError(f"I2C transfer failed (status=0x{status:08x})")
+    word = regs.sfp_i2c_master_rxtx.read()
+    return word.to_bytes(4, "big")[-length:]
+
+
+def recover_bus(regs):
+    reset_master(regs)
+    regs.sfp_i2c_master_settings.write(1 << 16)
+    regs.sfp_i2c_master_addr.write(0)
+    regs.sfp_i2c_master_active.write(1)
+    wait_status(regs, TX_READY)
+    regs.sfp_i2c_master_rxtx.write(0)
+    wait_status(regs, RX_READY)
+    status = regs.sfp_i2c_master_status.read()
+    regs.sfp_i2c_master_rxtx.read()
+    return status
+
+
+def read_eeprom(regs, slave=0x50, size=256):
+    data = bytearray()
+    for offset in range(0, size, 4):
+        count = min(4, size - offset)
+        data.extend(read_block(regs, slave, offset, count))
+    return bytes(data)
+
+
+def text_field(data, start, end):
+    return "".join(
+        chr(value) if 32 <= value < 127 else "."
+        for value in data[start:end]
+    ).strip()
+
+
+def checksum(data, first, last, check):
+    expected = sum(data[first:last + 1]) & 0xff
+    return expected == data[check], expected, data[check]
+
+
+def identity(data):
+    return {
+        "identifier": data[0],
+        "connector": data[2],
+        "encoding": data[11],
+        "nominal_bitrate_mbd": data[12] * 100,
+        "vendor": text_field(data, 20, 36),
+        "vendor_oui": data[37:40].hex(":"),
+        "part_number": text_field(data, 40, 56),
+        "revision": text_field(data, 56, 60),
+        "serial": text_field(data, 68, 84),
+        "date_code": text_field(data, 84, 92),
+    }
+
+
+def hex_dump(data):
+    for offset in range(0, len(data), 16):
+        row = data[offset:offset + 16]
+        ascii_row = "".join(chr(value) if 32 <= value < 127 else "." for value in row)
+        hex_row = " ".join(f"{value:02x}" for value in row)
+        print(f"{offset:02x}: {hex_row:47s}  {ascii_row}")
+
+
+def print_identity(data, prefix=""):
+    fields = identity(data)
+    print(f"{prefix}identifier       : 0x{fields['identifier']:02x}")
+    print(f"{prefix}connector        : 0x{fields['connector']:02x}")
+    print(f"{prefix}encoding         : 0x{fields['encoding']:02x}")
+    print(f"{prefix}nominal bitrate  : {fields['nominal_bitrate_mbd']} MBd")
+    print(f"{prefix}vendor           : {fields['vendor']!r}")
+    print(f"{prefix}vendor OUI       : {fields['vendor_oui']}")
+    print(f"{prefix}part number      : {fields['part_number']!r}")
+    print(f"{prefix}revision         : {fields['revision']!r}")
+    print(f"{prefix}serial           : {fields['serial']!r}")
+    print(f"{prefix}date code        : {fields['date_code']!r}")
+    for label, first, last, check_byte in (
+        ("CC_BASE", 0, 62, 63),
+        ("CC_EXT", 64, 94, 95),
+    ):
+        valid, expected, stored = checksum(data, first, last, check_byte)
+        print(f"{prefix}{label:16s}: {'valid' if valid else 'INVALID'} "
+              f"(calculated 0x{expected:02x}, stored 0x{stored:02x})")
+
+
+def require_registers(regs):
+    required = (
+        "sfp_i2c_phy_speed_mode",
+        "sfp_i2c_master_active",
+        "sfp_i2c_master_settings",
+        "sfp_i2c_master_addr",
+        "sfp_i2c_master_rxtx",
+        "sfp_i2c_master_status",
+    )
+    missing = [name for name in required if not hasattr(regs, name)]
+    if missing:
+        raise RuntimeError(
+            "gateware has no SFP I2C master; rebuild with --with-sfp-i2c "
+            f"(missing {', '.join(missing)})"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=1234)
+    parser.add_argument("--csr-csv", default="scripts/csr.csv")
+    parser.add_argument("--size", type=int, default=256, choices=(96, 128, 256))
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="repeat the complete A0 identity read (use 10 for a stability check)",
+    )
+    parser.add_argument("--interval", type=float, default=0.1)
+    parser.add_argument(
+        "--scan",
+        action="store_true",
+        help="scan addresses with read-only register-zero probes if A0 is absent",
+    )
+    args = parser.parse_args()
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+
+    with RemoteClient(
+        host=args.host,
+        port=args.port,
+        csr_csv=args.csr_csv,
+        timeout=3.0,
+        raise_on_timeout=True,
+    ) as bus:
+        regs = bus.regs
+        require_registers(regs)
+        regs.sfp_i2c_phy_speed_mode.write(0)  # 100kHz standard mode.
+        print(f"I2C bus recovery status: 0x{recover_bus(regs):08x}")
+
+        probes = {}
+        for slave in (0x50, 0x51):
+            try:
+                probes[slave] = read_block(regs, slave, 0, 1)[0]
+                print(f"I2C address 0x{slave:02x}: ACK, byte 0 = 0x{probes[slave]:02x}")
+            except (OSError, TimeoutError) as error:
+                print(f"I2C address 0x{slave:02x}: no response ({error})")
+
+        if 0x50 not in probes:
+            if args.scan:
+                print(
+                    "Scanning usable 7-bit addresses "
+                    "(read-only offset-zero probes)..."
+                )
+                responders = []
+                for slave in range(0x03, 0x78):
+                    try:
+                        responders.append((slave, read_block(regs, slave, 0, 1)[0]))
+                    except (OSError, TimeoutError):
+                        pass
+                if responders:
+                    for slave, value in responders:
+                        print(f"  0x{slave:02x}: ACK, byte 0 = 0x{value:02x}")
+                else:
+                    print("  no I2C device acknowledged")
+            raise SystemExit("SFP A0 EEPROM is not reachable")
+
+        reference = None
+        for index in range(args.repeat):
+            data = read_eeprom(regs, 0x50, args.size)
+            if len(data) < 96:
+                raise RuntimeError(
+                    "at least 96 EEPROM bytes are needed for identification"
+                )
+            current = identity(data)
+            if reference is None:
+                reference = current
+                print("\nSFP A0 EEPROM:")
+                hex_dump(data)
+                print("\nDecoded identification:")
+                print_identity(data, prefix="  ")
+            else:
+                state = "stable" if current == reference else "CHANGED"
+                print(
+                    f"identity read {index + 1}/{args.repeat}: {state}; "
+                    f"{current['vendor']} {current['part_number']} "
+                    f"{current['serial']}"
+                )
+            if index + 1 < args.repeat:
+                time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_capability.py
+++ b/test/test_capability.py
@@ -33,3 +33,27 @@ def test_capability_builds_with_valid_configuration():
         wr_sfp=1,
     )
     assert dut is not None
+
+
+def test_capability_accepts_experimental_5000basex():
+    dut = Capability(
+        api_version_str="1.2",
+        pcie_enabled=False,
+        pcie_speed="gen1",
+        pcie_lanes=1,
+        pcie_ptm=False,
+        eth_enabled=True,
+        eth_speed="5000basex",
+        eth_ptp=False,
+        eth_ptp_rfic_clock=False,
+        sata_enabled=False,
+        sata_gen="gen1",
+        sata_mode="read-only",
+        gpio_enabled=False,
+        wr_enabled=False,
+        variant="baseboard",
+        jtagbone=True,
+        eth_sfp=0,
+        wr_sfp=1,
+    )
+    assert dut._eth_config.fields.speed.reset == 2

--- a/test/test_cli_args.py
+++ b/test/test_cli_args.py
@@ -28,6 +28,7 @@ def test_rfic_clk_freq_policy():
     assert soc_mod.get_rfic_clk_freq(with_rfic_oversampling=True) == 491.52e6
     assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="1000basex") == 122.88e6
     assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="2500basex") == 245.76e6
+    assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="5000basex") == 245.76e6
     assert soc_mod.get_rfic_clk_freq(
         with_eth=True,
         eth_phy="1000basex",
@@ -45,6 +46,68 @@ def test_eth_phy_kwargs_policy():
         "pcs_kwargs"       : {"eth_tx_clk_freq": 125e6},
         "with_pcs_buffers" : True,
     }
+    assert soc_mod.get_eth_phy_kwargs("5000basex") == {
+        "tx_cm_type"       : "MMCM",
+        "rx_cm_type"       : "MMCM",
+        "with_pcs_buffers" : True,
+    }
+
+
+def test_main_selects_5000basex_with_i2c_and_phy_probe(monkeypatch):
+    soc_mod = _load_soc_module()
+    captured = {}
+
+    class FakeSoC:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def add_sfp_i2c(self):
+            captured["sfp_i2c"] = True
+
+        def add_eth_phy_probe(self):
+            captured["eth_phy_probe"] = True
+
+    class FakeBuilder:
+        def __init__(self, soc, **kwargs):
+            captured.update(kwargs)
+            self.gateware_dir = "build/fake/gateware"
+
+        def build(self, build_name, run):
+            captured["build_name"] = build_name
+            captured["run"] = run
+
+    monkeypatch.setattr(soc_mod, "BaseSoC", FakeSoC)
+    monkeypatch.setattr(soc_mod, "Builder", FakeBuilder)
+    monkeypatch.setattr(soc_mod, "generate_litepcie_software", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", [
+        "litex_m2sdr.py",
+        "--variant=baseboard",
+        "--with-eth",
+        "--eth-phy=5000basex",
+        "--with-sfp-i2c",
+        "--with-eth-phy-probe",
+    ])
+
+    soc_mod.main()
+
+    assert captured["kwargs"]["eth_phy"] == "5000basex"
+    assert captured["kwargs"]["sys_clk_freq"] == 100_000_000
+    assert captured["sfp_i2c"] is True
+    assert captured["eth_phy_probe"] is True
+    assert captured["build_name"] == "litex_m2sdr_baseboard_eth_5000basex_sfp_i2c"
+
+
+def test_main_rejects_ptp_with_experimental_5000basex(monkeypatch):
+    soc_mod = _load_soc_module()
+    monkeypatch.setattr(sys, "argv", [
+        "litex_m2sdr.py",
+        "--variant=baseboard",
+        "--with-eth",
+        "--eth-phy=5000basex",
+        "--with-eth-ptp",
+    ])
+    with pytest.raises(SystemExit):
+        soc_mod.main()
 
 
 def test_main_exposes_base_soc_optional_args(monkeypatch):

--- a/test/test_debug_scripts.py
+++ b/test/test_debug_scripts.py
@@ -1,0 +1,68 @@
+import importlib.util
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_script(name):
+    path = SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+eth_phy_prbs = _load_script("eth_phy_prbs")
+sfp_eeprom = _load_script("sfp_eeprom")
+
+control_word = eth_phy_prbs.control_word
+decode_status = eth_phy_prbs.decode_status
+checksum = sfp_eeprom.checksum
+identity = sfp_eeprom.identity
+text_field = sfp_eeprom.text_field
+
+
+def test_sfp_identity_and_checksums():
+    data = bytearray(96)
+    data[0] = 0x03
+    data[2] = 0x22
+    data[11] = 0x06
+    data[12] = 103
+    data[20:36] = b"6COM            "
+    data[37:40] = bytes.fromhex("001b21")
+    data[40:56] = b"6C-SFP-10G-T    "
+    data[56:60] = b"A1  "
+    data[68:84] = b"TEST1234        "
+    data[84:92] = b"260827  "
+    data[63] = sum(data[0:63]) & 0xff
+    data[95] = sum(data[64:95]) & 0xff
+
+    fields = identity(data)
+    assert fields["vendor"] == "6COM"
+    assert fields["part_number"] == "6C-SFP-10G-T"
+    assert fields["nominal_bitrate_mbd"] == 10300
+    assert checksum(data, 0, 62, 63)[0]
+    assert checksum(data, 64, 94, 95)[0]
+
+
+def test_sfp_text_field_replaces_non_printable_bytes():
+    assert text_field(b"ABC\x00DEF ", 0, 8) == "ABC.DEF"
+
+
+def test_eth_phy_control_word_layout():
+    assert control_word("near-pma", "prbs31", "prbs31") == (
+        0b010 | (0b100 << 4) | (0b100 << 8)
+    )
+    assert control_word("normal", "prbs7", "prbs15", True, True) == (
+        (0b001 << 4) | (0b010 << 8) | (1 << 12) | (1 << 13)
+    )
+
+
+def test_eth_phy_status_decode():
+    status = decode_status((1 << 0) | (1 << 1) | (1 << 4) | (1 << 7))
+    assert status["qpll_lock"]
+    assert status["rx_cdr_lock"]
+    assert status["byte_aligned"]
+    assert status["rx_prbs_error"]
+    assert not status["pcs_link_up"]

--- a/test/test_qpll.py
+++ b/test/test_qpll.py
@@ -103,6 +103,8 @@ def test_shared_qpll_can_use_system_clock_as_eth_reference(monkeypatch):
     ("1000basex", 156.25e6, 4, 1.25e9),
     ("2500basex", 125e6,    2, 3.125e9),
     ("2500basex", 156.25e6, 2, 3.125e9),
+    ("5000basex", 125e6,    1, 6.25e9),
+    ("5000basex", 156.25e6, 1, 6.25e9),
 ])
 def test_shared_qpll_eth_settings_generate_expected_linerate(monkeypatch, eth_phy, refclk_freq, out_div, expected_linerate):
     monkeypatch.setattr(qpll_mod, "QPLL", _FakeQPLL)


### PR DESCRIPTION
## Summary

- integrate the experimental Artix-7 `A7_5000BASEX` PHY on the Acorn Baseboard Mini
- use a timing-clean 100MHz system clock, a 125MHz GTP reference, and the 6.25Gbaud QPLL configuration
- add SFP management-bus access plus PRBS, loopback, persistent status counters, and LiteScope RX diagnostics
- expose the 5Gbps capability in software and document a layered JTAG bring-up procedure
- keep the validated 61.44MSPS RFIC budget and reject the not-yet-qualified PTP/5G combination

Depends on enjoy-digital/liteeth#216.

This is an experimental 6.25Gbaud 8b/10b mode, not IEEE 5GBASE-KR/R or 10GBASE-R.

## Validation

- full M2SDR suite: 176 passed
- post-style focused suite: 28 passed
- `m2sdr_util` compiled cleanly
- Vivado 2024.1: WNS +0.037ns, WHS +0.022ns
- Artix-7 near-PMA PRBS31: approximately 63.1 billion bits with zero error indications; deliberate error injection was detected
- normal-traffic near-PMA loopback: byte alignment, PCS link, and Clause-37 negotiation completed

## External module result

The tested 6COM `6C-SFP-10G-T` locked the receiver CDR at 6.25Gbaud but did not achieve comma/byte alignment or packet link. Its documented 10.3125Gbaud SFP+ host interface is therefore not compatible with this mode even though its copper side negotiates 2.5/5Gbps. A module explicitly supporting a 6.25Gbaud host interface is still needed for an external-link qualification.
