### PR TITLE
gateware: add experimental 5GBASE-R Ethernet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Imagine a minimalist AD9361-based SDR with:
 - 2T2R / 12-bit @ 61.44MSPS (and 2T2R / 12-bit @ 122.88MSPS for those wanting to use/explore Cellwizard/BladeRF [findings](https://www.nuand.com/2023-02-release-122-88mhz-bandwidth/)).
 - PCIe Gen 2 X4 (~14Gbps of TX/RX bandwidth) with [LitePCIe](https://github.com/enjoy-digital/litepcie), providing MMAP and several possible DMAs (for direct I/Q samples transfer or processed I/Q samples). ⚡
 - A large XC7A200T FPGA where the base infrastructure only uses a fraction of the available resources, allowing you to integrate large RF processing blocks. 💪
-- The option to reuse some of the PCIe lanes of the M.2 connector for 1Gbps or 2.5Gbps Ethernet through [LiteEth](https://github.com/enjoy-digital/liteeth). 🌐
+- The option to reuse some of the PCIe lanes of the M.2 connector for 1Gbps, 2.5Gbps, or experimental 5GBASE-R Ethernet through [LiteEth](https://github.com/enjoy-digital/liteeth). 🌐
 - Or ... for SATA through the [LiteSATA](https://github.com/enjoy-digital/litesata) gateware core. 💾
 - Or ... for inter-board SerDes-based communication through [LiteICLink](https://github.com/enjoy-digital/liteiclink). 🔗
 - Powerful debug capabilities through LiteX [Host <-> FPGA bridges](https://github.com/enjoy-digital/litex/wiki/Use-Host-Bridge-to-control-debug-a-SoC) and [LiteScope](https://github.com/enjoy-digital/litescope) logic analyzer. 🛠️
@@ -60,7 +60,7 @@ This board is proudly developed in France 🇫🇷 by [Enjoy-Digital](http://enj
 
 Ideal for SDR enthusiasts, this versatile board fits directly into an M.2 slot or can team up with others in a PCIe M.2 carrier for more complex projects, including coherent MIMO SDRs. 🔧
 
-For Ethernet support with 1000BaseX/2500BaseX and SATA connectivity to directly record/play samples to/from an SSD, mount it on the LiteX Acorn Mini Baseboard! 💽
+For Ethernet support with 1000BaseX/2500BaseX, experimental 5GBASE-R, and SATA connectivity to directly record/play samples to/from an SSD, mount it on the LiteX Acorn Mini Baseboard! 💽
 
 <div align="center">
   <img src="https://github.com/user-attachments/assets/fb75aeeb-4e99-45b5-9582-0c4dbd079af6" width="100%">
@@ -110,7 +110,7 @@ Both variants use the same **M.2 2280 Key M** module form factor.
 |                                 |                              |                              |                                               |
 | **Connectivity**                |                              |                              |                                               |
 | PCIe (up to Gen2 x4)            | ✅                           | ✅ (x1 only)                 | `--with-pcie --pcie-lanes=1|2|4`              |
-| Ethernet (1G/2.5G)              | ❌                           | ✅                           | `--with-eth`                                  |
+| Ethernet (1G/2.5G/experimental 5GBASE-R) | ❌                  | ✅                           | `--with-eth`                                  |
 | ├─ Ethernet RX (LiteEth)        | ❌                           | ✅                           | (included with `--with-eth`)                  |
 | └─ Ethernet TX (LiteEth)        | ❌                           | ✅                           | (included with `--with-eth`)                  |
 |                                 |                              |                              |                                               |
@@ -201,22 +201,33 @@ The SoC has the following architecture:
 
 The PCIe design has already been validated at the maximum AD9361 specified sample rate: 2T2R @ 61.44MSPS (and also seems to correctly handle the oversampling at 2T2R @ 122.88MSPS with 7.9 Gbps of bandwidth on the PCIe bus; this oversampling feature is already in place and more tests/experiments will be done with it in the future).
 
-[> Ethernet SoC Design (1/2.5Gbps x 1 or 2).
+[> Ethernet SoC Design (1/2.5Gbps, experimental 5GBASE-R x 1 or 2).
 --------------------------------------------
 <a id="ethernet-soc-design"></a>
 
 > [!NOTE]
 >
 > Ethernet support is intended for LiteX Acorn Baseboard Mini deployments and
-> is bandwidth-limited by the selected 1000BaseX/2500BaseX link.
+> is bandwidth-limited by the selected Ethernet link.
 
 <div align="center">
   <img src="https://github.com/user-attachments/assets/bbcc0c79-4ae8-4e5b-94d8-aa7aff89bae2" width="100%">
 </div>
 
-The Ethernet design variant gives flexibility when deploying the SDR. The PCIe connector has 4 SerDes transceivers that are in most cases used for... PCIe :) But these are 4 classical GTP transceivers of the Artix7 FPGA that are connected to the PCIe hardened PHY in the case of a PCIe application but can be used for any other SerDes-based protocol: Ethernet 1000BaseX/2500BaseX, SATA, etc...
+The Ethernet design variant gives flexibility when deploying the SDR. The PCIe connector has 4 SerDes transceivers that are in most cases used for... PCIe :) But these are 4 classical GTP transceivers of the Artix7 FPGA that are connected to the PCIe hardened PHY in the case of a PCIe application but can be used for any other SerDes-based protocol: Ethernet 1000BaseX/2500BaseX/5GBASE-R, SATA, etc...
 
-In this design, the PCIe core will then be replaced with [LiteEth](https://github.com/enjoy-digital/liteeth), providing the 1000BaseX or 2500BaseX PHY but also the UDP/IP hardware stack + Streaming/Etherbone front-end cores.
+In this design, the PCIe core will then be replaced with [LiteEth](https://github.com/enjoy-digital/liteeth), providing the 1000BaseX, 2500BaseX, or 5GBASE-R PHY but also the UDP/IP hardware stack + Streaming/Etherbone front-end cores.
+
+The experimental 5GBASE-R mode uses the Artix-7 GTP native 64b/66b gearbox at
+5.15625Gbaud and a 103.125MHz GTP reference clock. The SFP/SFP+ module must
+explicitly expose 5GBASE-R on its host interface; support for 5GBASE-T on the
+copper side does not by itself guarantee a compatible host interface. Build a
+diagnostic image with:
+
+```bash
+./litex_m2sdr.py --variant=baseboard --with-eth --eth-phy=5000baser \
+    --with-eth-phy-probe --build --load
+```
 
 The Ethernet SoC design supports control plus RX/TX sample streaming over the LiteEth UDP path. The achievable 2T2R sample rate is capped by link bandwidth, so Ethernet builds also cap the RFIC clock to the selected link speed.
 
@@ -341,7 +352,7 @@ If you are an SDR enthusiast looking to get started with the LiteX-M2SDR board, 
 - **PCIe PTM host-time sync**: Build with `--with-pcie --pcie-lanes=1 --with-pcie-ptm` and run `scripts/m2sdr_pcie_time_sync.py` on the host to make the board PHC follow `CLOCK_REALTIME` through `phc2sys`. If the host clock is locked by NTP/PTP, the board follows that disciplined host time over PCIe.
 - **Ethernet VRT (optional RX path)**: Build with `--with-eth --with-eth-vrt` to enable an Ethernet RX VRT UDP streamer in hardware. A simple host receiver utility is available at `litex_m2sdr/software/user/m2sdr_vrt_rx.py`.
 - **Ethernet / SATA**: Ethernet RX/TX streaming is supported on the LiteX Acorn Baseboard Mini. Source builds can combine Ethernet and SATA with `./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 --with-sata --build`. `m2sdr_sata` supports low-level sector tests and named capture workflows for RF-to-SATA recording, host import/export, SATA-to-RF replay, and SATA replay into the normal PCIe/Ethernet RX path used by SoapySDR/GQRX.
-- **Ethernet RFIC clocking**: Ethernet builds cap the RFIC clock to the link-speed streaming budget for 2T2R SC8: 122.88MHz with `1000basex` and 245.76MHz with `2500basex`. PCIe builds keep the full 245.76MHz/491.52MHz non-oversample/oversample options.
+- **Ethernet RFIC clocking**: Ethernet builds cap the RFIC clock to the link-speed streaming budget for 2T2R SC8: 122.88MHz with `1000basex` and 245.76MHz with `2500basex` or `5000baser`. PCIe builds keep the full 245.76MHz/491.52MHz non-oversample/oversample options.
 - **Ethernet PTP (optional timing path)**: Build with `--with-eth --with-eth-ptp` to discipline the existing board `time_gen` from LiteEth PTP. `m2sdr_util info`, `m2sdr_util --watch ptp-status`, and `m2sdr_util ptp-config` expose the current lock/holdover state, learned port identity, runtime servo controls, and board-side discipline counters. While PTP discipline is active, host-side time writes are rejected to avoid two masters steering the same clock.
 - **Ethernet PTP RFIC reference (optional clock path)**: Add `--with-eth-ptp-rfic-clock` to expose a PTP-referenced FPGA 10MHz monitor/discipline loop. Enable it at runtime with `m2sdr_util ptp-clock10-config enable on`, verify `Reference Locked` and `Clock Locked`, then select the FPGA clock input for RF setup with `m2sdr_rf --sync fpga` or the matching SoapySDR `clock_source=fpga` setting. This gives RFIC reference frequency coherence; deterministic sample/RF phase alignment still needs AD9361 synchronization and timestamped stream start.
 
@@ -509,6 +520,10 @@ For those who want to explore the full potential of the LiteX-M2SDR board, inclu
    ```
      The validated baseboard configuration has JP1 and JP4 fitted. `R82`/`R83`
      are needed only for optional SFP EEPROM I2C access, not for Ethernet link.
+   - For an experimental 5GBASE-R module, add `--eth-phy=5000baser`. Add
+     `--with-eth-phy-probe` to expose GTP/PCS status, PRBS31 controls, near-end
+     PMA loopback control, and a receive-side LiteScope analyzer. See the
+     [Debugging Guide](doc/debugging-guide.md#5gbaser-phy-diagnostics).
    - After loading an Ethernet image, use `m2sdr_util` loopback tests to
      exercise the stream path before starting Soapy/Gqrx:
    ```

--- a/doc/debugging-guide.md
+++ b/doc/debugging-guide.md
@@ -50,6 +50,63 @@ Common Ethernet/Etherbone build on the baseboard:
 ping 192.168.1.50
 ```
 
+### 5GBASE-R PHY Diagnostics
+
+The experimental 5GBASE-R mode requires a module that presents a 5.15625Gbaud
+64b/66b host interface. Build it with the dedicated probe:
+
+```bash
+./litex_m2sdr.py --variant=baseboard --with-eth --eth-sfp=0 \
+    --eth-phy=5000baser --with-eth-phy-probe --build --load
+litex_server --jtag --jtag-config=openocd_xc7_ft4232.cfg
+```
+
+Read the compact status word over JTAGBone:
+
+```bash
+litex_cli --csr-csv=scripts/csr.csv --read=eth_phy_baser_status
+litex_cli --csr-csv=scripts/csr.csv --read=eth_phy_baser_rx_error_count
+```
+
+`eth_phy_baser_status` bits 0 through 7 are QPLL lock, TX reset done, RX reset
+done, RX PMA reset done, 64b/66b block lock, high BER, RX link status, and
+sequence error. A healthy external link normally reads `0x5f`: all reset/lock
+bits set, high BER clear, and no sequence error.
+
+The probe also exposes the raw GTP `LOOPBACK` field for transceiver-specific
+experiments. For example, select near-end PMA loopback and reset the GTP RX
+after entering or leaving the mode:
+
+```bash
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_baser_control 0x8
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_reset 1
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_reset 0
+litex_cli --csr-csv=scripts/csr.csv --read=eth_phy_baser_status
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_baser_control 0x0
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_reset 1
+litex_cli --csr-csv=scripts/csr.csv --write eth_phy_reset 0
+```
+
+On Artix-7 native-gearbox builds, near-end PMA loopback can suppress
+`RXDATAVALID` instead of returning framed gearbox words. In that case, a
+failure to acquire block lock is not by itself evidence of a PCS failure; use
+the LiteEth PCS simulation loopback to validate the 64b/66b logic and use the
+hardware probe to inspect the external receive path.
+
+Capture the native gearbox and decoded receive status when block lock is
+missing:
+
+```bash
+litescope_cli --csv=test/analyzer.csv --csr-csv=scripts/csr.csv --list
+litescope_cli --csv=test/analyzer.csv --csr-csv=scripts/csr.csv \
+    --length=512 --dump=/tmp/m2sdr-5gbaser.vcd
+```
+
+If QPLL and resets are healthy but the external path never achieves block
+lock, verify the module's host-side protocol. A module advertising
+2.5/5/10GBASE-T may still use fixed 10GBASE-R, 5GBASE-X, or a vendor-specific
+rate-adaptation mode toward the FPGA.
+
 Common PCIe build:
 
 ```bash

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -126,10 +126,11 @@ def _load_prepare_wr_environment(root_dir, wr_nic_dir=None):
 def get_rfic_clk_freq(with_eth=False, eth_phy="1000basex", with_rfic_oversampling=False):
     if with_eth:
         # Ethernet builds are limited by streaming bandwidth. Size the RFIC clock for 2T2R SC8:
-        # 1000BaseX -> 30.72MSPS, 2500BaseX -> 61.44MSPS.
+        # 1000BASE-X -> 30.72MSPS, 2500BASE-X/5GBASE-R -> 61.44MSPS.
         return {
             "1000basex" : 122.88e6,
             "2500basex" : 245.76e6,
+            "5000baser" : 245.76e6,
         }[eth_phy]
     return {
         False : 245.76e6, # Max rfic_clk for  61.44MSPS / 2T2R.
@@ -367,9 +368,11 @@ class BaseSoC(SoCMini):
 
         # Clocking ---------------------------------------------------------------------------------
 
-        # Match the Acorn 2.5G bring-up's 125MHz reference and x25 QPLL
-        # divider configuration. 1000BASE-X already uses 125MHz here.
-        eth_refclk_freq = 125e6
+        eth_refclk_freq = {
+            "1000basex" : 125e6,
+            "2500basex" : 125e6,
+            "5000baser" : 103.125e6,
+        }[eth_phy] if with_eth else 125e6
 
         # General.
         self.crg = CRG(platform, sys_clk_freq,
@@ -609,11 +612,15 @@ class BaseSoC(SoCMini):
         if with_eth:
             # PHY.
             # ----
-            eth_phy_cls = {
-                "1000basex" : A7_1000BASEX,
-                "2500basex" : A7_2500BASEX,
-            }[eth_phy]
-            self.eth_phy = eth_phy_cls(
+            if eth_phy == "5000baser":
+                from liteeth.phy.a7_1000basex import A7_5000BASER
+                eth_phy_cls = A7_5000BASER
+            else:
+                eth_phy_cls = {
+                    "1000basex" : A7_1000BASEX,
+                    "2500basex" : A7_2500BASEX,
+                }[eth_phy]
+            eth_phy_kwargs = dict(
                 qpll_channel = self.qpll.get_channel("eth"),
                 data_pads    = self.platform.request("sfp", eth_sfp),
                 sys_clk_freq = sys_clk_freq,
@@ -621,7 +628,11 @@ class BaseSoC(SoCMini):
                 tx_polarity  = 0, # Inverted on M2SDR and Acorn Baseboard Mini.
                 **get_eth_phy_kwargs(eth_phy),
             )
-            self.eth_phy.pcs.add_csr()
+            if eth_phy == "5000baser":
+                eth_phy_kwargs["platform"] = platform
+            self.eth_phy = eth_phy_cls(**eth_phy_kwargs)
+            if not getattr(self.eth_phy, "baser", False):
+                self.eth_phy.pcs.add_csr()
 
             # Core + MMAP (Etherbone).
             # ------------------------
@@ -1167,8 +1178,9 @@ class BaseSoC(SoCMini):
 
         # Ethernet transceiver clocks.
         if with_eth:
-            platform.add_period_constraint(self.eth_phy.txoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
-            platform.add_period_constraint(self.eth_phy.rxoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
+            if not getattr(self.eth_phy, "baser", False):
+                platform.add_period_constraint(self.eth_phy.txoutclk, 1e9/(self.eth_phy.tx_clk_freq/2))
+                platform.add_period_constraint(self.eth_phy.rxoutclk, 1e9/(self.eth_phy.rx_clk_freq/2))
             platform.add_false_path_constraints(self.eth_phy.txoutclk, self.eth_phy.rxoutclk, self.crg.cd_sys.clk)
             if eth_phy == "2500basex":
                 # The two halves of the RX gearbox exchange state/data on each
@@ -1498,6 +1510,96 @@ class BaseSoC(SoCMini):
             csr_csv      = "test/analyzer.csv"
         )
 
+    def add_eth_phy_probe(self, depth=4096):
+        """Add 5GBASE-R status CSRs and a receive-side LiteScope probe."""
+        assert hasattr(self, "eth_phy")
+        if not getattr(self.eth_phy, "baser", False):
+            raise ValueError("The Ethernet PHY probe currently targets the BASE-R datapath.")
+
+        control = self.eth_phy._baser_control = CSRStorage(name="baser_control", fields=[
+            CSRField("tx_prbs31", size=1, offset=0, description="Transmit BASE-R PRBS31 blocks."),
+            CSRField("rx_prbs31", size=1, offset=1, description="Check BASE-R PRBS31 blocks."),
+            CSRField("loopback", size=3, offset=2,
+                description="GTP LOOPBACK control (010 selects near-end PMA loopback)."),
+        ], description="5GBASE-R PCS diagnostics.")
+        tx_prbs31 = Signal()
+        rx_prbs31 = Signal()
+        loopback  = Signal(3)
+        self.specials += [
+            MultiReg(control.fields.tx_prbs31, tx_prbs31, "eth_tx"),
+            MultiReg(control.fields.rx_prbs31, rx_prbs31, "eth_rx"),
+            MultiReg(control.fields.loopback,  loopback,  "eth_tx"),
+        ]
+        self.comb += [
+            self.eth_phy.pcs.tx_prbs31_enable.eq(tx_prbs31),
+            self.eth_phy.pcs.rx_prbs31_enable.eq(rx_prbs31),
+            self.eth_phy.loopback.eq(loopback),
+        ]
+
+        status_signals = [Signal() for _ in range(8)]
+        self.specials += [
+            MultiReg(self.eth_phy.qpll_lock,              status_signals[0]),
+            MultiReg(self.eth_phy.tx_reset_done,          status_signals[1]),
+            MultiReg(self.eth_phy.rx_reset_done,          status_signals[2]),
+            MultiReg(self.eth_phy.rx_pma_reset_done,      status_signals[3]),
+            MultiReg(self.eth_phy.pcs.rx_block_lock,      status_signals[4]),
+            MultiReg(self.eth_phy.pcs.rx_high_ber,        status_signals[5]),
+            MultiReg(self.eth_phy.pcs.rx_status,          status_signals[6]),
+            MultiReg(self.eth_phy.pcs.rx_sequence_error,  status_signals[7]),
+        ]
+        self.eth_phy._baser_status = CSRStatus(name="baser_status", fields=[
+            CSRField("qpll_lock",         size=1, offset=0),
+            CSRField("tx_reset_done",     size=1, offset=1),
+            CSRField("rx_reset_done",     size=1, offset=2),
+            CSRField("rx_pma_reset_done", size=1, offset=3),
+            CSRField("rx_block_lock",     size=1, offset=4),
+            CSRField("rx_high_ber",       size=1, offset=5),
+            CSRField("rx_status",         size=1, offset=6),
+            CSRField("rx_sequence_error", size=1, offset=7),
+        ], description="5GBASE-R GTP and PCS status.")
+        self.comb += [
+            self.eth_phy._baser_status.fields.qpll_lock.eq(status_signals[0]),
+            self.eth_phy._baser_status.fields.tx_reset_done.eq(status_signals[1]),
+            self.eth_phy._baser_status.fields.rx_reset_done.eq(status_signals[2]),
+            self.eth_phy._baser_status.fields.rx_pma_reset_done.eq(status_signals[3]),
+            self.eth_phy._baser_status.fields.rx_block_lock.eq(status_signals[4]),
+            self.eth_phy._baser_status.fields.rx_high_ber.eq(status_signals[5]),
+            self.eth_phy._baser_status.fields.rx_status.eq(status_signals[6]),
+            self.eth_phy._baser_status.fields.rx_sequence_error.eq(status_signals[7]),
+        ]
+
+        self.eth_phy._baser_rx_error_count = CSRStatus(7,
+            name        = "baser_rx_error_count",
+            description = "BASE-R PRBS31 error count from the most recent PCS interval.",
+        )
+        self.specials += MultiReg(
+            self.eth_phy.pcs.rx_error_count,
+            self.eth_phy._baser_rx_error_count.status,
+        )
+
+        analyzer_signals = [
+            self.eth_phy.rx_data_valid,
+            self.eth_phy.rx_header_valid,
+            self.eth_phy.rx_block_ce,
+            self.eth_phy.pcs.serdes_rx_hdr,
+            self.eth_phy.pcs.serdes_rx_data,
+            self.eth_phy.pcs.rx_block_lock,
+            self.eth_phy.pcs.rx_high_ber,
+            self.eth_phy.pcs.rx_bad_block,
+            self.eth_phy.pcs.rx_sequence_error,
+            self.eth_phy.pcs.rx_status,
+            self.eth_phy.source.valid,
+            self.eth_phy.source.last,
+            self.eth_phy.source.error,
+        ]
+        self.analyzer = LiteScopeAnalyzer(analyzer_signals,
+            depth        = depth,
+            samplerate   = self.eth_phy.rx_clk_freq,
+            clock_domain = "eth_rx",
+            register     = True,
+            csr_csv      = "test/analyzer.csv"
+        )
+
     # RFIC.
     def add_ad9361_spi_probe(self, depth=4096):
         analyzer_signals = [self.platform.lookup_request("ad9361_spi")]
@@ -1550,7 +1652,8 @@ def main():
     # Ethernet parameters.
     parser.add_argument("--with-eth",        action="store_true",     help="Enable Ethernet Communication.")
     parser.add_argument("--eth-sfp",         default=0, type=int,     help="Ethernet SFP.", choices=[0, 1])
-    parser.add_argument("--eth-phy",         default="1000basex",     help="Ethernet PHY.", choices=["1000basex", "2500basex"])
+    parser.add_argument("--eth-phy", default="1000basex", help="Ethernet PHY.",
+        choices=["1000basex", "2500basex", "5000baser"])
     parser.add_argument("--eth-local-ip",    default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
     parser.add_argument("--eth-udp-port",    default=2345, type=int,  help="Ethernet Remote port.")
     parser.add_argument("--with-eth-ptp",    action="store_true",     help="Enable LiteEth PTP and discipline the board time generator from it.")
@@ -1588,6 +1691,8 @@ def main():
     probeopts.add_argument("--with-si5351-i2c-probe",  action="store_true", help="Enable SI5351 I2C Probe.")
     probeopts.add_argument("--with-eth-phy-rx-probe",  action="store_true", help="Enable raw Ethernet PHY RX Probe.")
     probeopts.add_argument("--with-eth-tx-probe",      action="store_true", help="Enable Ethernet Tx Probe.")
+    probeopts.add_argument("--with-eth-phy-probe", action="store_true",
+        help="Enable 5GBASE-R GTP/PCS status and RX Probe.")
     probeopts.add_argument("--with-ad9361-spi-probe",  action="store_true", help="Enable AD9361 SPI Probe.")
     probeopts.add_argument("--with-ad9361-data-probe", action="store_true", help="Enable AD9361 Data Probe.")
 
@@ -1687,6 +1792,8 @@ def main():
         soc.add_eth_phy_rx_probe()
     if args.with_eth_tx_probe:
         soc.add_eth_tx_probe()
+    if args.with_eth_phy_probe:
+        soc.add_eth_phy_probe()
     if args.with_ad9361_spi_probe:
         soc.add_ad9361_spi_probe()
     if args.with_ad9361_data_probe:

--- a/litex_m2sdr/gateware/capability.py
+++ b/litex_m2sdr/gateware/capability.py
@@ -75,13 +75,13 @@ class Capability(LiteXModule):
 
         # Ethernet Config.
         # ----------------
-        eth_speed_map  = {"1000basex": 0, "2500basex": 1}
+        eth_speed_map  = {"1000basex": 0, "2500basex": 1, "5000baser": 2}
         eth_speed_value = eth_speed_map[eth_speed] if eth_enabled else 0
         self._eth_config = CSRStatus(32, fields=[
             CSRField("speed", size=2, offset=0, reset=eth_speed_value, values=[
                 ("``0b00``", "1Gbps"),
                 ("``0b01``", "2.5Gbps"),
-                ("``0b10``", "Reserved"),
+                ("``0b10``", "5Gbps"),
                 ("``0b11``", "Reserved"),
             ], description="Ethernet speed configuration."),
             CSRField("ptp", size=1, offset=2, reset=int(eth_ptp), description="Ethernet PTP time discipline build support."),

--- a/litex_m2sdr/gateware/qpll.py
+++ b/litex_m2sdr/gateware/qpll.py
@@ -29,9 +29,9 @@ class SharedQPLL(LiteXModule):
         qpll_eth_settings = QPLLSettings(
             # Match the original Acorn 2.5G topology on GTREFCLK0 while
             # preserving the existing internal reference for 1000BASE-X.
-            refclksel  = {"1000basex": 0b111, "2500basex": 0b001}[eth_phy],
-            fbdiv      = {"1000basex": 4, "2500basex": 5}[eth_phy],
-            fbdiv_45   = {125e6: 5, 156.25e6 : 4}[eth_refclk_freq],
+            refclksel  = {"1000basex": 0b111, "2500basex": 0b001, "5000baser": 0b111}[eth_phy],
+            fbdiv      = {"1000basex": 4, "2500basex": 5, "5000baser": 5}[eth_phy],
+            fbdiv_45   = {103.125e6: 5, 125e6: 5, 156.25e6: 4}[eth_refclk_freq],
             refclk_div = 1,
         )
 

--- a/test/test_capability.py
+++ b/test/test_capability.py
@@ -33,3 +33,28 @@ def test_capability_builds_with_valid_configuration():
         wr_sfp=1,
     )
     assert dut is not None
+
+
+def test_capability_encodes_5000baser_speed():
+    dut = Capability(
+        api_version_str="1.2",
+        pcie_enabled=False,
+        pcie_speed="gen1",
+        pcie_lanes=1,
+        pcie_ptm=False,
+        eth_enabled=True,
+        eth_speed="5000baser",
+        eth_ptp=False,
+        eth_ptp_rfic_clock=False,
+        sata_enabled=False,
+        sata_gen="gen1",
+        sata_mode="read-only",
+        gpio_enabled=False,
+        wr_enabled=False,
+        variant="baseboard",
+        jtagbone=True,
+        eth_sfp=0,
+        wr_sfp=1,
+    )
+
+    assert dut._eth_config.fields.speed.reset.value == 2

--- a/test/test_cli_args.py
+++ b/test/test_cli_args.py
@@ -28,6 +28,7 @@ def test_rfic_clk_freq_policy():
     assert soc_mod.get_rfic_clk_freq(with_rfic_oversampling=True) == 491.52e6
     assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="1000basex") == 122.88e6
     assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="2500basex") == 245.76e6
+    assert soc_mod.get_rfic_clk_freq(with_eth=True, eth_phy="5000baser") == 245.76e6
     assert soc_mod.get_rfic_clk_freq(
         with_eth=True,
         eth_phy="1000basex",

--- a/test/test_qpll.py
+++ b/test/test_qpll.py
@@ -103,6 +103,7 @@ def test_shared_qpll_can_use_system_clock_as_eth_reference(monkeypatch):
     ("1000basex", 156.25e6, 4, 1.25e9),
     ("2500basex", 125e6,    2, 3.125e9),
     ("2500basex", 156.25e6, 2, 3.125e9),
+    ("5000baser", 103.125e6, 1, 5.15625e9),
 ])
 def test_shared_qpll_eth_settings_generate_expected_linerate(monkeypatch, eth_phy, refclk_freq, out_div, expected_linerate):
     monkeypatch.setattr(qpll_mod, "QPLL", _FakeQPLL)


### PR DESCRIPTION
## Summary

- add an experimental standards-based `5000baser` Ethernet PHY mode for the Acorn Mini baseboard
- configure the SI5351/GTP path for a 103.125 MHz reference and 5.15625 Gbaud line rate
- expose the 5 Gbps capability code and retain the safe 245.76 MHz Ethernet RFIC clock policy
- add JTAG-accessible GTP/PCS status, PRBS31 controls, raw GTP loopback control, and a receive-side LiteScope analyzer
- document module host-interface requirements and the hardware-debug workflow
- load the new LiteEth PHY only when 5GBASE-R is selected, so existing release builds remain compatible until the dependency merges

This depends on enjoy-digital/liteeth#217. It is the IEEE-style 5GBASE-R
path and is separate from the earlier custom 5GBASE-X experiment in #160.

## Validation

- `pytest -q`: 169 tests passed on current `main`
- `./release.py --nobuild` passes against current LiteEth `master`; 5G SoC elaboration passes with enjoy-digital/liteeth#217
- Vivado 2024.1 full baseboard build with `--eth-phy=5000baser --with-eth-phy-probe` generated the main, operational, and fallback bitstreams
- all new 5GBASE-R clock groups meet setup and hold timing; the slowest new crossing has +0.019 ns hold and +0.063 ns setup slack
- the complete image is within 3 ps of closure only in the pre-existing 245.76 MHz RFIC group; BASE-R RX/TX intra-clock setup slack is +6.730/+9.800 ns

The `build` workflow and both software jobs pass. The separate `ci` hardware
jobs currently stop in the unrelated White Rabbit smoke test because an
external `wrpc-sw` GitLab SSH submodule cannot be cloned. The current upstream
`main` run fails at the same step:
https://github.com/enjoy-digital/litex_m2sdr/actions/runs/33117244721

## Hardware result

The final image was loaded over JTAG on the connected M2SDR/baseboard and
tested with the installed multirate copper SFP+ module:

- status `0x2f`: QPLL locked and TX, RX, and RX-PMA reset completion asserted
- the final LiteScope capture shows active native-gearbox receive data with `RXDATAVALID=01` and the expected block cadence
- received sync headers remain invalid (`00`/`11`), so high BER stays asserted and block lock/link status remain low
- 3/3 pings to `192.168.1.50` were lost

This demonstrates that the electrical/GTP receive path is active, but the
module does not expose a usable 5GBASE-R host stream in its current mode.
The documentation also records that Artix-7 near-end PMA loopback can suppress
native-gearbox `RXDATAVALID`, so that raw control is not presented as a
guaranteed PCS self-test.
