### PR TITLE
Meet timing on the M.2 PCIe builds, and fix the stream loopback test on PCIe

### DIFF
--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -6,6 +6,7 @@
 # Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import inspect
 import os
 import sys
 import argparse
@@ -1724,7 +1725,22 @@ def main():
         return r
 
     builder = Builder(soc, output_dir=os.path.join("build", get_build_name()), csr_csv="scripts/csr.csv")
-    builder.build(build_name=get_build_name(), run=args.build)
+    # Timing-closure directives. The 125 MHz sys clock is this design's critical domain: direct
+    # place and route for timing and run the post-place and post-route physical-optimization
+    # passes so the PCIe variants meet timing at the stock clock. Implementation-stage directives
+    # only -- steering synthesis/logic optimization degrades this design's sys-clock result. A
+    # bitstream that misses timing must never be flashed: a marginal image mis-clocks the AD9361
+    # and presents as a dead RFIC.
+    build_kwargs = {}
+    toolchain = getattr(getattr(soc, "platform", None), "toolchain", None)
+    if toolchain is not None and "vivado_place_directive" in inspect.signature(toolchain.build).parameters:
+        build_kwargs.update(
+            vivado_place_directive               = "ExtraTimingOpt",
+            vivado_post_place_phys_opt_directive = "AggressiveExplore",
+            vivado_route_directive               = "AggressiveExplore",
+            vivado_post_route_phys_opt_directive = "AggressiveExplore",
+        )
+    builder.build(build_name=get_build_name(), run=args.build, **build_kwargs)
 
     # Generate LitePCIe Driver.
     generate_litepcie_software(soc, "litex_m2sdr/software", use_litepcie_software=args.driver)

--- a/litex_m2sdr/software/user/m2sdr_util.c
+++ b/litex_m2sdr/software/user/m2sdr_util.c
@@ -2634,6 +2634,18 @@ static void loopback_print_stream_diagnostics(struct m2sdr_dev *dev)
     printf("\n");
 }
 
+/* The TX crossbar mux selects the stream source: 0 = PCIe DMA, 1 = Ethernet TX streamer. The
+ * prefill hold/release below only makes sense for an Ethernet device, but USE_LITEETH is defined
+ * in every build (all three Makefile INTERFACE settings emit -DUSE_LITEPCIE -DUSE_LITEETH), so it
+ * has to be gated on the transport actually in use. */
+static bool loopback_is_liteeth(struct m2sdr_dev *dev)
+{
+    enum m2sdr_transport_kind transport;
+
+    return m2sdr_get_transport(dev, &transport) == M2SDR_ERR_OK &&
+           transport == M2SDR_TRANSPORT_KIND_LITEETH;
+}
+
 static int loopback_reset_datapath(struct m2sdr_dev *dev, const char *phase)
 {
     int rc = m2sdr_reset_datapath(dev);
@@ -2782,7 +2794,7 @@ static int stream_loopback_test(int data_width,
         goto cleanup_disable_loopback;
     }
 #ifdef CSR_CROSSBAR_MUX_SEL_ADDR
-    if (m2sdr_reg_write(dev, CSR_CROSSBAR_MUX_SEL_ADDR, 0) != 0) {
+    if (loopback_is_liteeth(dev) && m2sdr_reg_write(dev, CSR_CROSSBAR_MUX_SEL_ADDR, 0) != 0) {
         fprintf(stderr, "m2sdr TX prefill hold failed\n");
         goto cleanup_disable_loopback;
     }
@@ -2810,7 +2822,7 @@ static int stream_loopback_test(int data_width,
             rx_observed_base = stats.rx_buffers;
     }
 #ifdef CSR_CROSSBAR_MUX_SEL_ADDR
-    if (m2sdr_reg_write(dev, CSR_CROSSBAR_MUX_SEL_ADDR, 1) != 0) {
+    if (loopback_is_liteeth(dev) && m2sdr_reg_write(dev, CSR_CROSSBAR_MUX_SEL_ADDR, 1) != 0) {
         fprintf(stderr, "m2sdr TX prefill release failed\n");
         goto cleanup_disable_loopback;
     }


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. Vivado implementation directives (`62f9d85`)

The M.2 PCIe builds don't meet timing with Vivado's default implementation strategy. Measured on
current `main` with Vivado 2025.2.1:

| build | WNS | failing setup endpoints |
|---|---|---|
| x4 | −0.415 ns | 145 |
| x2 | −0.225 ns | 8 |

Directing place and route for timing, plus the post-place and post-route physical-optimization
passes, closes both — same toolchain, no other change:

| build | WNS | failing setup endpoints |
|---|---|---|
| x4 | +0.063 ns | 0 |
| x2 | +0.018 ns | 0 |

Implementation-stage directives only; synthesis and logic optimization are left at their defaults
because steering those made this design's sys-clock result worse. They're applied only if the
installed LiteX toolchain accepts them, so older LiteX still builds.

Worth flagging: `release.py` gates releases on `WNS >= 0`, so both variants currently fail that
gate on this toolchain. A bitstream that misses timing also mis-clocks the AD9361 and presents as
a dead RFIC, which is unpleasant to diagnose from the host side.

## 2. Stream loopback test on PCIe (`61bba03`)

`fpga-loopback-test` can't run on a PCIe device — it always fails with
`m2sdr_sync_rx failed: timeout with TX window full`.

`stream_loopback_test()` brackets its TX prefill with a crossbar hold/release
(`CSR_CROSSBAR_MUX_SEL = 0`, then `= 1`). Mux input 1 is the **Ethernet** TX streamer, which isn't
instantiated on a PCIe-only image, so "release" parks the transmit path on an unconnected input.

Both writes are under `#ifdef USE_LITEETH`, but that macro is defined in every build — all three
Makefile `INTERFACE` settings emit `-DUSE_LITEPCIE -DUSE_LITEETH`, only the default transport
differs — so there's no build where this Ethernet-specific step is compiled out. Gated on the
active transport instead.

Verified on an M.2 board over PCIe Gen2 x4: before, immediate timeout at every rate and `--pace`
mode; after, the test streams both directions at ~6.4 Gbps with 188 899 buffers checked.
`make clean all`, `make all INTERFACE=USE_LITEETH`, `make test-libm2sdr` and `make
analyze-libm2sdr` all pass.
