### PR TITLE
wr: update reusable core, CPU memory and MMCM integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/enjoy-digital/litex_wr_nic.git /tmp/litex_wr_nic
           # Reusable core, CPU memory/boot, management and MMCM APIs (#72-#77).
-          git -C /tmp/litex_wr_nic fetch --depth=1 origin 98034d6ea2545bc3d9b513030221e6ef577e3479
+          git -C /tmp/litex_wr_nic fetch --depth=1 origin 6e4fd67bae0463caa8da563ba58ee811828b2dfb
           git -C /tmp/litex_wr_nic checkout --detach FETCH_HEAD
 
       - name: Run White Rabbit integration smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/enjoy-digital/litex_wr_nic.git /tmp/litex_wr_nic
           # Reusable core, CPU memory/boot, management and MMCM APIs (#72-#77).
-          git -C /tmp/litex_wr_nic fetch --depth=1 origin 6a2c7e646d1ca2f1118cc151378bbb856fcbafd4
+          git -C /tmp/litex_wr_nic fetch --depth=1 origin 98034d6ea2545bc3d9b513030221e6ef577e3479
           git -C /tmp/litex_wr_nic checkout --detach FETCH_HEAD
 
       - name: Run White Rabbit integration smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/enjoy-digital/litex_wr_nic.git /tmp/litex_wr_nic
           # Reusable core, CPU memory/boot, management and MMCM APIs (#72-#77).
-          git -C /tmp/litex_wr_nic fetch --depth=1 origin 6e4fd67bae0463caa8da563ba58ee811828b2dfb
+          git -C /tmp/litex_wr_nic fetch --depth=1 origin bac7b7a7af1215f741bbeeb095cac5a01a732b8a
           git -C /tmp/litex_wr_nic checkout --detach FETCH_HEAD
 
       - name: Run White Rabbit integration smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Checkout LiteX-WR-NIC (for WR smoke tests)
         run: |
           git clone --depth=1 https://github.com/enjoy-digital/litex_wr_nic.git /tmp/litex_wr_nic
+          # Reusable core, CPU memory/boot, management and MMCM APIs (#72-#77).
+          git -C /tmp/litex_wr_nic fetch --depth=1 origin 6a2c7e646d1ca2f1118cc151378bbb856fcbafd4
+          git -C /tmp/litex_wr_nic checkout --detach FETCH_HEAD
 
       - name: Run White Rabbit integration smoke tests
         env:
@@ -147,6 +150,10 @@ jobs:
           ./litex_m2sdr.py --with-pcie --with-white-rabbit --variant=baseboard
           rm -rf wr-cores
           ./litex_m2sdr.py --with-pcie --with-white-rabbit --variant=baseboard --wr-sfp=1
+
+          # LiteX CPU and host-loaded integrated RAM.
+          ./litex_m2sdr.py --with-pcie --with-white-rabbit --variant=baseboard --wr-cpu-type=vexriscv --wr-cpu-memory=integrated
+          ./litex_m2sdr.py --with-pcie --with-white-rabbit --variant=baseboard --wr-cpu-type=vexriscv --wr-cpu-memory=integrated --wr-cpu-boot=host
 
           # WR stale local wr-cores checkout smoke test.
           rm -rf wr-cores
@@ -172,6 +179,8 @@ jobs:
           rm -rf wr-cores
 
       - name: Run gateware simulation tests
+        env:
+          PYTHONPATH: /tmp/litex_wr_nic
         run: |
           python3 -m pytest -v test
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ For those who want to explore the full potential of the LiteX-M2SDR board, inclu
    ./litex_m2sdr.py --with-pcie --with-white-rabbit --variant=baseboard --build
    ```
    - The White Rabbit helper logic is provided by `litex_wr_nic`; install it, set `LITEX_WR_NIC_DIR`, or keep a sibling `../litex_wr_nic` checkout.
+   - Use the reusable-core/MMCM API version documented in the [WR integration guide](doc/wr_integration.md). The default remains uRV with private RAM; VexRiscv, integrated RAM and host loading are selectable. The guide includes dependency setup, build commands and WR console access.
    - `--wr-sfp` is optional; when omitted, the first available `sfp` index is auto-selected.
    - Firmware path lookup order:
      1. `--wr-firmware`

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -8,9 +8,13 @@ The default is uRV with 128 KiB of private RAM and embedded firmware.
 
 This integration requires the core, memory/boot, management and clock APIs from
 [LiteX-WR-NIC #72–#77](https://github.com/enjoy-digital/litex_wr_nic/pull/77).
-CI pins commit `6a2c7e646d1ca2f1118cc151378bbb856fcbafd4` while that series is
+CI pins commit `98034d6ea2545bc3d9b513030221e6ef577e3479` while that series is
 pending merge. Select a checkout containing that commit or the merged APIs.
 The dependency's MMCM backend still needs physical clock/WR servo qualification.
+It preserves the previous nominal MMCM tuning rate and polarity; this update
+does not retune the Acorn firmware PI coefficients. The dependency also keeps
+the original `PSGen` implementation for older integrations. M2SDR explicitly
+uses `WRMMCMBackend` with both completion signals connected.
 
 Run the following commands from the M2SDR repository, with the dependency path
 pointing to the **repository root**:

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -8,7 +8,7 @@ The default is uRV with 128 KiB of private RAM and embedded firmware.
 
 This integration requires the core, memory/boot, management and clock APIs from
 [LiteX-WR-NIC #72–#77](https://github.com/enjoy-digital/litex_wr_nic/pull/77).
-CI pins commit `98034d6ea2545bc3d9b513030221e6ef577e3479` while that series is
+CI pins commit `6e4fd67bae0463caa8da563ba58ee811828b2dfb` while that series is
 pending merge. Select a checkout containing that commit or the merged APIs.
 The dependency's MMCM backend still needs physical clock/WR servo qualification.
 It preserves the previous nominal MMCM tuning rate and polarity; this update
@@ -96,6 +96,29 @@ Both MMCM backends accept coherent tuning commands from `wr_sys` and wait for
 their own `PSDONE` in `clk200`. Their status/counters report busy, completion
 timeout, completed shifts and superseded commands. A completion timeout requires
 resetting the backend and MMCM, for example by reloading the FPGA.
+
+Both WR MMCMs explicitly use `fractional=False`: fine phase shifting requires
+integer output division. Their nominal outputs remain 125 MHz and 62.5 MHz.
+The selected VCO is 1.5 GHz, giving approximately 11.905 ps per shift. The
+previous fractional DMTD configuration used a 1.59375 GHz VCO and an output
+divider of 25.5, which is incompatible with fine phase shifting. Correcting it
+changes the DMTD phase-step size by 6.25%; firmware PI coefficients are unchanged.
+
+The dependency's XSim tests exercise the real Xilinx MMCM models for both
+M2SDR clock configurations, including phase wraparound, completion timing and
+reset/relock. Full-width RTL tests also cover frequent small corrections,
+completion faults and stopped-clock resets. Same-direction command updates
+retain fractional phase, and the FIFO waits for both clocks after reset to
+prevent old commands from replaying. To run these checks in the dependency:
+
+```sh
+cd "$LITEX_WR_NIC_DIR"
+pytest -q test/test_wr_clock.py test/test_wr_mmcm.py
+```
+
+Vivado's `xvlog`, `xelab` and `xsim` must be on `PATH` for the MMCM model tests;
+otherwise pytest reports them as skipped. These digital simulations do not
+measure physical clock jitter or closed-loop WR performance.
 
 `read-time` snapshots WR's native time. The existing SDR `time_gen` is a separate
 timebase; this update does not connect WR timecode to SDR sample timestamps.

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -1,0 +1,99 @@
+# White Rabbit on M2SDR
+
+WR requires the Acorn Baseboard Mini and an SFP port. M2SDR uses the reusable
+`add_white_rabbit` integration helper and its automatic HDL source registration.
+The default is uRV with 128 KiB of private RAM and embedded firmware.
+
+## Dependency
+
+This integration requires the core, memory/boot, management and clock APIs from
+[LiteX-WR-NIC #72–#77](https://github.com/enjoy-digital/litex_wr_nic/pull/77).
+CI pins commit `6a2c7e646d1ca2f1118cc151378bbb856fcbafd4` while that series is
+pending merge. Select a checkout containing that commit or the merged APIs.
+The dependency's MMCM backend still needs physical clock/WR servo qualification.
+
+Run the following commands from the M2SDR repository, with the dependency path
+pointing to the **repository root**:
+
+```sh
+export LITEX_WR_NIC_DIR=/path/to/litex_wr_nic
+export PYTHONPATH="$LITEX_WR_NIC_DIR${PYTHONPATH:+:$PYTHONPATH}"
+./litex_m2sdr.py --variant=baseboard --wr-status
+```
+
+## Build
+
+Default uRV/private RAM, with PCIe and JTAGBone access:
+
+```sh
+./litex_m2sdr.py --variant=baseboard --with-pcie --with-white-rabbit --build
+```
+
+VexRiscv `lite` with embedded firmware in integrated RAM:
+
+```sh
+./litex_m2sdr.py --variant=baseboard --with-pcie --with-white-rabbit \
+    --wr-cpu-type=vexriscv --wr-cpu-memory=integrated --build
+```
+
+VexRiscv with integrated RAM held for host loading:
+
+```sh
+./litex_m2sdr.py --variant=baseboard --with-pcie --with-white-rabbit \
+    --wr-cpu-type=vexriscv --wr-cpu-memory=integrated --wr-cpu-boot=host --build
+```
+
+uRV can also use integrated RAM with embedded or host boot. Private RAM requires
+uRV and embedded boot. This target has no WR HyperRAM/DDR or SPI-boot option.
+`--wr-sfp=0` or `--wr-sfp=1` chooses a port; omission selects the first available.
+
+The build helper selects CPU-specific firmware and uses the `acorn` firmware
+target. A custom `--wr-firmware image.bram` for integrated embedded boot needs
+the corresponding `image.bin` alongside it. Omitting `--build` performs only
+elaboration, building firmware first if it is missing. Use `--load` with the
+same configuration to load the generated image.
+
+Build directory names include nondefault CPU, variant, memory and boot choices.
+Save the generated `scripts/csr.csv` with each bitstream: it is overwritten by
+the next configuration. Rebuild host software against the matching generated
+headers when changing configuration.
+
+## Console and host loading
+
+Start a LiteX server using the board's PCIe address, for example:
+
+```sh
+sudo litex_server --pcie --pcie-bar=04:00.0
+```
+
+The [debugging guide](debugging-guide.md) covers other available transports.
+In another terminal with the dependency on `PYTHONPATH`:
+
+```sh
+python3 -m litex_wr_nic.wr --csr-csv scripts/csr.csv status
+python3 -m litex_wr_nic.wr --csr-csv scripts/csr.csv console --command ver
+python3 -m litex_wr_nic.wr --csr-csv scripts/csr.csv console --command uptime
+python3 -m litex_wr_nic.wr --csr-csv scripts/csr.csv read-time
+```
+
+With host boot, load firmware before using the console:
+
+```sh
+python3 -m litex_wr_nic.wr --csr-csv scripts/csr.csv load-firmware \
+    "$LITEX_WR_NIC_DIR/litex_wr_nic/firmware/spec_a7_wrc_vexriscv.boot"
+```
+
+The common host tool verifies the full reserved RAM before releasing the CPU.
+The shared UART provides a 4096-byte RX FIFO, occupancy and overflow reporting.
+The WR host window remains at `0x00040000`, size `0x00040000`; generated UART
+and management CSRs require the new bitstream's CSV.
+
+Both MMCM backends accept coherent tuning commands from `wr_sys` and wait for
+their own `PSDONE` in `clk200`. Their status/counters report busy, completion
+timeout, completed shifts and superseded commands. A completion timeout requires
+resetting the backend and MMCM, for example by reloading the FPGA.
+
+`read-time` snapshots WR's native time. The existing SDR `time_gen` is a separate
+timebase; this update does not connect WR timecode to SDR sample timestamps.
+CPU/console operation and valid snapshots do not establish servo lock, jitter
+or calibrated PPS accuracy.

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -8,9 +8,10 @@ The default is uRV with 128 KiB of private RAM and embedded firmware.
 
 This integration requires the core, memory/boot, management and clock APIs from
 [LiteX-WR-NIC #72–#77](https://github.com/enjoy-digital/litex_wr_nic/pull/77).
-CI pins commit `6e4fd67bae0463caa8da563ba58ee811828b2dfb` while that series is
+CI pins commit `bac7b7a7af1215f741bbeeb095cac5a01a732b8a` while that series is
 pending merge. Select a checkout containing that commit or the merged APIs.
-The dependency's MMCM backend still needs physical clock/WR servo qualification.
+The MMCM backend has passed physical phase-request and output-frequency tests
+on SPEC-A7. M2SDR WR servo lock, jitter and PPS accuracy still need measurement.
 It preserves the previous nominal MMCM tuning rate and polarity; this update
 does not retune the Acorn firmware PI coefficients. The dependency also keeps
 the original `PSGen` implementation for older integrations. M2SDR explicitly

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -108,10 +108,14 @@ def _iter_wr_nic_import_candidates(root_dir, wr_nic_dir=None):
 
 
 def _load_prepare_wr_environment(root_dir, wr_nic_dir=None):
-    for candidate in _iter_wr_nic_import_candidates(root_dir, wr_nic_dir):
-        for path in (candidate, os.path.dirname(candidate)):
-            if path not in sys.path:
-                sys.path.insert(0, path)
+    # Inserting at the front reverses priority: process fallbacks first so an
+    # explicit checkout wins over a stale sibling or an installed package.
+    candidates = list(_iter_wr_nic_import_candidates(root_dir, wr_nic_dir))
+    for candidate in reversed(candidates):
+        for path in (os.path.dirname(candidate), candidate):
+            if path in sys.path:
+                sys.path.remove(path)
+            sys.path.insert(0, path)
 
     try:
         from litex_wr_nic.integration import prepare_wr_environment
@@ -205,14 +209,15 @@ class CRG(LiteXModule):
 
         # Ethernet PLL.
         # -------------
-        if eth_refclk_direct:
+        # WR's tunable MMCM owns refclk_eth when enabled.
+        if eth_refclk_direct and not with_white_rabbit:
             if sys_clk_freq != eth_refclk_freq:
                 raise ValueError("A direct Ethernet reference requires sys_clk_freq == eth_refclk_freq.")
             self.comb += [
                 self.cd_refclk_eth.clk.eq(self.cd_sys.clk),
                 self.cd_refclk_eth.rst.eq(self.cd_sys.rst),
             ]
-        elif with_eth or with_sata or with_white_rabbit:
+        elif (with_eth or with_sata) and not with_white_rabbit:
             self.eth_pll = eth_pll = S7PLL()
             eth_pll.register_clkin(self.cd_sys.clk, sys_clk_freq)
             eth_pll.create_clkout(self.cd_refclk_eth, eth_refclk_freq, margin=0)
@@ -320,6 +325,7 @@ class BaseSoC(SoCMini):
         with_sata              = False, sata_gen=2,
         with_white_rabbit      = False, wr_sfp=None, wr_dac_bits=16, wr_firmware=None,
         wr_nic_dir             = None,
+        wr_cpu_type            = "urv", wr_cpu_variant=None, wr_cpu_memory="private", wr_cpu_boot="embedded",
         wr_ext_clk10_port      = None,  wr_ext_clk10_period=100.0, wr_ext_clk10_name="wr_ext_clk10",
         with_jtagbone          = True,
         with_gpio              = False,
@@ -963,10 +969,17 @@ class BaseSoC(SoCMini):
                     if path not in sys.path:
                         sys.path.insert(0, path)
 
-            from litex.soc.cores.uart import UARTPHY, UART
+            from litex_wr_nic.gateware.uart import (
+                UARTPads, UARTShared, WR_UART_CROSSOVER_MODE, WR_UART_MANUAL_MODE,
+            )
+            from litex_wr_nic.gateware.wr_core   import add_white_rabbit
+            from litex_wr_nic.gateware.wr_clock  import WRMMCMBackend
+            from litex_wr_nic.gateware.wr_memory import add_wr_cpu_memory
 
-            from litex_wr_nic.gateware.soc  import LiteXWRNICSoC
-            from litex_wr_nic.gateware.ps_gen  import PSGen
+            if wr_cpu_memory not in ("private", "integrated"):
+                raise ValueError("M2SDR WR CPU memory must be private or integrated.")
+            if wr_cpu_boot not in ("embedded", "host"):
+                raise ValueError("M2SDR WR CPU boot must be embedded or host.")
 
             # IOs.
             # ----
@@ -983,30 +996,36 @@ class BaseSoC(SoCMini):
             # UART.
             # -----
 
-            class UARTPads:
-                def __init__(self):
-                    self.tx = Signal()
-                    self.rx = Signal()
+            # M2SDR exposes the WR console over CSRs. Keep the unused physical
+            # RX idle and use the shared console's buffered crossover path.
+            wr_uart_pads = UARTPads()
+            self.comb += wr_uart_pads.rx.eq(1)
+            self.uart = UARTShared(wr_uart_pads, sys_clk_freq,
+                default_sel  = WR_UART_CROSSOVER_MODE,
+                default_mode = WR_UART_MANUAL_MODE,
+            )
 
-            self.uart_xover_pads = UARTPads()
-            self.shared_pads     = UARTPads()
-            self.uart_xover_phy  = UARTPHY(self.uart_xover_pads, clk_freq=sys_clk_freq, baudrate=115200)
-            self.uart_xover      = UART(self.uart_xover_phy, rx_fifo_depth=128, rx_fifo_rx_we=True)
-
-            self.comb += [
-                self.uart_xover_pads.rx.eq(self.shared_pads.tx),
-                self.shared_pads.rx.eq(self.uart_xover_pads.tx),
-            ]
+            # CPU Memory / Boot.
+            # ------------------
+            wr_memory = add_wr_cpu_memory(self,
+                cpu_type = wr_cpu_type,
+                memory   = wr_cpu_memory,
+                boot     = wr_cpu_boot,
+                firmware = os.path.splitext(wr_firmware)[0] + ".bin",
+            )
 
             # Core Instance.
             # --------------
             sfp_i2c_pads = platform.request("sfp_i2c")
-            LiteXWRNICSoC.add_wr_core(self,
+            wr = add_white_rabbit(self,
                 # CPU.
-                cpu_firmware    = wr_firmware,
+                cpu_firmware = wr_firmware,
+                cpu_type     = wr_cpu_type,
+                cpu_variant  = wr_cpu_variant,
+                **wr_memory,
 
                 # Board name.
-                board_name       = "SAWR",
+                board_name = "SAWR",
 
                 # Main/DMTD PLL.
                 dac_bits = wr_dac_bits,
@@ -1022,14 +1041,11 @@ class BaseSoC(SoCMini):
                 with_ext_clk    = False,
 
                 # Serial.
-                serial_pads     = self.shared_pads,
+                serial_pads     = self.uart.shared_pads,
 
                 # Wishbone Slave.
-                wb_slave_origin = 0x0004_0000,
-                wb_slave_size   = 0x0004_0000
+                wb_slave_region = SoCRegion(origin=0x0004_0000, size=0x0004_0000, cached=False),
             )
-
-            LiteXWRNICSoC.add_sources(self)
 
             # Clk10M Generator.
             # -----------------
@@ -1040,30 +1056,30 @@ class BaseSoC(SoCMini):
 
             # RefClk MMCM Phase Shift.
             # ------------------------
-            self.refclk_mmcm_ps_gen = PSGen(
-                 cd_psclk    = "clk200",
-                 cd_sys      = "wr",
-                 ctrl_size   = wr_dac_bits,
-                 )
+            self.refclk_mmcm_ps_gen = WRMMCMBackend(
+                cd_psclk   = "clk200",
+                cd_command = "wr_sys",
+                width      = wr_dac_bits,
+            )
             self.comb += [
-                self.refclk_mmcm_ps_gen.ctrl_data.eq(self.dac_refclk_data),
-                self.refclk_mmcm_ps_gen.ctrl_load.eq(self.dac_refclk_load),
+                wr.refclk_tuning.connect(self.refclk_mmcm_ps_gen.command),
                 self.crg.refclk_mmcm.psen.eq(self.refclk_mmcm_ps_gen.psen),
                 self.crg.refclk_mmcm.psincdec.eq(self.refclk_mmcm_ps_gen.psincdec),
+                self.refclk_mmcm_ps_gen.psdone.eq(self.crg.refclk_mmcm.psdone),
             ]
 
             # DMTD MMCM Phase Shift.
             # ----------------------
-            self.dmtd_mmcm_ps_gen = PSGen(
-                 cd_psclk    = "clk200",
-                 cd_sys      = "wr",
-                 ctrl_size   = wr_dac_bits,
-                 )
+            self.dmtd_mmcm_ps_gen = WRMMCMBackend(
+                cd_psclk   = "clk200",
+                cd_command = "wr_sys",
+                width      = wr_dac_bits,
+            )
             self.comb += [
-                self.dmtd_mmcm_ps_gen.ctrl_data.eq(self.dac_dmtd_data),
-                self.dmtd_mmcm_ps_gen.ctrl_load.eq(self.dac_dmtd_load),
+                wr.dmtd_tuning.connect(self.dmtd_mmcm_ps_gen.command),
                 self.crg.dmtd_mmcm.psen.eq(self.dmtd_mmcm_ps_gen.psen),
                 self.crg.dmtd_mmcm.psincdec.eq(self.dmtd_mmcm_ps_gen.psincdec),
+                self.dmtd_mmcm_ps_gen.psdone.eq(self.crg.dmtd_mmcm.psdone),
             ]
 
             # Timings Constraints.
@@ -1078,8 +1094,10 @@ class BaseSoC(SoCMini):
             platform.add_false_path_constraints(
                 "wr_rxoutclk",
                 "wr_txoutclk",
-                "{{*crg_s7mmcm0_clkout}}",
-                "{{*crg_s7mmcm1_clkout}}",
+                # Resolve clocks from their nets rather than generated MMCM
+                # names, which differ for single- and multi-output instances.
+                self.crg.cd_clk_125m_gtp.clk,
+                self.crg.cd_clk_62m5_dmtd.clk,
             )
 
         # Timing Constraints -----------------------------------------------------------------------
@@ -1577,6 +1595,10 @@ def main():
     parser.add_argument("--wr-nic-dir",          default=os.environ.get("LITEX_WR_NIC_DIR"), help="Path to litex_wr_nic checkout (or set LITEX_WR_NIC_DIR).")
     parser.add_argument("--wr-firmware",         default=None,                           help="Path to WR firmware BRAM image (e.g. .../firmware/spec_a7_wrc.bram).")
     parser.add_argument("--wr-firmware-target",  default="acorn",                        help="WR firmware build target passed to build.py (when --build).")
+    parser.add_argument("--wr-cpu-type",    default="urv",      choices=["urv", "vexriscv"], help="WR CPU implementation.")
+    parser.add_argument("--wr-cpu-variant", default=None,       choices=["lite"],            help="LiteX WR CPU variant (VexRiscv only).")
+    parser.add_argument("--wr-cpu-memory",  default="private",  choices=["private", "integrated"], help="WR CPU memory.")
+    parser.add_argument("--wr-cpu-boot",    default="embedded", choices=["embedded", "host"], help="WR firmware source (host requires integrated RAM).")
     parser.add_argument("--wr-status",           action="store_true",                    help="Print resolved WR environment status.")
     parser.add_argument("--wr-ext-clk10-port",   default=None,                           help="Vivado port for external 10MHz clock constraint (e.g. clk10m_in).")
     parser.add_argument("--wr-ext-clk10-period", default=100.0, type=float,              help="External 10MHz clock period in ns for constraint.")
@@ -1614,6 +1636,9 @@ def main():
             wr_nic_dir        = args.wr_nic_dir,
             wr_firmware       = args.wr_firmware,
             wr_firmware_target= args.wr_firmware_target,
+            wr_cpu_type       = args.wr_cpu_type,
+            wr_cpu_variant    = args.wr_cpu_variant,
+            wr_cpu_memory     = args.wr_cpu_memory,
             build             = args.build,
             status            = args.wr_status,
         )
@@ -1672,6 +1697,10 @@ def main():
         wr_dac_bits       = args.wr_dac_bits,
         wr_firmware       = wr_firmware,
         wr_nic_dir        = wr_env["wr_nic_dir"],
+        wr_cpu_type       = args.wr_cpu_type,
+        wr_cpu_variant    = args.wr_cpu_variant,
+        wr_cpu_memory     = args.wr_cpu_memory,
+        wr_cpu_boot       = args.wr_cpu_boot,
         wr_ext_clk10_port   = args.wr_ext_clk10_port,
         wr_ext_clk10_period = args.wr_ext_clk10_period,
         wr_ext_clk10_name   = args.wr_ext_clk10_name,
@@ -1718,6 +1747,14 @@ def main():
             r += f"_sata"
         if args.with_white_rabbit:
             r += f"_white_rabbit"
+            if args.wr_cpu_type != "urv":
+                r += f"_{args.wr_cpu_type}"
+            if args.wr_cpu_variant is not None:
+                r += f"_{args.wr_cpu_variant}"
+            if args.wr_cpu_memory != "private":
+                r += f"_{args.wr_cpu_memory}"
+            if args.wr_cpu_boot != "embedded":
+                r += f"_{args.wr_cpu_boot}"
         if args.with_rfic_oversampling:
             r += "_rfic_oversampling"
         if args.without_jtagbone:

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -1019,16 +1019,16 @@ class BaseSoC(SoCMini):
             sfp_i2c_pads = platform.request("sfp_i2c")
             wr = add_white_rabbit(self,
                 # CPU.
-                cpu_firmware = wr_firmware,
-                cpu_type     = wr_cpu_type,
-                cpu_variant  = wr_cpu_variant,
+                cpu_firmware    = wr_firmware,
+                cpu_type        = wr_cpu_type,
+                cpu_variant     = wr_cpu_variant,
                 **wr_memory,
 
                 # Board name.
-                board_name = "SAWR",
+                board_name      = "SAWR",
 
                 # Main/DMTD PLL.
-                dac_bits = wr_dac_bits,
+                dac_bits        = wr_dac_bits,
 
                 # SFP.
                 sfp_pads        = platform.request("sfp", wr_sfp),
@@ -1063,8 +1063,8 @@ class BaseSoC(SoCMini):
             )
             self.comb += [
                 wr.refclk_tuning.connect(self.refclk_mmcm_ps_gen.command),
-                self.crg.refclk_mmcm.psen.eq(self.refclk_mmcm_ps_gen.psen),
-                self.crg.refclk_mmcm.psincdec.eq(self.refclk_mmcm_ps_gen.psincdec),
+                self.crg.refclk_mmcm.psen.eq(     self.refclk_mmcm_ps_gen.psen),
+                self.crg.refclk_mmcm.psincdec.eq( self.refclk_mmcm_ps_gen.psincdec),
                 self.refclk_mmcm_ps_gen.psdone.eq(self.crg.refclk_mmcm.psdone),
             ]
 
@@ -1077,8 +1077,8 @@ class BaseSoC(SoCMini):
             )
             self.comb += [
                 wr.dmtd_tuning.connect(self.dmtd_mmcm_ps_gen.command),
-                self.crg.dmtd_mmcm.psen.eq(self.dmtd_mmcm_ps_gen.psen),
-                self.crg.dmtd_mmcm.psincdec.eq(self.dmtd_mmcm_ps_gen.psincdec),
+                self.crg.dmtd_mmcm.psen.eq(     self.dmtd_mmcm_ps_gen.psen),
+                self.crg.dmtd_mmcm.psincdec.eq( self.dmtd_mmcm_ps_gen.psincdec),
                 self.dmtd_mmcm_ps_gen.psdone.eq(self.crg.dmtd_mmcm.psdone),
             ]
 
@@ -1589,20 +1589,20 @@ def main():
     parser.add_argument("--with-gpio",       action="store_true",     help="Enable GPIO support.")
 
     # White Rabbit parameters.
-    parser.add_argument("--with-white-rabbit",   action="store_true",                    help="Enable White-Rabbit Support.")
-    parser.add_argument("--wr-sfp",              default=None, type=int,                 help="White Rabbit SFP (default: auto-select first available).", choices=[0, 1])
-    parser.add_argument("--wr-dac-bits",         default=16, type=int,                   help="White Rabbit MMCM phase-shift control word width (in bits).")
+    parser.add_argument("--with-white-rabbit",   action="store_true",                        help="Enable White-Rabbit Support.")
+    parser.add_argument("--wr-sfp",              default=None, type=int,                     help="White Rabbit SFP (default: auto-select first available).", choices=[0, 1])
+    parser.add_argument("--wr-dac-bits",         default=16, type=int,                       help="White Rabbit MMCM phase-shift control word width (in bits).")
     parser.add_argument("--wr-nic-dir",          default=os.environ.get("LITEX_WR_NIC_DIR"), help="Path to litex_wr_nic checkout (or set LITEX_WR_NIC_DIR).")
-    parser.add_argument("--wr-firmware",         default=None,                           help="Path to WR firmware BRAM image (e.g. .../firmware/spec_a7_wrc.bram).")
-    parser.add_argument("--wr-firmware-target",  default="acorn",                        help="WR firmware build target passed to build.py (when --build).")
-    parser.add_argument("--wr-cpu-type",    default="urv",      choices=["urv", "vexriscv"], help="WR CPU implementation.")
-    parser.add_argument("--wr-cpu-variant", default=None,       choices=["lite"],            help="LiteX WR CPU variant (VexRiscv only).")
-    parser.add_argument("--wr-cpu-memory",  default="private",  choices=["private", "integrated"], help="WR CPU memory.")
-    parser.add_argument("--wr-cpu-boot",    default="embedded", choices=["embedded", "host"], help="WR firmware source (host requires integrated RAM).")
-    parser.add_argument("--wr-status",           action="store_true",                    help="Print resolved WR environment status.")
-    parser.add_argument("--wr-ext-clk10-port",   default=None,                           help="Vivado port for external 10MHz clock constraint (e.g. clk10m_in).")
-    parser.add_argument("--wr-ext-clk10-period", default=100.0, type=float,              help="External 10MHz clock period in ns for constraint.")
-    parser.add_argument("--wr-ext-clk10-name",   default="wr_ext_clk10",                 help="External 10MHz clock name for constraint.")
+    parser.add_argument("--wr-firmware",         default=None,                               help="Path to WR firmware BRAM image (e.g. .../firmware/spec_a7_wrc.bram).")
+    parser.add_argument("--wr-firmware-target",  default="acorn",                            help="WR firmware build target passed to build.py (when --build).")
+    parser.add_argument("--wr-cpu-type",         default="urv",                              help="WR CPU implementation.", choices=["urv", "vexriscv"])
+    parser.add_argument("--wr-cpu-variant",      default=None,                               help="LiteX WR CPU variant (VexRiscv only).", choices=["lite"])
+    parser.add_argument("--wr-cpu-memory",       default="private",                          help="WR CPU memory.", choices=["private", "integrated"])
+    parser.add_argument("--wr-cpu-boot",         default="embedded",                         help="WR firmware source (host requires integrated RAM).", choices=["embedded", "host"])
+    parser.add_argument("--wr-status",           action="store_true",                        help="Print resolved WR environment status.")
+    parser.add_argument("--wr-ext-clk10-port",   default=None,                               help="Vivado port for external 10MHz clock constraint (e.g. clk10m_in).")
+    parser.add_argument("--wr-ext-clk10-period", default=100.0, type=float,                  help="External 10MHz clock period in ns for constraint.")
+    parser.add_argument("--wr-ext-clk10-name",   default="wr_ext_clk10",                     help="External 10MHz clock name for constraint.")
 
     # Litescope Analyzer Probes.
     probeopts = parser.add_mutually_exclusive_group()
@@ -1628,19 +1628,19 @@ def main():
     if args.with_white_rabbit or args.wr_status:
         prepare_wr_environment = _load_prepare_wr_environment(this_dir, args.wr_nic_dir)
         wr_env = prepare_wr_environment(
-            root_dir          = this_dir,
-            variant           = args.variant,
-            baseboard_io      = _io_baseboard,
-            with_white_rabbit = args.with_white_rabbit,
-            wr_sfp            = args.wr_sfp,
-            wr_nic_dir        = args.wr_nic_dir,
-            wr_firmware       = args.wr_firmware,
-            wr_firmware_target= args.wr_firmware_target,
-            wr_cpu_type       = args.wr_cpu_type,
-            wr_cpu_variant    = args.wr_cpu_variant,
-            wr_cpu_memory     = args.wr_cpu_memory,
-            build             = args.build,
-            status            = args.wr_status,
+            root_dir           = this_dir,
+            variant            = args.variant,
+            baseboard_io       = _io_baseboard,
+            with_white_rabbit  = args.with_white_rabbit,
+            wr_sfp             = args.wr_sfp,
+            wr_nic_dir         = args.wr_nic_dir,
+            wr_firmware        = args.wr_firmware,
+            wr_firmware_target = args.wr_firmware_target,
+            wr_cpu_type        = args.wr_cpu_type,
+            wr_cpu_variant     = args.wr_cpu_variant,
+            wr_cpu_memory      = args.wr_cpu_memory,
+            build              = args.build,
+            status             = args.wr_status,
         )
     wr_firmware = wr_env["wr_firmware"]
     wr_sfp      = wr_env["wr_sfp"]
@@ -1692,15 +1692,15 @@ def main():
         with_jtagbone = not args.without_jtagbone,
 
         # White Rabbit.
-        with_white_rabbit = args.with_white_rabbit,
-        wr_sfp            = wr_sfp,
-        wr_dac_bits       = args.wr_dac_bits,
-        wr_firmware       = wr_firmware,
-        wr_nic_dir        = wr_env["wr_nic_dir"],
-        wr_cpu_type       = args.wr_cpu_type,
-        wr_cpu_variant    = args.wr_cpu_variant,
-        wr_cpu_memory     = args.wr_cpu_memory,
-        wr_cpu_boot       = args.wr_cpu_boot,
+        with_white_rabbit  = args.with_white_rabbit,
+        wr_sfp             = wr_sfp,
+        wr_dac_bits        = args.wr_dac_bits,
+        wr_firmware        = wr_firmware,
+        wr_nic_dir         = wr_env["wr_nic_dir"],
+        wr_cpu_type        = args.wr_cpu_type,
+        wr_cpu_variant     = args.wr_cpu_variant,
+        wr_cpu_memory      = args.wr_cpu_memory,
+        wr_cpu_boot        = args.wr_cpu_boot,
         wr_ext_clk10_port   = args.wr_ext_clk10_port,
         wr_ext_clk10_period = args.wr_ext_clk10_period,
         wr_ext_clk10_name   = args.wr_ext_clk10_name,

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -233,7 +233,8 @@ class CRG(LiteXModule):
         # -------------------
         if with_white_rabbit:
             # RefClk MMCM (125MHz).
-            self.refclk_mmcm = S7MMCM(speedgrade=-3)
+            # Fine phase shifting requires integer feedback/output division (UG472).
+            self.refclk_mmcm = S7MMCM(speedgrade=-3, fractional=False)
             self.comb += self.refclk_mmcm.reset.eq(self.rst)
             self.refclk_mmcm.register_clkin(ClockSignal("clk100"), 100e6)
             self.refclk_mmcm.expose_dps("clk200", with_csr=False)
@@ -245,7 +246,7 @@ class CRG(LiteXModule):
             self.refclk_mmcm.params.update(p_CLKOUT1_USE_FINE_PS="TRUE")
 
             # DMTD MMCM (62.5MHz).
-            self.dmtd_mmcm = S7MMCM(speedgrade=-3)
+            self.dmtd_mmcm = S7MMCM(speedgrade=-3, fractional=False)
             self.comb += self.dmtd_mmcm.reset.eq(self.rst)
             self.dmtd_mmcm.register_clkin(ClockSignal("clk100"), 100e6)
             self.dmtd_mmcm.create_clkout(self.cd_clk_62m5_dmtd, 62.5e6, margin=0)

--- a/litex_m2sdr.py
+++ b/litex_m2sdr.py
@@ -203,9 +203,9 @@ class CRG(LiteXModule):
             self.cd_clk200.rst.eq(self.cd_idelay.rst),
             self.cd_clk100.clk.eq(pll.clkin),
         ]
-        # IDelayCtrl.
-        # -----------
-        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+        # No IDELAY/ODELAY primitives are used by this target. An unused
+        # IDELAYCTRL can remain unplaced in Vivado; keep only its 200 MHz
+        # clock, which also supplies the MMCM phase-shift interfaces.
 
         # Ethernet PLL.
         # -------------
@@ -1085,6 +1085,9 @@ class BaseSoC(SoCMini):
 
             # Timings Constraints.
             # --------------------
+            # Tuning commands cross an asynchronous FIFO into PSCLK. The
+            # disciplined WR clock has no fixed phase relative to PSCLK.
+            platform.add_false_path_constraints(self.crg.cd_clk200.clk, wr.cd_wr_sys.clk)
             platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks REQP-123]")
             if wr_ext_clk10_port is not None:
                 platform.add_platform_command(

--- a/test/test_cli_args.py
+++ b/test/test_cli_args.py
@@ -5,8 +5,9 @@
 # Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import importlib.util
 import sys
+import subprocess
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -259,6 +260,77 @@ def test_main_wr_status_uses_lazy_wr_integration(monkeypatch):
     assert captured["loader_wr_nic_dir"] == "/tmp/litex_wr_nic"
     assert captured["prepare_kwargs"]["status"] is True
     assert captured["prepare_kwargs"]["with_white_rabbit"] is False
+
+
+@pytest.mark.parametrize("options,cpu,memory,boot,suffix", [
+    ([], "urv", "private", "embedded", ""),
+    (["--wr-cpu-type=vexriscv", "--wr-cpu-memory=integrated"],
+        "vexriscv", "integrated", "embedded", "_vexriscv_integrated"),
+    (["--wr-cpu-type=vexriscv", "--wr-cpu-variant=lite", "--wr-cpu-memory=integrated", "--wr-cpu-boot=host"],
+        "vexriscv", "integrated", "host", "_vexriscv_lite_integrated_host"),
+])
+def test_main_wr_cpu_configuration_and_distinct_build_names(monkeypatch, options, cpu, memory, boot, suffix):
+    soc_mod = _load_soc_module()
+    captured = {}
+
+    class FakeSoC:
+        def __init__(self, **kwargs):
+            captured["soc"] = kwargs
+
+    class FakeBuilder:
+        def __init__(self, soc, **kwargs):
+            self.gateware_dir = "build/fake/gateware"
+
+        def build(self, build_name, run):
+            captured["build_name"] = build_name
+
+    def prepare(**kwargs):
+        captured["prepare"] = kwargs
+        return dict(wr_nic_dir="/tmp/wr", wr_firmware="/tmp/wr/firmware.bram", wr_sfp=0)
+
+    monkeypatch.setattr(soc_mod, "BaseSoC", FakeSoC)
+    monkeypatch.setattr(soc_mod, "Builder", FakeBuilder)
+    monkeypatch.setattr(soc_mod, "_load_prepare_wr_environment", lambda *args: prepare)
+    monkeypatch.setattr(soc_mod, "generate_litepcie_software", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", [
+        "litex_m2sdr.py", "--variant=baseboard", "--with-white-rabbit", *options,
+    ])
+    soc_mod.main()
+    for name in ("soc", "prepare"):
+        assert captured[name]["wr_cpu_type"] == cpu
+        assert captured[name]["wr_cpu_memory"] == memory
+    assert captured["soc"]["wr_cpu_boot"] == boot
+    assert captured["soc"]["wr_cpu_variant"] == captured["prepare"]["wr_cpu_variant"]
+    assert captured["build_name"] == "litex_m2sdr_baseboard_white_rabbit" + suffix
+
+
+@pytest.mark.parametrize("package_path", [False, True])
+def test_wr_loader_prefers_explicit_checkout_over_sibling(tmp_path, package_path):
+    root = Path(__file__).resolve().parents[1]
+    project = tmp_path / "m2sdr"
+    project.mkdir()
+    for name in ("selected", "litex_wr_nic"):
+        package = tmp_path / name / "litex_wr_nic"
+        package.mkdir(parents=True)
+        (package / "__init__.py").touch()
+        (package / "integration.py").write_text(
+            f"def prepare_wr_environment():\n    return {name!r}\n", encoding="utf-8")
+    selected = tmp_path / "selected"
+    if package_path:
+        selected /= "litex_wr_nic"
+    # A fresh interpreter prevents prior WR tests' cached imports from masking
+    # which checkout the command-line loader actually selects.
+    script = """
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location("m2sdr_soc", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+prepare = module._load_prepare_wr_environment(sys.argv[2], sys.argv[3])
+assert prepare() == "selected"
+"""
+    subprocess.run([sys.executable, "-c", script, str(root / "litex_m2sdr.py"),
+        str(project), str(selected)], check=True)
 
 
 def test_base_soc_rejects_pcie_eth_sata_triple_use():

--- a/test/test_cli_args.py
+++ b/test/test_cli_args.py
@@ -270,7 +270,7 @@ def test_main_wr_status_uses_lazy_wr_integration(monkeypatch):
         "vexriscv", "integrated", "host", "_vexriscv_lite_integrated_host"),
 ])
 def test_main_wr_cpu_configuration_and_distinct_build_names(monkeypatch, options, cpu, memory, boot, suffix):
-    soc_mod = _load_soc_module()
+    soc_mod  = _load_soc_module()
     captured = {}
 
     class FakeSoC:
@@ -306,7 +306,7 @@ def test_main_wr_cpu_configuration_and_distinct_build_names(monkeypatch, options
 
 @pytest.mark.parametrize("package_path", [False, True])
 def test_wr_loader_prefers_explicit_checkout_over_sibling(tmp_path, package_path):
-    root = Path(__file__).resolve().parents[1]
+    root    = Path(__file__).resolve().parents[1]
     project = tmp_path / "m2sdr"
     project.mkdir()
     for name in ("selected", "litex_wr_nic"):

--- a/test/test_soc_white_rabbit.py
+++ b/test/test_soc_white_rabbit.py
@@ -86,6 +86,18 @@ def test_wr_cpu_memory_console_and_automatic_sources(wr_soc, tmp_path, sfp, cpu,
         assert "csr_register,wr_cpu_boot_host_ready," in csr_csv
 
 
+def test_wr_mmcm_configuration_supports_fine_phase_shifting(wr_soc):
+    create, _ = wr_soc
+    soc = create(wr_sfp=0)
+    for mmcm, frequency in [(soc.crg.refclk_mmcm, 125e6), (soc.crg.dmtd_mmcm, 62.5e6)]:
+        config = mmcm.compute_config()
+        assert config["clkfbout_mult"] == int(config["clkfbout_mult"])
+        assert config["clkout0_divide"] == int(config["clkout0_divide"])
+        assert config["clkout0_freq"] == frequency
+        assert mmcm.params["p_CLKOUT0_USE_FINE_PS"] == "TRUE"
+    assert soc.crg.refclk_mmcm.params["p_CLKOUT1_USE_FINE_PS"] == "TRUE"
+
+
 def test_wr_tuning_uses_system_clock_and_waits_for_both_mmcm_completions(wr_soc):
     create, _ = wr_soc
     soc = create(wr_sfp=0)

--- a/test/test_soc_white_rabbit.py
+++ b/test/test_soc_white_rabbit.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+#
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from migen import *
+from migen.fhdl.structure import _Assign
+
+from litex.gen import LiteXModule
+
+from litex.soc.integration.builder import Builder
+
+# Helpers ------------------------------------------------------------------------------------------
+
+@pytest.fixture
+def wr_soc(monkeypatch, tmp_path):
+    wr_core = pytest.importorskip("litex_wr_nic.gateware.wr_core")
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location("litex_m2sdr_soc", root / "litex_m2sdr.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    registered = []
+    # The board tests elaborate WR as an HDL instance; the dependency's own
+    # tests cover source preparation and the VHDL/CPU implementations.
+    monkeypatch.setattr(wr_core.WhiteRabbitCore, "add_sources", staticmethod(registered.append))
+    firmware = tmp_path / "firmware.bram"
+    firmware.write_text("00000013\n", encoding="utf-8")
+    firmware.with_suffix(".bin").write_bytes(bytes.fromhex("13000000"))
+
+    def create(**kwargs):
+        return module.BaseSoC(
+            variant           = "baseboard",
+            with_pcie         = False,
+            with_jtagbone     = False,
+            with_white_rabbit = True,
+            wr_firmware       = str(firmware),
+            **kwargs,
+        )
+
+    return create, registered
+
+# WR Integration Tests -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sfp,cpu,memory,boot", [
+    (0, "urv",      "private",    "embedded"),
+    (1, "urv",      "private",    "embedded"),
+    (0, "urv",      "integrated", "host"),
+    (0, "vexriscv", "integrated", "embedded"),
+    (1, "vexriscv", "integrated", "host"),
+])
+def test_wr_cpu_memory_console_and_automatic_sources(wr_soc, tmp_path, sfp, cpu, memory, boot):
+    create, registered = wr_soc
+    soc = create(wr_sfp=sfp, wr_cpu_type=cpu, wr_cpu_memory=memory, wr_cpu_boot=boot)
+    assert registered == []
+    region = soc.bus.regions["wr_wb_slave"]
+    assert (region.origin, region.size, region.cached) == (0x40000, 0x40000, False)
+    assert not hasattr(soc.crg, "eth_pll") # The tunable MMCM owns refclk_eth.
+    assert soc.wr_core.wr_info.cpu_type.status.reset.value == int(cpu == "vexriscv")
+    assert soc.uart.xover.rx_fifo.depth == 4096
+    if memory == "integrated":
+        assert soc.bus.regions["wr_cpu_mem"].size == 128*1024
+        assert "wr_cpu" in soc.bus.masters
+    else:
+        assert soc.wr_core.cpu_bus is None
+    if boot == "host":
+        assert soc.wr_cpu_boot._host_ready.storage.reset.value == 0
+
+    Builder(soc,
+        output_dir       = tmp_path / "build",
+        compile_software = False,
+        csr_csv          = str(tmp_path / "csr.csv"),
+    ).build(run=False)
+    assert registered == [soc.platform]
+    csr_csv = (tmp_path / "csr.csv").read_text(encoding="utf-8")
+    for name in ("uart_xover_rxtx", "uart_rxlevel", "uart_rxoverflow", "wr_info_magic",
+        "wr_time_capture", "refclk_mmcm_ps_gen_status", "dmtd_mmcm_ps_gen_status"):
+        assert f"csr_register,{name}," in csr_csv
+    if boot == "host":
+        assert "csr_register,wr_cpu_boot_host_ready," in csr_csv
+
+
+def test_wr_tuning_uses_system_clock_and_waits_for_both_mmcm_completions(wr_soc):
+    create, _ = wr_soc
+    soc = create(wr_sfp=0)
+    dut = LiteXModule()
+    dut.cd_sys    = ClockDomain("sys")
+    dut.cd_wr_sys = ClockDomain("wr_sys")
+    dut.cd_clk200 = ClockDomain("clk200")
+    backends = [soc.refclk_mmcm_ps_gen, soc.dmtd_mmcm_ps_gen]
+    mmcms    = [soc.crg.refclk_mmcm, soc.crg.dmtd_mmcm]
+    commands = [soc.wr_core.refclk_tuning, soc.wr_core.dmtd_tuning]
+    dut.submodules += backends
+
+    # Simulate the actual board connections around the two real backends.
+    # Replace only the FPGA MMCM primitives with delayed PSDONE responses.
+    destinations = []
+    for backend, mmcm in zip(backends, mmcms):
+        destinations += [backend.command.data, backend.command.load, backend.psdone,
+            mmcm.psen, mmcm.psincdec]
+    connections = [statement for statement in soc._fragment.comb
+        if isinstance(statement, _Assign) and any(statement.l is signal for signal in destinations)]
+    assert len(connections) == len(destinations)
+    dut.comb += connections
+    completed = [0, 0]
+
+    def send_commands():
+        for _ in range(10):
+            yield
+        for command in commands:
+            yield command.data.eq(0)
+            yield command.load.eq(1)
+        yield
+        for command in commands:
+            yield command.load.eq(0)
+
+    def mmcm_model(index, delay):
+        mmcm      = mmcms[index]
+        backend   = backends[index]
+        pending   = 0
+        direction = None
+        for _ in range(1200):
+            if pending:
+                assert not (yield mmcm.psen), "A second shift started before PSDONE"
+                assert (yield mmcm.psincdec) == direction
+                pending -= 1
+                if pending == 0:
+                    completed[index] += 1
+            if (yield mmcm.psen):
+                pending = delay
+                direction = yield mmcm.psincdec
+            yield mmcm.psdone.eq(pending == 1)
+            assert not (yield backend.fault)
+            yield
+
+    clocks = {"sys": 8, "wr_sys": 16, "clk200": 5}
+    for backend in backends:
+        clocks[backend.cdc.input_cd]  = clocks["wr_sys"]
+        clocks[backend.cdc.output_cd] = clocks["clk200"]
+    run_simulation(dut, {
+        "wr_sys" : send_commands(),
+        "clk200" : [mmcm_model(0, 23), mmcm_model(1, 37)],
+    }, clocks=clocks)
+    assert all(count > 2 for count in completed)
+
+
+@pytest.mark.parametrize("cpu,memory,boot", [
+    ("vexriscv", "private",    "embedded"),
+    ("urv",      "private",    "host"),
+    ("urv",      "hyperram",   "host"),
+    ("urv",      "integrated", "spi"),
+])
+def test_wr_rejects_unsupported_memory_and_boot(wr_soc, cpu, memory, boot):
+    create, _ = wr_soc
+    with pytest.raises(ValueError):
+        create(wr_sfp=0, wr_cpu_type=cpu, wr_cpu_memory=memory, wr_cpu_boot=boot)

--- a/test/test_soc_white_rabbit.py
+++ b/test/test_soc_white_rabbit.py
@@ -22,9 +22,9 @@ from litex.soc.integration.builder import Builder
 @pytest.fixture
 def wr_soc(monkeypatch, tmp_path):
     wr_core = pytest.importorskip("litex_wr_nic.gateware.wr_core")
-    root = Path(__file__).resolve().parents[1]
-    spec = importlib.util.spec_from_file_location("litex_m2sdr_soc", root / "litex_m2sdr.py")
-    module = importlib.util.module_from_spec(spec)
+    root    = Path(__file__).resolve().parents[1]
+    spec    = importlib.util.spec_from_file_location("litex_m2sdr_soc", root / "litex_m2sdr.py")
+    module  = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     registered = []
     # The board tests elaborate WR as an HDL instance; the dependency's own
@@ -133,7 +133,7 @@ def test_wr_tuning_uses_system_clock_and_waits_for_both_mmcm_completions(wr_soc)
                 if pending == 0:
                     completed[index] += 1
             if (yield mmcm.psen):
-                pending = delay
+                pending   = delay
                 direction = yield mmcm.psincdec
             yield mmcm.psdone.eq(pending == 1)
             assert not (yield backend.fault)


### PR DESCRIPTION
M2SDR's White Rabbit integration uses the reusable WR APIs, preserving default uRV/private RAM and adding selectable VexRiscv, integrated RAM and host boot. HDL sources register automatically when the core is finalized.

Both tunable MMCMs receive coherent commands from `wr_sys` and return their own PSDONE. WR mode removes a duplicate driver on `refclk_eth`; constraints resolve actual WR clock nets and declare the tuning FIFO crossing asynchronous. The WR console has a 4096-byte receive FIFO with occupancy/overflow reporting. Remove the unused IDELAYCTRL: this target contains no IDELAY/ODELAY primitives, and the orphan controller prevented placement. The 200 MHz clock is retained.

The WR host window remains at `0x00040000`, size `0x00040000`. Nondefault CPU/memory/boot selections have distinct build names. Use each image's CSR CSV and matching host headers. Explicit dependency paths take precedence over stale sibling checkouts. Commands are in [doc/wr_integration.md](https://github.com/enjoy-digital/litex_m2sdr/blob/wr-reusable-core-integration/doc/wr_integration.md). SDR timestamps retain the existing `time_gen`.

### MMCM configuration and dependency

Depends on enjoy-digital/litex_wr_nic#72 through enjoy-digital/litex_wr_nic#77. CI pins **`bac7b7a7af1215f741bbeeb095cac5a01a732b8a`**, including the registered 200 MHz command path and fixes for lost small corrections and stale command replay after stopped-clock resets. Legacy PSGen, effective SPEC-A7 x2 DAC gain and firmware PI coefficients remain unchanged.

Both WR MMCMs use `fractional=False`. The previous DMTD divider of 25.5 was incompatible with fine phase shifting. Nominal outputs remain 125/62.5 MHz with a 1.5 GHz VCO and approximately 11.905 ps steps. Compared with the invalid 1.59375 GHz configuration, step size increases by 6.25%; physical servo qualification is still required.

### Validation at `b541a68ddcf548b58e315d23cefe92b67712ec7a`

- **All six GitHub checks pass** on this exact commit, including both complete release/WR/gateware CI runs and the software builds.
- **183 M2SDR tests passed** with the updated dependency. Coverage includes SFP 0/1, default uRV, VexRiscv, integrated/host boot, automatic source registration, invalid selections, actual MMCM wiring and integer configurations.
- Fresh PCIe/VexRiscv/integrated elaboration and the **complete generated Vivado 2024.1 implementation flow pass**, including existing pre-placement constraints and timing directives. **WNS +0.006 ns, WHS +0.046 ns**, all 34,206 routable nets fully routed, zero routing errors. MMCM backend setup margin is **+0.595 ns at 200 MHz**. Whole-design setup margin is small.
- Existing internal-clock/IP warnings, DRC warnings (including GTGREFCLK and WR RAM reset checks) and CDC classifications remain visible in the reports. This is not a blanket CDC sign-off. Timing elaboration uses the existing CPU-specific firmware image; no M2SDR image was loaded or runtime-tested.
- The dependency passes **30 clock tests** and **110 full-stack tests**, no skips, including generated RTL, real Xilinx MMCM models, uRV execution and two unbounded protocol proofs.
- **84 physical MMCM measurements passed on SPEC-A7**, counting **33,554,560 completed shifts**, with zero protocol/lock errors and output-frequency predictions within one counted edge. Tests include both directions, one-LSB refresh, endpoints, neutral, fault recovery and stopped-clock reset. The test image meets setup/hold timing (+0.330/+0.055 ns). SPEC-A7 uses a -2 part and 1.375 GHz VCO; this does not substitute for M2SDR servo/jitter/PPS qualification.
- After hardware testing, the working SPEC-A7 uRV/private image was restored and its CPU/console verified; flash was not modified.

Tests use LiteX `ac4a6767263937ac0a95b31a471bb2ddb25d8794` and LiteEth `8c9150ff121cb3148d8ea26ce3b1c5200479848d`. Physical M2SDR WR firmware/console, servo lock, jitter and PPS qualification against a reference peer is planned as follow-up testing.
