### PR TITLE
tools: add release multiboot flasher

### DIFF
--- a/doc/flash-release.md
+++ b/doc/flash-release.md
@@ -1,0 +1,44 @@
+# Flashing Release Images
+
+Install `openFPGALoader` with its `spiOverJtag_xc7a200tsbg484.bit.gz` bridge and USB access rules, then power the board and connect its FTDI USB JTAG programmer. The release flasher requires Python 3 and Internet access; Vivado and a working PCIe connection are not required.
+
+Flash the latest stable release, using the **M.2 PCIe x1** image by default:
+
+```bash
+./scripts/flash_release.py
+```
+
+The tool verifies the GitHub archive SHA-256 and release manifest, identifies the XC7A200T and its FPGA DNA, and asks before flashing. It backs up the two multiboot slots, writes fallback at `0x00000000` and operational at `0x00800000`, reads back both images, and checks FPGA startup and multiboot status before reporting `PASS`.
+
+For a production batch, press Enter after connecting each board and enter `q` to finish:
+
+```bash
+./scripts/flash_release.py --batch
+
+# Pin a release for repeatable production runs.
+./scripts/flash_release.py --batch --release 2026_05_15
+
+# Skip backups when programming blank production boards.
+./scripts/flash_release.py --batch --release 2026_05_15 --no-backup
+```
+
+The selected release stays fixed throughout a batch, and a board that already passed in that batch is skipped when its FPGA DNA is seen again. Downloads, per-board `programmer.log` / `result.json` files, readback images, and backups are saved under `build/flash_release/` (override with `--output-dir`). The backup covers the first 16 MiB containing both multiboot slots. Keep the board records with the production batch; they include the release, source revision, FPGA DNA, image hashes and result. `PASS` covers flash contents and FPGA boot; use the board autotests for PCIe and RF qualification.
+
+Other useful operations:
+
+```bash
+# Validate the latest release download without accessing the board.
+./scripts/flash_release.py --dry-run
+
+# Recheck a flashed board without writing flash (temporarily reconfigures the FPGA).
+./scripts/flash_release.py --release 2026_05_15 --verify-only
+
+# Select another release image.
+./scripts/flash_release.py --image m2_pcie_x2
+
+# Select a probe when several are connected.
+openFPGALoader --scan-usb
+./scripts/flash_release.py --busdev-num 001:016
+```
+
+If an operation fails, inspect that board's log, check power/JTAG connections and USB permissions, and retry with the same `--release`. Batch mode allows another attempt and returns a nonzero exit status if any attempt failed. A lower JTAG frequency, such as `--freq 10000000`, can help with unreliable cables. After an interrupted write, rerun the full flashing operation over JTAG to restore both slots. `--yes` skips the single-board confirmation; batch mode always waits for the operator to signal the next board.

--- a/scripts/flash_release.py
+++ b/scripts/flash_release.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Flash published multiboot images over USB JTAG, including production batches."""
+
+import re
+import sys
+import json
+import time
+import shlex
+import shutil
+import hashlib
+import zipfile
+import argparse
+import tempfile
+import subprocess
+import urllib.request
+
+from pathlib import Path
+from datetime import datetime, timezone
+
+# Constants ----------------------------------------------------------------------------------------
+
+REPOSITORY  = "enjoy-digital/litex_m2sdr"
+SLOT_SIZE   = 0x00800000
+FPGA_IDCODE = 0x03636093
+FPGA_PART   = "xc7a200tsbg484"
+
+IMAGES = {
+    "m2_pcie_x1" : {
+        "variant"    : "m2",
+        "with_pcie"  : True,
+        "pcie_lanes" : 1,
+        "with_eth"   : False,
+    },
+    "m2_pcie_x2" : {
+        "variant"    : "m2",
+        "with_pcie"  : True,
+        "pcie_lanes" : 2,
+        "with_eth"   : False,
+    },
+    "baseboard_eth" : {
+        "variant"    : "baseboard",
+        "with_pcie"  : False,
+        "with_eth"   : True,
+    },
+    "baseboard_eth_ptp_rfic_clock" : {
+        "variant"                : "baseboard",
+        "with_pcie"              : False,
+        "with_eth"               : True,
+        "with_eth_ptp"           : True,
+        "with_eth_ptp_rfic_clock" : True,
+    },
+    "baseboard_pcie_x1_eth" : {
+        "variant"    : "baseboard",
+        "with_pcie"  : True,
+        "pcie_lanes" : 1,
+        "with_eth"   : True,
+    },
+}
+
+FTDI_CABLES = {
+    "6011" : "ft4232",
+    "6010" : "ft2232",
+    "6014" : "digilent_hs2",
+}
+
+# Helpers ------------------------------------------------------------------------------------------
+
+class FlashError(RuntimeError):
+    pass
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# Release Download ---------------------------------------------------------------------------------
+
+def request(url):
+    headers = {
+        "User-Agent"          : "litex-m2sdr-flash-release",
+        "Accept"              : "application/vnd.github+json",
+        "X-GitHub-Api-Version" : "2026-03-10",
+    }
+    return urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30)
+
+
+def fetch_release(tag):
+    if tag != "latest" and not re.fullmatch(r"\d{4}_\d{2}_\d{2}", tag):
+        raise FlashError("Use --release latest or a date tag such as 2026_05_15.")
+    endpoint = "latest" if tag == "latest" else f"tags/{tag}"
+    with request(f"https://api.github.com/repos/{REPOSITORY}/releases/{endpoint}") as response:
+        release = json.load(response)
+    resolved = release.get("tag_name", "")
+    if not re.fullmatch(r"\d{4}_\d{2}_\d{2}", resolved):
+        raise FlashError(f"Unsupported release tag: {resolved!r}")
+    if tag != "latest" and resolved != tag:
+        raise FlashError("GitHub returned a different release than requested.")
+    if release.get("draft") or release.get("prerelease"):
+        raise FlashError("Production flashing requires a published stable release.")
+    return release
+
+
+def download_asset(asset, directory):
+    digest = asset.get("digest") or ""
+    if not re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest):
+        raise FlashError("The release asset has no GitHub SHA-256 digest; refusing to flash.")
+    expected = digest.split(":", 1)[1].lower()
+    size = asset.get("size", 0)
+    if not isinstance(size, int) or not 0 < size <= 64 * 1024 * 1024:
+        raise FlashError("Invalid release archive size.")
+    path = directory / asset["name"]
+    if path.exists() and path.stat().st_size == size and sha256(path) == expected:
+        print(f"Using verified archive: {path}")
+        return path
+    url = asset["browser_download_url"]
+    if not url.startswith(f"https://github.com/{REPOSITORY}/releases/download/"):
+        raise FlashError("Unexpected release download URL.")
+    print(f"Downloading {asset['name']}...")
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=directory, delete=False) as output:
+            temporary = Path(output.name)
+            with request(url) as response:
+                total = 0
+                for chunk in iter(lambda: response.read(1024 * 1024), b""):
+                    total += len(chunk)
+                    if total > size:
+                        raise FlashError("Release download exceeds its advertised size.")
+                    output.write(chunk)
+        if temporary.stat().st_size != size or sha256(temporary) != expected:
+            raise FlashError("Release archive size or SHA-256 mismatch.")
+        temporary.replace(path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+    return path
+
+
+# Release Images -----------------------------------------------------------------------------------
+
+def unpack_images(archive_path, directory, tag, image):
+    build = f"litex_m2sdr_{image}"
+    names = ["release_manifest.json", f"{build}_fallback.bin", f"{build}_operational.bin"]
+    with zipfile.ZipFile(archive_path) as archive:
+        # Read only these exact members, never extract arbitrary archive paths.
+        for name in names:
+            if archive.namelist().count(name) != 1:
+                raise FlashError(f"Archive must contain exactly one {name}.")
+            limit = 64 * 1024 if name.endswith(".json") else SLOT_SIZE
+            if not 0 < archive.getinfo(name).file_size <= limit:
+                raise FlashError(f"Invalid size for {name}.")
+        manifest = json.loads(archive.read(names[0]))
+        expected = {
+            "project"      : "litex_m2sdr",
+            "release_date" : tag,
+            "build_name"   : build,
+        }
+        for key, value in expected.items():
+            if manifest.get(key) != value:
+                raise FlashError(f"Release manifest {key} does not match {value!r}.")
+        if manifest.get("git_dirty") is not False or not re.fullmatch(
+            r"[0-9a-fA-F]{40}", manifest.get("git_revision", "")
+        ):
+            raise FlashError("Release manifest must identify a clean source revision.")
+        for key, value in IMAGES[image].items():
+            if manifest.get("configuration", {}).get(key) != value:
+                raise FlashError(f"Release configuration {key} does not match {value!r}.")
+        contents = {name: archive.read(name) for name in names}
+    # Both images have been checked before either is made available to the flasher.
+    for name, data in contents.items():
+        (directory / name).write_bytes(data)
+    return manifest, [directory / name for name in names[1:]]
+
+
+def prepare_release(args):
+    release = fetch_release(args.release)
+    tag     = release["tag_name"]
+    name    = f"litex_m2sdr_{args.image}_{tag}.zip"
+    assets  = [asset for asset in release.get("assets", []) if asset.get("name") == name]
+    if len(assets) != 1:
+        raise FlashError(f"Release {tag} does not contain exactly one {name}.")
+    directory = args.output_dir / "releases" / tag / args.image
+    directory.mkdir(parents=True, exist_ok=True)
+    archive = download_asset(assets[0], directory)
+    manifest, images = unpack_images(archive, directory, tag, args.image)
+    write_json(directory / "github-release.json", release)
+    return {
+        "tag"            : tag,
+        "image"          : args.image,
+        "archive_sha256" : sha256(archive),
+        "git_revision"   : manifest["git_revision"],
+        "images"         : images,
+    }
+
+
+# JTAG Programmer ----------------------------------------------------------------------------------
+
+def run_loader(command, log):
+    rendered = "+ " + shlex.join(str(part) for part in command) + "\n"
+    print(rendered, end="", flush=True)
+    log.write(rendered)
+    log.flush()
+    output = []
+    with subprocess.Popen(command,
+        stdout  = subprocess.PIPE,
+        stderr  = subprocess.STDOUT,
+        text    = True,
+        errors  = "replace",
+        bufsize = 1,
+    ) as process:
+        for line in process.stdout:
+            output.append(line)
+            print(line, end="", flush=True)
+            log.write(line)
+            log.flush()
+        returncode = process.wait()
+    if returncode:
+        raise FlashError(f"openFPGALoader failed (exit {returncode}); see programmer.log.")
+    return "".join(output)
+
+
+def select_probe(output, busdev=None, cable=None):
+    probes = []
+    for bus, device, pid in re.findall(
+        r"^\s*(\d+)\s+(\d+)\s+0x0403:0x(6011|6010|6014)\b", output, re.MULTILINE
+    ):
+        address = f"{int(bus):03d}:{int(device):03d}"
+        if busdev and address != busdev:
+            continue
+        if cable and FTDI_CABLES[pid] != cable:
+            continue
+        probes.append((address, FTDI_CABLES[pid]))
+    if not probes:
+        raise FlashError("No matching FTDI JTAG probe found. Check USB, permissions and probe selection.")
+    if len(probes) != 1:
+        raise FlashError("Multiple FTDI probes found; select one with --busdev-num BUS:DEVICE.")
+    return probes[0]
+
+
+# Board Identification / Boot Status ---------------------------------------------------------------
+
+def identify_board(run):
+    output = run("--detect")
+    ids    = re.findall(r"\bidcode\s+0x([0-9a-fA-F]+)", output)
+    if not ids:
+        raise FlashError("No FPGA found on JTAG. Check board power and the JTAG connection.")
+    if len(ids) != 1 or (int(ids[0], 16) & 0x0fffffff) != FPGA_IDCODE:
+        raise FlashError("Expected one XC7A200T FPGA on the JTAG chain.")
+    output = run("--read-dna")
+    match  = re.search(r'"dna"\s*:\s*"0x([0-9a-fA-F]+)"', output)
+    if not match or not 0 < int(match[1], 16) < (1 << 57) - 1:
+        raise FlashError("Unable to read a valid FPGA DNA identifier.")
+    return f"{int(match[1], 16):016x}"
+
+
+def register_value(output):
+    match = re.search(r"Register raw value:\s*0x([0-9a-fA-F]+)", output)
+    if not match:
+        raise FlashError("Cannot parse FPGA status; use an openFPGALoader version with --read-register.")
+    return int(match[1], 16)
+
+
+def check_boot(run):
+    deadline = time.monotonic() + 5
+    ready    = (1 << 14) | (1 << 4) # DONE and end of startup (UG470 STAT).
+    errors   = (1 << 0) | (1 << 15) | (1 << 16) | (1 << 17)
+    while True:
+        status = register_value(run("--read-register", "STAT"))
+        if status & errors:
+            raise FlashError(f"FPGA configuration error: STAT=0x{status:08x}.")
+        if (status & ready) == ready:
+            break
+        if time.monotonic() >= deadline:
+            raise FlashError(f"FPGA did not finish booting: STAT=0x{status:08x}.")
+        time.sleep(0.5)
+    boot = register_value(run("--read-register", "BOOTSTS"))
+    # Current entry must be valid, reached through IPROG and have no fallback/errors.
+    # Check the older entry's errors too, when that entry is valid (UG470 BOOTSTS).
+    if (boot & 0xff) != 0x05 or (boot & 0x100 and boot & 0xfa00):
+        raise FlashError(f"Multiboot reported an error or fallback: BOOTSTS=0x{boot:08x}.")
+    return {
+        "STAT"    : f"0x{status:08x}",
+        "BOOTSTS" : f"0x{boot:08x}",
+    }
+
+
+# Multiboot Flashing --------------------------------------------------------------------------------
+
+def flash_and_verify(run, images, directory, report, backup=True, verify_only=False):
+    bridge_active = False
+    try:
+        if backup and not verify_only:
+            path = directory / "flash-before.bin"
+            bridge_active = True
+            run("--dump-flash", "--file-size", str(2 * SLOT_SIZE), str(path))
+            bridge_active = False
+            if path.stat().st_size != 2 * SLOT_SIZE:
+                raise FlashError("Incomplete backup of the two multiboot slots.")
+            report["backup_sha256"] = sha256(path)
+        if not verify_only:
+            for index, path in enumerate(images):
+                bridge_active = True
+                flags = ["--skip-load-bridge"] if index else []
+                run(
+                    "--write-flash", "--offset", hex(index * SLOT_SIZE),
+                    "--verify", "--skip-reset", *flags, str(path),
+                )
+        # Compare actual flash bytes as well as using the programmer's verification.
+        # This also catches loader versions that do not propagate a verify failure.
+        report["slots"] = []
+        for index, path in enumerate(images):
+            readback = directory / f"{path.stem}-readback.bin"
+            flags    = ["--skip-load-bridge"] if bridge_active else []
+            if index == 0:
+                flags.append("--skip-reset")
+            bridge_active = True
+            run(
+                "--dump-flash", "--offset", hex(index * SLOT_SIZE),
+                "--file-size", str(path.stat().st_size), *flags, str(readback),
+            )
+            bridge_active = index == 0
+            expected = sha256(path)
+            actual   = sha256(readback)
+            if readback.stat().st_size != path.stat().st_size or actual != expected:
+                raise FlashError(f"Flash readback mismatch at {hex(index * SLOT_SIZE)}.")
+            report["slots"].append({
+                "image"    : path.name,
+                "offset"   : hex(index * SLOT_SIZE),
+                "size"     : path.stat().st_size,
+                "sha256"   : actual,
+                "verified" : True,
+            })
+        report["boot"] = check_boot(run)
+    finally:
+        if bridge_active:
+            # A failed/interrupted operation must not leave the SPI bridge running.
+            try:
+                run("--reset")
+            except (FlashError, OSError) as error:
+                print(f"Could not reset FPGA after failure: {error}", file=sys.stderr)
+
+
+# Board Records ------------------------------------------------------------------------------------
+
+def process_board(args, release, seen):
+    runs = args.output_dir / "boards"
+    runs.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    directory = Path(tempfile.mkdtemp(prefix=timestamp + "-", dir=runs))
+    report = {key: value for key, value in release.items() if key != "images"}
+    report.update(
+        started_utc = timestamp,
+        result      = "failed",
+        mode        = "verify" if args.verify_only else "flash",
+    )
+    try:
+        with (directory / "programmer.log").open("w", encoding="utf-8") as log:
+            probe_output = run_loader([args.loader, "--scan-usb"], log)
+            busdev, cable = select_probe(probe_output, args.busdev_num, args.cable)
+            command = [
+                args.loader,
+                "-c", cable,
+                "--busdev-num", busdev,
+                "--fpga-part", FPGA_PART,
+                "--freq", str(args.freq),
+            ]
+
+            def run(*flags):
+                return run_loader([*command, *flags], log)
+
+            report.update(busdev=busdev, cable=cable)
+            dna = identify_board(run)
+            report["fpga_dna"] = dna
+            print(f"Board FPGA DNA: {dna}")
+            if dna in seen:
+                report["result"] = "skipped"
+                print("This board already passed in this batch. Connect the next board.")
+                return "skipped"
+            if not (args.yes or args.batch):
+                action = "Read back and verify" if args.verify_only else "Flash both multiboot slots on"
+                if input(f"{action} board {dna}? [y/N] ").strip().lower() not in ("y", "yes"):
+                    report["result"] = "cancelled"
+                    return "cancelled"
+            flash_and_verify(run, release["images"], directory, report,
+                backup      = not args.no_backup,
+                verify_only = args.verify_only,
+            )
+            report["result"] = "passed"
+            seen.add(dna)
+            print(f"PASS: {dna} - {release['tag']} / {release['image']}")
+            return "passed"
+    except (FlashError, OSError, ValueError, EOFError, KeyboardInterrupt) as error:
+        report["error"] = str(error) or type(error).__name__
+        raise
+    finally:
+        report["finished_utc"] = datetime.now(timezone.utc).isoformat()
+        write_json(directory / "result.json", report)
+        print(f"Board record: {directory}")
+
+
+# Arguments ----------------------------------------------------------------------------------------
+
+def argument_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    # Release / Image.
+    parser.add_argument("--release", default="latest", help="Release tag (default: latest stable).")
+    parser.add_argument("--image",   default="m2_pcie_x1", choices=IMAGES,
+        help="Release image (default: m2_pcie_x1).")
+
+    # Flashing / Verification.
+    parser.add_argument("--batch",       action="store_true", help="Prompt for successive boards with one release.")
+    parser.add_argument("-y", "--yes",   action="store_true", help="Skip single-board confirmation.")
+    parser.add_argument("--no-backup",   action="store_true", help="Skip the 16 MiB multiboot backup.")
+    parser.add_argument("--verify-only", action="store_true", help="Read back flash and check boot; temporarily reconfigures the FPGA.")
+    parser.add_argument("--dry-run",     action="store_true", help="Download and validate images without USB/JTAG access.")
+
+    # JTAG Programmer.
+    parser.add_argument("--cable",      default=None, choices=sorted(set(FTDI_CABLES.values())),
+        help="FTDI cable type (default: auto-detect).")
+    parser.add_argument("--busdev-num", default=None, help="USB probe address, e.g. 001:016.")
+    parser.add_argument("--freq",       default=20000000, type=int, help="JTAG frequency in Hz (default: 20000000).")
+    parser.add_argument("--loader",     default="openFPGALoader",   help="openFPGALoader executable.")
+
+    # Release Cache / Board Records.
+    parser.add_argument("--output-dir", type=Path,
+        default=Path(__file__).resolve().parents[1] / "build" / "flash_release",
+        help="Release cache, board logs and backups (default: build/flash_release).")
+    return parser
+
+
+# Main ---------------------------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argument_parser()
+    args   = parser.parse_args(argv)
+    if args.freq <= 0:
+        parser.error("--freq must be positive")
+    if args.busdev_num:
+        if not re.fullmatch(r"\d{1,3}:\d{1,3}", args.busdev_num):
+            parser.error("--busdev-num must use BUS:DEVICE, e.g. 001:016")
+        args.busdev_num = ":".join(f"{int(value):03d}" for value in args.busdev_num.split(":"))
+    if args.batch and not args.dry_run and not sys.stdin.isatty():
+        parser.error("--batch needs an interactive terminal to signal each board change")
+    args.output_dir = args.output_dir.resolve()
+    try:
+        if not args.dry_run and shutil.which(args.loader) is None:
+            raise FlashError("openFPGALoader is required, including the XC7A200T SPI-over-JTAG bridge.")
+        release = prepare_release(args)
+        print(f"Release: {release['tag']} / {release['image']}")
+        print(f"Archive SHA-256: {release['archive_sha256']}")
+        for index, path in enumerate(release["images"]):
+            print(f"  {path.name}: {path.stat().st_size} bytes at 0x{index * SLOT_SIZE:08x}")
+        if args.dry_run:
+            print("Dry run complete. No USB/JTAG access. Normal runs verify both slots and FPGA boot.")
+            return 0
+        seen     = set()
+        failures = 0
+        while True:
+            if args.batch:
+                answer = input("Connect the next board, then press Enter (q to finish): ").strip().lower()
+                if answer == "q":
+                    break
+                if answer:
+                    continue
+            try:
+                result = process_board(args, release, seen)
+                if result == "cancelled":
+                    break
+            except (FlashError, OSError, ValueError) as error:
+                failures += 1
+                print(f"FAIL: {error}", file=sys.stderr)
+            if not args.batch:
+                break
+        print(f"Completed: {len(seen)} board(s) passed, {failures} failed attempt(s).")
+        return 1 if failures else 0
+    except (FlashError, OSError, ValueError, zipfile.BadZipFile) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    except (EOFError, KeyboardInterrupt):
+        print("\nStopped. See the per-board records for completed or interrupted operations.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_flash_release.py
+++ b/test/test_flash_release.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+
+# This file is part of LiteX-M2SDR.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import io
+import json
+import hashlib
+import zipfile
+import importlib.util
+
+from pathlib import Path
+
+import pytest
+
+# Helpers ------------------------------------------------------------------------------------------
+@pytest.fixture
+def flasher():
+    path   = Path(__file__).resolve().parents[1] / "scripts" / "flash_release.py"
+    spec   = importlib.util.spec_from_file_location("flash_release", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_archive(tmp_path, manifest_changes=None, config_changes=None, missing=None, extra=None):
+    build = "litex_m2sdr_m2_pcie_x1"
+    manifest = {
+        "project"       : "litex_m2sdr",
+        "release_date"  : "2026_05_15",
+        "build_name"    : build,
+        "git_revision"  : "a" * 40,
+        "git_dirty"     : False,
+        "configuration" : {
+            "variant"    : "m2",
+            "with_pcie"  : True,
+            "pcie_lanes" : 1,
+            "with_eth"   : False,
+        },
+    }
+    manifest.update(manifest_changes or {})
+    manifest["configuration"].update(config_changes or {})
+    path = tmp_path / f"{build}_2026_05_15.zip"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("release_manifest.json", json.dumps(manifest))
+        for slot in ("fallback", "operational"):
+            if slot != missing:
+                archive.writestr(f"{build}_{slot}.bin", (slot + " image").encode())
+        if extra:
+            archive.writestr(*extra)
+    return path
+
+
+# Release Downloads / Validation -------------------------------------------------------------------
+
+@pytest.mark.parametrize("tag,endpoint", [("latest", "latest"), ("2026_05_15", "tags/2026_05_15")])
+def test_resolves_latest_and_pinned_release(flasher, monkeypatch, tag, endpoint):
+    requests = []
+
+    def request(url):
+        requests.append(url)
+        return io.BytesIO(json.dumps({"tag_name": "2026_05_15"}).encode())
+
+    monkeypatch.setattr(flasher, "request", request)
+    assert flasher.fetch_release(tag)["tag_name"] == "2026_05_15"
+    assert requests == [f"https://api.github.com/repos/enjoy-digital/litex_m2sdr/releases/{endpoint}"]
+
+
+def test_download_rechecks_cached_bytes_and_repairs_corruption(flasher, tmp_path, monkeypatch):
+    contents = b"release archive bytes"
+    asset = {
+        "name": "release.zip", "size": len(contents),
+        "digest": "sha256:" + hashlib.sha256(contents).hexdigest(),
+        "browser_download_url": "https://github.com/enjoy-digital/litex_m2sdr/releases/download/2026_05_15/release.zip",
+    }
+    requests = []
+
+    def request(url):
+        requests.append(url)
+        return io.BytesIO(contents)
+
+    monkeypatch.setattr(flasher, "request", request)
+    path = flasher.download_asset(asset, tmp_path)
+    assert path.read_bytes() == contents
+    flasher.download_asset(asset, tmp_path)
+    assert len(requests) == 1
+    path.write_bytes(b"X" * len(contents))
+    flasher.download_asset(asset, tmp_path)
+    assert len(requests) == 2
+    assert path.read_bytes() == contents
+
+
+@pytest.mark.parametrize("digest", [None, "sha256:" + "0" * 64])
+def test_download_rejects_missing_or_wrong_digest(flasher, tmp_path, monkeypatch, digest):
+    asset = {
+        "name": "release.zip", "size": 4, "digest": digest,
+        "browser_download_url": "https://github.com/enjoy-digital/litex_m2sdr/releases/download/2026_05_15/release.zip",
+    }
+    monkeypatch.setattr(flasher, "request", lambda url: io.BytesIO(b"data"))
+    with pytest.raises(flasher.FlashError, match="SHA-256"):
+        flasher.download_asset(asset, tmp_path)
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("changes", [
+    {"manifest_changes": {"release_date": "2026_05_14"}},
+    {"manifest_changes": {"git_dirty": True}},
+    {"manifest_changes": {"build_name": "litex_m2sdr_m2_pcie_x2"}},
+    {"config_changes": {"pcie_lanes": 2}},
+    {"config_changes": {"variant": "baseboard"}},
+    {"missing": "operational"},
+])
+def test_rejects_wrong_or_incomplete_release_before_extracting(flasher, tmp_path, changes):
+    path = make_archive(tmp_path, **changes)
+    output = tmp_path / "output"
+    output.mkdir()
+    with pytest.raises(flasher.FlashError):
+        flasher.unpack_images(path, output, "2026_05_15", "m2_pcie_x1")
+    assert not list(output.iterdir())
+
+
+def test_extracts_only_expected_members(flasher, tmp_path):
+    path = make_archive(tmp_path, extra=("../outside.bin", b"untrusted"))
+    output = tmp_path / "output"
+    output.mkdir()
+    manifest, images = flasher.unpack_images(path, output, "2026_05_15", "m2_pcie_x1")
+    assert manifest["configuration"]["pcie_lanes"] == 1
+    assert [path.read_bytes() for path in images] == [b"fallback image", b"operational image"]
+    assert not (tmp_path / "outside.bin").exists()
+
+
+def test_rejects_image_larger_than_multiboot_slot(flasher, tmp_path):
+    path = make_archive(tmp_path, extra=("irrelevant", b"data"))
+    flasher.SLOT_SIZE = 4
+    with pytest.raises(flasher.FlashError, match="Invalid size"):
+        flasher.unpack_images(path, tmp_path, "2026_05_15", "m2_pcie_x1")
+
+
+# Probe Selection ----------------------------------------------------------------------------------
+
+def test_probe_selection_requires_unambiguous_target(flasher):
+    output = """Bus device vid:pid       probe_type manufacturer serial product
+001 016    0x0403:0x6011 ft4232     FTDI         none   Quad RS232-HS
+002 003    0x0403:0x6010 ft2232     FTDI         none   Dual RS232-HS
+"""
+    with pytest.raises(flasher.FlashError, match="Multiple"):
+        flasher.select_probe(output)
+    assert flasher.select_probe(output, "001:016") == ("001:016", "ft4232")
+    assert flasher.select_probe(output, cable="ft2232") == ("002:003", "ft2232")
+    with pytest.raises(flasher.FlashError, match="No matching"):
+        flasher.select_probe(output, "001:017")
+
+
+# Flash Model --------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("detected", ["", "idcode 0x12345678", "idcode 0x3636093\nidcode 0x3636093"])
+def test_rejects_missing_wrong_or_multiple_fpgas_before_dna_read(flasher, detected):
+    commands = []
+
+    def run(*flags):
+        commands.append(flags)
+        return detected
+
+    with pytest.raises(flasher.FlashError):
+        flasher.identify_board(run)
+    assert commands == [("--detect",)]
+
+
+class FakeBoard:
+    """A flash memory model independent of the flasher's expected image hashes."""
+
+    def __init__(self, flasher, images):
+        self.flasher           = flasher
+        self.images            = images
+        self.memory            = bytearray(b"\xff") * 0x1000000
+        self.commands          = []
+        self.dna               = "00381c891c104854"
+        self.boot              = 0x5
+        self.silent_corruption = False
+        self.fail_write        = False
+        self.fail_backup       = False
+        self.short_backup      = False
+
+    def __call__(self, *flags):
+        self.commands.append(flags)
+        if "--scan-usb" in flags:
+            return "001 016    0x0403:0x6011 ft4232 FTDI none Quad RS232-HS\n"
+        if "--detect" in flags:
+            return "index 0:\n\tidcode 0x3636093\n"
+        if "--read-dna" in flags:
+            return json.dumps({"dna": "0x" + self.dna})
+        if "--read-register" in flags:
+            value = 0x501079fc if flags[-1] == "STAT" else self.boot
+            return f"Register raw value: 0x{value:x}\n"
+        if "--write-flash" in flags:
+            if self.fail_write:
+                raise self.flasher.FlashError("injected write failure")
+            offset = int(flags[flags.index("--offset") + 1], 0)
+            data = Path(flags[-1]).read_bytes()
+            self.memory[offset:offset + len(data)] = data
+            if self.silent_corruption:
+                self.memory[offset] ^= 0xff
+        if "--dump-flash" in flags:
+            size = int(flags[flags.index("--file-size") + 1])
+            offset = int(flags[flags.index("--offset") + 1], 0) if "--offset" in flags else 0
+            if size == 0x1000000:
+                if self.fail_backup:
+                    raise self.flasher.FlashError("injected backup failure")
+                if self.short_backup:
+                    size -= 1
+            Path(flags[-1]).write_bytes(self.memory[offset:offset + size])
+        return "Done\n"
+
+
+@pytest.fixture
+def board(flasher, tmp_path):
+    images = [tmp_path / "fallback.bin", tmp_path / "operational.bin"]
+    images[0].write_bytes(b"fallback contents" * 64)
+    images[1].write_bytes(b"operational contents" * 64)
+    return FakeBoard(flasher, images)
+
+
+# Programming / Readback / Boot ---------------------------------------------------------------------
+
+def test_programs_both_slots_preserves_other_bytes_and_verifies_boot(flasher, board, tmp_path):
+    before = bytes(board.memory)
+    report = {}
+    flasher.flash_and_verify(board, board.images, tmp_path, report)
+    assert (tmp_path / "flash-before.bin").read_bytes() == before
+    for offset, image in zip((0, 0x800000), board.images):
+        data = image.read_bytes()
+        assert board.memory[offset:offset + len(data)] == data
+        assert board.memory[offset + len(data):offset + 0x800000] == before[offset + len(data):offset + 0x800000]
+    assert report["boot"] == {"STAT": "0x501079fc", "BOOTSTS": "0x00000005"}
+    assert len(report["slots"]) == 2
+    assert all(slot["verified"] for slot in report["slots"])
+    writes = [command for command in board.commands if "--write-flash" in command]
+    assert all("--verify" in command and "--skip-reset" in command for command in writes)
+    assert "--skip-load-bridge" not in writes[0]
+    assert "--skip-load-bridge" in writes[1]
+
+
+@pytest.mark.parametrize("failure", ["fail_backup", "short_backup", "fail_write", "silent_corruption"])
+def test_failures_never_reach_boot_pass_and_reset_bridge(flasher, board, tmp_path, failure):
+    setattr(board, failure, True)
+    report = {}
+    with pytest.raises(flasher.FlashError):
+        flasher.flash_and_verify(board, board.images, tmp_path, report)
+    assert "boot" not in report
+    if failure in ("fail_backup", "short_backup"):
+        assert not any("--write-flash" in command for command in board.commands)
+    else:
+        assert board.commands[-1] == ("--reset",)
+
+
+def test_verify_only_never_writes_flash(flasher, board, tmp_path):
+    for offset, image in zip((0, 0x800000), board.images):
+        data = image.read_bytes()
+        board.memory[offset:offset + len(data)] = data
+    before = bytes(board.memory)
+    report = {}
+    flasher.flash_and_verify(board, board.images, tmp_path, report, verify_only=True)
+    assert board.memory == before
+    assert not any("--write-flash" in command for command in board.commands)
+    assert report["boot"]["BOOTSTS"] == "0x00000005"
+
+
+@pytest.mark.parametrize("status,boot", [
+    (0x501079fd, 0x5),  # CRC error.
+    (0x501079fc, 0x7),  # Fallback, even though DONE is high.
+    (0x501079fc, 0x1),  # No multiboot jump.
+    (0x501079fc, 0x2105),  # Older valid entry contains a CRC error.
+])
+def test_rejects_configuration_and_multiboot_errors(flasher, status, boot):
+    def run(*flags):
+        return f"Register raw value: 0x{status if flags[-1] == 'STAT' else boot:x}"
+
+    with pytest.raises(flasher.FlashError):
+        flasher.check_boot(run)
+
+
+def test_boot_timeout_is_reported(flasher, monkeypatch):
+    ticks = iter([0, 6])
+    monkeypatch.setattr(flasher.time, "monotonic", lambda: next(ticks))
+    with pytest.raises(flasher.FlashError, match="did not finish booting"):
+        flasher.check_boot(lambda *flags: "Register raw value: 0x0")
+
+
+# Board Records / Batch Mode -----------------------------------------------------------------------
+
+def test_records_board_result_and_skips_duplicate_dna(flasher, board, tmp_path, monkeypatch):
+    monkeypatch.setattr(flasher, "run_loader", lambda command, log: board(*command))
+    args = flasher.argument_parser().parse_args(["--yes", "--no-backup", "--output-dir", str(tmp_path)])
+    release = {"tag": "2026_05_15", "image": "m2_pcie_x1", "images": board.images}
+    seen = set()
+    assert flasher.process_board(args, release, seen) == "passed"
+    write_count = sum("--write-flash" in command for command in board.commands)
+    assert flasher.process_board(args, release, seen) == "skipped"
+    assert sum("--write-flash" in command for command in board.commands) == write_count
+    results = [json.loads(path.read_text()) for path in (tmp_path / "boards").glob("*/result.json")]
+    assert sorted(result["result"] for result in results) == ["passed", "skipped"]
+    assert all(result["fpga_dna"] == board.dna for result in results)
+
+
+def test_records_failed_board(flasher, board, tmp_path, monkeypatch):
+    board.silent_corruption = True
+    monkeypatch.setattr(flasher, "run_loader", lambda command, log: board(*command))
+    args = flasher.argument_parser().parse_args(["--yes", "--no-backup", "--output-dir", str(tmp_path)])
+    release = {"tag": "2026_05_15", "image": "m2_pcie_x1", "images": board.images}
+    seen = set()
+    with pytest.raises(flasher.FlashError, match="readback mismatch"):
+        flasher.process_board(args, release, seen)
+    result = json.loads(next((tmp_path / "boards").glob("*/result.json")).read_text())
+    assert result["result"] == "failed"
+    assert result["fpga_dna"] == board.dna
+    assert not seen
+
+
+def test_dry_run_does_not_access_programmer(flasher, board, monkeypatch):
+    release = {"tag": "2026_05_15", "image": "m2_pcie_x1", "archive_sha256": "a" * 64, "images": board.images}
+    monkeypatch.setattr(flasher, "prepare_release", lambda args: release)
+
+    def unexpected(*args):
+        pytest.fail("Dry run accessed programmer")
+
+    monkeypatch.setattr(flasher, "run_loader", unexpected)
+    assert flasher.main(["--dry-run", "--loader", "/missing/programmer"]) == 0
+
+
+def test_batch_pins_release_continues_after_failure_and_returns_failure(flasher, board, monkeypatch):
+    release = {"tag": "2026_05_15", "image": "m2_pcie_x1", "archive_sha256": "a" * 64, "images": board.images}
+    downloads = []
+    boards = []
+
+    def prepare(args):
+        downloads.append(args.release)
+        return release
+
+    def process(args, selected, seen):
+        boards.append(selected)
+        if len(boards) == 1:
+            raise flasher.FlashError("first board failed")
+        seen.add(board.dna)
+        return "passed"
+
+    answers = iter(["", "", "q"])
+    monkeypatch.setattr(flasher.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(flasher.shutil, "which", lambda name: name)
+    monkeypatch.setattr("builtins.input", lambda prompt: next(answers))
+    monkeypatch.setattr(flasher, "prepare_release", prepare)
+    monkeypatch.setattr(flasher, "process_board", process)
+    assert flasher.main(["--batch"]) == 1
+    assert downloads == ["latest"]
+    assert boards == [release, release]


### PR DESCRIPTION
Flashing published multiboot images currently requires manually downloading the correct archive and programming both flash slots. Add `scripts/flash_release.py` to select the latest stable release or a pinned tag, verify the archive checksum and manifest, and program the fallback and operational slots over USB JTAG. M.2 PCIe x1 is the default image.

The tool checks the FPGA ID and DNA, backs up both slots unless disabled, verifies their contents by readback, and checks startup and multiboot status. Batch mode holds the release fixed, skips boards that already passed in the batch, and saves per-board logs and results. Developer usage and recovery instructions are in `doc/flash-release.md`.

Validation:

- `python3 -m pytest -q test/test_flash_release.py test/test_github_release.py test/test_release.py`: 40 passed on the current `main` base.
- Latest-release and pinned `2026_05_15` dry runs downloaded/validated the real M.2 PCIe x1 release archive.
- Python 3.9 syntax compatibility and `git diff --check` passed.
- Full hardware validation of the new tool remains pending: the verification-only run found the USB programmer but no FPGA responded on JTAG, so it stopped before accessing flash. Programming, corruption/failure handling, boot checks and batch behavior are covered by the software tests.
